### PR TITLE
Deterministic WAL replay: physical log entries and branch ancestry

### DIFF
--- a/internal/branch/wal/service.go
+++ b/internal/branch/wal/service.go
@@ -74,10 +74,14 @@ func (s *BranchService) CreateBranch(projectID, name, parentID string) (*wal.Bra
 		}
 	}
 
+	// The branch ID is generated up front so the WAL entry can reference
+	// it; data entries key on branch IDs, so control entries must too.
+	branchID := primitive.NewObjectID().Hex()
+
 	// Create WAL entry for branch creation
 	entry := &wal.Entry{
 		ProjectID: projectID,
-		BranchID:  name,
+		BranchID:  branchID,
 		Operation: wal.OpCreateBranch,
 		Metadata: map[string]interface{}{
 			"branch_name": name,
@@ -92,7 +96,7 @@ func (s *BranchService) CreateBranch(projectID, name, parentID string) (*wal.Bra
 
 	// Create branch record
 	branch := &wal.Branch{
-		ID:         primitive.NewObjectID().Hex(),
+		ID:         branchID,
 		ProjectID:  projectID,
 		Name:       name,
 		ParentID:   parentID,
@@ -155,6 +159,36 @@ func (s *BranchService) GetBranchByID(branchID string) (*wal.Branch, error) {
 	}
 
 	return &branch, nil
+}
+
+// GetBranchByIDAny retrieves a branch by its ID regardless of deletion
+// state. Ancestry resolution uses this: a force-deleted parent must still
+// anchor its descendants' history, whose entries remain in the WAL.
+func (s *BranchService) GetBranchByIDAny(branchID string) (*wal.Branch, error) {
+	ctx := context.Background()
+	var branch wal.Branch
+
+	err := s.collection.FindOne(ctx, bson.M{"_id": branchID}).Decode(&branch)
+	if err != nil {
+		return nil, err
+	}
+
+	return &branch, nil
+}
+
+// AddDiscardedRange records an LSN window abandoned by a reset so that
+// materialization skips it. The entries themselves stay in the WAL for
+// audit and for time travel to points before the reset.
+func (s *BranchService) AddDiscardedRange(branchID string, from, to int64) error {
+	if from > to {
+		return fmt.Errorf("invalid discarded range [%d, %d]", from, to)
+	}
+	ctx := context.Background()
+	_, err := s.collection.UpdateOne(ctx,
+		bson.M{"_id": branchID},
+		bson.M{"$push": bson.M{"discarded_ranges": wal.LSNRange{From: from, To: to}}},
+	)
+	return err
 }
 
 // ListBranches lists all branches for a project

--- a/internal/driver/wal/canonical.go
+++ b/internal/driver/wal/canonical.go
@@ -1,0 +1,94 @@
+package wal
+
+import (
+	"fmt"
+	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// Decoded documents are Go maps, and marshalling a map serializes its keys
+// in randomized iteration order — so comparing two logically identical
+// documents by marshalling each of them is not stable. CanonicalBytes fixes
+// an ordering (keys sorted, recursively) purely for comparison purposes.
+//
+// Note this makes document equality field-order-insensitive, which is a
+// documented deviation from MongoDB (where {a:1,b:2} != {b:2,a:1} as a
+// value): the original field order is already lost when a post-image is
+// decoded into a map, so order-insensitive comparison is the only stable
+// choice until reads run on a real mongod.
+
+// CanonicalBytes returns a deterministic byte representation of a BSON value.
+func CanonicalBytes(v interface{}) ([]byte, error) {
+	canonical, err := canonicalizeValue(v)
+	if err != nil {
+		return nil, err
+	}
+	return bson.Marshal(bson.D{{Key: "v", Value: canonical}})
+}
+
+// CanonicalEqual reports whether two BSON values are equal under the
+// canonical (sorted-key) representation.
+func CanonicalEqual(a, b interface{}) (bool, error) {
+	aBytes, err := CanonicalBytes(a)
+	if err != nil {
+		return false, err
+	}
+	bBytes, err := CanonicalBytes(b)
+	if err != nil {
+		return false, err
+	}
+	return string(aBytes) == string(bBytes), nil
+}
+
+func canonicalizeValue(v interface{}) (interface{}, error) {
+	switch val := v.(type) {
+	case bson.M:
+		return canonicalizeMap(val)
+	case map[string]interface{}:
+		return canonicalizeMap(val)
+	case bson.D:
+		m := make(map[string]interface{}, len(val))
+		for _, e := range val {
+			m[e.Key] = e.Value
+		}
+		return canonicalizeMap(m)
+	case []interface{}:
+		return canonicalizeSlice(val)
+	case primitive.A:
+		return canonicalizeSlice(val)
+	default:
+		return v, nil
+	}
+}
+
+func canonicalizeMap(m map[string]interface{}) (bson.D, error) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	doc := make(bson.D, 0, len(m))
+	for _, k := range keys {
+		cv, err := canonicalizeValue(m[k])
+		if err != nil {
+			return nil, fmt.Errorf("field %s: %w", k, err)
+		}
+		doc = append(doc, bson.E{Key: k, Value: cv})
+	}
+	return doc, nil
+}
+
+func canonicalizeSlice(s []interface{}) ([]interface{}, error) {
+	out := make([]interface{}, len(s))
+	for i, item := range s {
+		cv, err := canonicalizeValue(item)
+		if err != nil {
+			return nil, fmt.Errorf("index %d: %w", i, err)
+		}
+		out[i] = cv
+	}
+	return out, nil
+}

--- a/internal/driver/wal/collection.go
+++ b/internal/driver/wal/collection.go
@@ -7,25 +7,21 @@ import (
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
 	"github.com/argon-lab/argon/internal/wal"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// Collection represents a WAL-enabled collection
+// Collection is a WAL-backed collection handle with a mongo.Collection-like
+// surface. Writes are resolved once and logged as physical entries; reads
+// materialize branch state and evaluate the filter in-process.
+//
+// M1 limitations (until reads route through a real mongod in M3): Find
+// options (sort/skip/limit/projection) are not applied, aggregation is not
+// supported, and results are returned in canonical document-ID order.
 type Collection struct {
-	name         string
-	branch       *wal.Branch
-	interceptor  *Interceptor
-	materializer Materializer
-	underlying   *mongo.Collection
-}
-
-// Materializer interface for building state from WAL
-type Materializer interface {
-	MaterializeCollection(branch *wal.Branch, collection string) (map[string]bson.M, error)
-	MaterializeDocument(branch *wal.Branch, collection, documentID string) (bson.M, error)
-	MaterializeBranch(branch *wal.Branch) (map[string]map[string]bson.M, error)
+	name        string
+	branch      *wal.Branch
+	interceptor *Interceptor
 }
 
 // NewCollection creates a new WAL-enabled collection
@@ -35,16 +31,11 @@ func NewCollection(
 	walService *wal.Service,
 	branchService *branchwal.BranchService,
 	materializer Materializer,
-	underlying *mongo.Collection,
 ) *Collection {
-	interceptor := NewInterceptor(walService, branch, branchService)
-
 	return &Collection{
-		name:         name,
-		branch:       branch,
-		interceptor:  interceptor,
-		materializer: materializer,
-		underlying:   underlying,
+		name:        name,
+		branch:      branch,
+		interceptor: NewInterceptor(walService, branch, branchService, materializer),
 	}
 }
 
@@ -54,10 +45,7 @@ func (c *Collection) InsertOne(ctx context.Context, document interface{}, opts .
 	if err != nil {
 		return nil, err
 	}
-
-	return &mongo.InsertOneResult{
-		InsertedID: result.InsertedID,
-	}, nil
+	return &mongo.InsertOneResult{InsertedID: result.InsertedID}, nil
 }
 
 // InsertMany inserts multiple documents
@@ -66,25 +54,40 @@ func (c *Collection) InsertMany(ctx context.Context, documents []interface{}, op
 	if err != nil {
 		return nil, err
 	}
-
-	return &mongo.InsertManyResult{
-		InsertedIDs: insertedIDs,
-	}, nil
+	return &mongo.InsertManyResult{InsertedIDs: insertedIDs}, nil
 }
 
 // UpdateOne updates a single document
 func (c *Collection) UpdateOne(ctx context.Context, filter, update interface{}, opts ...*options.UpdateOptions) (*mongo.UpdateResult, error) {
-	result, err := c.interceptor.UpdateOne(ctx, c.name, filter, update)
+	result, err := c.interceptor.UpdateOne(ctx, c.name, filter, update, upsertFromUpdateOptions(opts))
 	if err != nil {
 		return nil, err
 	}
+	return toMongoUpdateResult(result), nil
+}
 
-	return &mongo.UpdateResult{
-		MatchedCount:  result.MatchedCount,
-		ModifiedCount: result.ModifiedCount,
-		UpsertedCount: 0,
-		UpsertedID:    result.UpsertedID,
-	}, nil
+// UpdateMany updates every matching document
+func (c *Collection) UpdateMany(ctx context.Context, filter, update interface{}, opts ...*options.UpdateOptions) (*mongo.UpdateResult, error) {
+	result, err := c.interceptor.UpdateMany(ctx, c.name, filter, update, upsertFromUpdateOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return toMongoUpdateResult(result), nil
+}
+
+// ReplaceOne replaces a single document
+func (c *Collection) ReplaceOne(ctx context.Context, filter, replacement interface{}, opts ...*options.ReplaceOptions) (*mongo.UpdateResult, error) {
+	upsert := false
+	for _, o := range opts {
+		if o != nil && o.Upsert != nil {
+			upsert = *o.Upsert
+		}
+	}
+	result, err := c.interceptor.ReplaceOne(ctx, c.name, filter, replacement, upsert)
+	if err != nil {
+		return nil, err
+	}
+	return toMongoUpdateResult(result), nil
 }
 
 // DeleteOne deletes a single document
@@ -93,120 +96,55 @@ func (c *Collection) DeleteOne(ctx context.Context, filter interface{}, opts ...
 	if err != nil {
 		return nil, err
 	}
-
-	return &mongo.DeleteResult{
-		DeletedCount: result.DeletedCount,
-	}, nil
+	return &mongo.DeleteResult{DeletedCount: result.DeletedCount}, nil
 }
 
-// Find executes a query and returns a cursor
+// DeleteMany deletes every matching document
+func (c *Collection) DeleteMany(ctx context.Context, filter interface{}, opts ...*options.DeleteOptions) (*mongo.DeleteResult, error) {
+	result, err := c.interceptor.DeleteMany(ctx, c.name, filter)
+	if err != nil {
+		return nil, err
+	}
+	return &mongo.DeleteResult{DeletedCount: result.DeletedCount}, nil
+}
+
+// Find executes a query and returns a real cursor over the matching
+// documents in canonical document-ID order.
 func (c *Collection) Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {
-	// For MVP, we'll materialize and filter in memory
-	// Future: implement proper cursor support
-
-	// Convert filter to bson.M
-	var filterDoc bson.M
-	if filter == nil {
-		filterDoc = bson.M{}
-	} else {
-		switch f := filter.(type) {
-		case bson.M:
-			filterDoc = f
-		case map[string]interface{}:
-			filterDoc = bson.M(f)
-		default:
-			bytes, _ := bson.Marshal(filter)
-			_ = bson.Unmarshal(bytes, &filterDoc)
-		}
-	}
-
-	// Materialize collection state
-	state, err := c.materializer.MaterializeCollection(c.branch, c.name)
+	docs, err := c.interceptor.FindMatches(c.name, filter, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to materialize collection: %w", err)
+		return nil, err
 	}
-
-	// Apply filter
-	var results []interface{}
-	for _, doc := range state {
-		if matchesFilter(doc, filterDoc) {
-			results = append(results, doc)
-		}
+	asInterfaces := make([]interface{}, len(docs))
+	for i, doc := range docs {
+		asInterfaces[i] = doc
 	}
-
-	// Create a mock cursor with results
-	// In a real implementation, we'd return a proper cursor
-	return createMockCursor(results), nil
+	cursor, err := mongo.NewCursorFromDocuments(asInterfaces, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build cursor: %w", err)
+	}
+	return cursor, nil
 }
 
-// FindOne executes a query and returns a single result
+// FindOne executes a query and returns the first match in canonical order.
 func (c *Collection) FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) *mongo.SingleResult {
-	// Convert filter to bson.M
-	var filterDoc bson.M
-	if filter == nil {
-		filterDoc = bson.M{}
-	} else {
-		switch f := filter.(type) {
-		case bson.M:
-			filterDoc = f
-		case map[string]interface{}:
-			filterDoc = bson.M(f)
-		default:
-			bytes, _ := bson.Marshal(filter)
-			_ = bson.Unmarshal(bytes, &filterDoc)
-		}
-	}
-
-	// Materialize collection state
-	state, err := c.materializer.MaterializeCollection(c.branch, c.name)
+	docs, err := c.interceptor.FindMatches(c.name, filter, true)
 	if err != nil {
-		return mongo.NewSingleResultFromDocument(nil, err, nil)
+		return mongo.NewSingleResultFromDocument(bson.M{}, err, nil)
 	}
-
-	// Find first matching document
-	for _, doc := range state {
-		if matchesFilter(doc, filterDoc) {
-			return mongo.NewSingleResultFromDocument(doc, nil, nil)
-		}
+	if len(docs) == 0 {
+		return mongo.NewSingleResultFromDocument(bson.M{}, mongo.ErrNoDocuments, nil)
 	}
-
-	// No match found
-	return mongo.NewSingleResultFromDocument(nil, mongo.ErrNoDocuments, nil)
+	return mongo.NewSingleResultFromDocument(docs[0], nil, nil)
 }
 
 // CountDocuments counts documents matching the filter
 func (c *Collection) CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error) {
-	// Convert filter to bson.M
-	var filterDoc bson.M
-	if filter == nil {
-		filterDoc = bson.M{}
-	} else {
-		switch f := filter.(type) {
-		case bson.M:
-			filterDoc = f
-		case map[string]interface{}:
-			filterDoc = bson.M(f)
-		default:
-			bytes, _ := bson.Marshal(filter)
-			_ = bson.Unmarshal(bytes, &filterDoc)
-		}
-	}
-
-	// Materialize collection state
-	state, err := c.materializer.MaterializeCollection(c.branch, c.name)
+	docs, err := c.interceptor.FindMatches(c.name, filter, false)
 	if err != nil {
-		return 0, fmt.Errorf("failed to materialize collection: %w", err)
+		return 0, err
 	}
-
-	// Count matching documents
-	var count int64
-	for _, doc := range state {
-		if matchesFilter(doc, filterDoc) {
-			count++
-		}
-	}
-
-	return count, nil
+	return int64(len(docs)), nil
 }
 
 // Name returns the collection name
@@ -214,183 +152,20 @@ func (c *Collection) Name() string {
 	return c.name
 }
 
-// matchesFilter checks if a document matches a filter with MongoDB operators support
-func matchesFilter(doc, filter bson.M) bool {
-	// Empty filter matches all
-	if len(filter) == 0 {
-		return true
-	}
-
-	// Check each filter field
-	for key, expected := range filter {
-		actual, exists := doc[key]
-		if !exists {
-			return false
-		}
-
-		// Handle different operator types
-		switch exp := expected.(type) {
-		case bson.M:
-			// Handle operators like $gt, $lt, etc.
-			if !matchesOperators(actual, exp) {
-				return false
-			}
-		case map[string]interface{}:
-			// Convert to bson.M and handle as operators
-			if !matchesOperators(actual, bson.M(exp)) {
-				return false
-			}
-		default:
-			// Simple equality check
-			if !isEqual(actual, expected) {
-				return false
-			}
-		}
-	}
-
-	return true
-}
-
-// matchesOperators handles MongoDB query operators
-func matchesOperators(value interface{}, operators bson.M) bool {
-	for op, operand := range operators {
-		switch op {
-		case "$eq":
-			if !isEqual(value, operand) {
-				return false
-			}
-		case "$ne":
-			if isEqual(value, operand) {
-				return false
-			}
-		case "$gt":
-			if !isGreaterThan(value, operand) {
-				return false
-			}
-		case "$gte":
-			if !isGreaterThanOrEqual(value, operand) {
-				return false
-			}
-		case "$lt":
-			if !isLessThan(value, operand) {
-				return false
-			}
-		case "$lte":
-			if !isLessThanOrEqual(value, operand) {
-				return false
-			}
-		case "$in":
-			if !isInArray(value, operand) {
-				return false
-			}
-		case "$nin":
-			if isInArray(value, operand) {
-				return false
-			}
-		default:
-			// Unknown operator, skip
-		}
-	}
-	return true
-}
-
-// isEqual compares two values for equality
-func isEqual(a, b interface{}) bool {
-	// Handle BSON type conversions
-	aBytes, _ := bson.Marshal(bson.M{"v": a})
-	bBytes, _ := bson.Marshal(bson.M{"v": b})
-
-	var aDoc, bDoc bson.M
-	_ = bson.Unmarshal(aBytes, &aDoc)
-	_ = bson.Unmarshal(bBytes, &bDoc)
-
-	return fmt.Sprintf("%v", aDoc["v"]) == fmt.Sprintf("%v", bDoc["v"])
-}
-
-// createMockCursor creates a simple cursor from results
-// TODO: Implement proper cursor for production
-func createMockCursor(results []interface{}) *mongo.Cursor {
-	// This is a placeholder - in production we'd implement a proper cursor
-	// that can stream results efficiently
-	return nil
-}
-
-// Comparison helper functions
-func isGreaterThan(a, b interface{}) bool {
-	return compareValues(a, b) > 0
-}
-
-func isGreaterThanOrEqual(a, b interface{}) bool {
-	return compareValues(a, b) >= 0
-}
-
-func isLessThan(a, b interface{}) bool {
-	return compareValues(a, b) < 0
-}
-
-func isLessThanOrEqual(a, b interface{}) bool {
-	return compareValues(a, b) <= 0
-}
-
-func isInArray(value, array interface{}) bool {
-	switch arr := array.(type) {
-	case []interface{}:
-		for _, item := range arr {
-			if isEqual(value, item) {
-				return true
-			}
-		}
-	case primitive.A: // BSON array type
-		for _, item := range arr {
-			if isEqual(value, item) {
-				return true
-			}
-		}
-	case []string:
-		valueStr := fmt.Sprintf("%v", value)
-		for _, item := range arr {
-			if item == valueStr {
-				return true
-			}
+func upsertFromUpdateOptions(opts []*options.UpdateOptions) bool {
+	for _, o := range opts {
+		if o != nil && o.Upsert != nil {
+			return *o.Upsert
 		}
 	}
 	return false
 }
 
-func compareValues(a, b interface{}) int {
-	// Simple numeric comparison for MVP
-	aFloat := toFloat64(a)
-	bFloat := toFloat64(b)
-
-	if aFloat > bFloat {
-		return 1
-	} else if aFloat < bFloat {
-		return -1
-	}
-	return 0
-}
-
-func toFloat64(v interface{}) float64 {
-	switch val := v.(type) {
-	case int:
-		return float64(val)
-	case int32:
-		return float64(val)
-	case int64:
-		return float64(val)
-	case float32:
-		return float64(val)
-	case float64:
-		return val
-	default:
-		// Try to convert via string
-		if str := fmt.Sprintf("%v", v); str != "" {
-			if f, err := fmt.Sscanf(str, "%f", new(float64)); err == nil && f == 1 {
-				var result float64
-				_, _ = fmt.Sscanf(str, "%f", &result)
-				return result
-			}
-		}
-		return 0
+func toMongoUpdateResult(result *UpdateResult) *mongo.UpdateResult {
+	return &mongo.UpdateResult{
+		MatchedCount:  result.MatchedCount,
+		ModifiedCount: result.ModifiedCount,
+		UpsertedCount: result.UpsertedCount,
+		UpsertedID:    result.UpsertedID,
 	}
 }

--- a/internal/driver/wal/database.go
+++ b/internal/driver/wal/database.go
@@ -5,7 +5,6 @@ import (
 
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
 	"github.com/argon-lab/argon/internal/wal"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // Database represents a WAL-enabled database
@@ -15,7 +14,6 @@ type Database struct {
 	wal          *wal.Service
 	branches     *branchwal.BranchService
 	materializer Materializer
-	underlying   *mongo.Database
 }
 
 // NewDatabase creates a new WAL-enabled database
@@ -25,7 +23,6 @@ func NewDatabase(
 	walService *wal.Service,
 	branchService *branchwal.BranchService,
 	materializer Materializer,
-	underlying *mongo.Database,
 ) *Database {
 	return &Database{
 		name:         name,
@@ -33,7 +30,6 @@ func NewDatabase(
 		wal:          walService,
 		branches:     branchService,
 		materializer: materializer,
-		underlying:   underlying,
 	}
 }
 
@@ -45,7 +41,6 @@ func (d *Database) Collection(name string) *Collection {
 		d.wal,
 		d.branches,
 		d.materializer,
-		d.underlying.Collection(name),
 	)
 }
 

--- a/internal/driver/wal/filter.go
+++ b/internal/driver/wal/filter.go
@@ -1,0 +1,581 @@
+package wal
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// This file implements MongoDB query filter matching for the SDK write and
+// read paths. It is only ever executed once, at operation time — the outcome
+// (which documents were touched, and their post-images) is what gets logged
+// to the WAL, so replay correctness never depends on this code.
+//
+// Supported: implicit equality, $eq, $ne, $gt, $gte, $lt, $lte, $in, $nin,
+// $exists, $regex, $size, $all, $elemMatch, $and, $or, $nor, $not, dotted
+// field paths, and match-any-element semantics for arrays. Unsupported
+// operators fail loudly instead of being silently skipped.
+
+// MatchesFilter reports whether a document matches a MongoDB query filter.
+func MatchesFilter(doc bson.M, filter bson.M) (bool, error) {
+	for key, expected := range filter {
+		switch key {
+		case "$and":
+			conds, err := toFilterSlice(expected, "$and")
+			if err != nil {
+				return false, err
+			}
+			for _, cond := range conds {
+				ok, err := MatchesFilter(doc, cond)
+				if err != nil || !ok {
+					return false, err
+				}
+			}
+		case "$or":
+			conds, err := toFilterSlice(expected, "$or")
+			if err != nil {
+				return false, err
+			}
+			matched := false
+			for _, cond := range conds {
+				ok, err := MatchesFilter(doc, cond)
+				if err != nil {
+					return false, err
+				}
+				if ok {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false, nil
+			}
+		case "$nor":
+			conds, err := toFilterSlice(expected, "$nor")
+			if err != nil {
+				return false, err
+			}
+			for _, cond := range conds {
+				ok, err := MatchesFilter(doc, cond)
+				if err != nil {
+					return false, err
+				}
+				if ok {
+					return false, nil
+				}
+			}
+		default:
+			if strings.HasPrefix(key, "$") {
+				return false, fmt.Errorf("unsupported top-level query operator %q", key)
+			}
+			ok, err := matchesField(doc, key, expected)
+			if err != nil || !ok {
+				return false, err
+			}
+		}
+	}
+	return true, nil
+}
+
+// matchesField evaluates a single field condition (dotted paths allowed).
+func matchesField(doc bson.M, path string, expected interface{}) (bool, error) {
+	value, exists := lookupPath(doc, path)
+
+	if opDoc, ok := asOperatorDoc(expected); ok {
+		return matchesOperators(value, exists, opDoc)
+	}
+
+	// Implicit equality.
+	if !exists {
+		return isBSONNull(expected), nil
+	}
+	return valuesMatch(value, expected), nil
+}
+
+// matchesOperators evaluates an operator document like {$gt: 5, $lt: 10}
+// against a field value.
+func matchesOperators(value interface{}, exists bool, operators bson.M) (bool, error) {
+	for op, operand := range operators {
+		switch op {
+		case "$eq":
+			if !exists || !valuesMatch(value, operand) {
+				return false, nil
+			}
+		case "$ne":
+			if exists && valuesMatch(value, operand) {
+				return false, nil
+			}
+		case "$gt", "$gte", "$lt", "$lte":
+			if !exists || !compareMatch(value, operand, op) {
+				return false, nil
+			}
+		case "$in":
+			arr, err := toSlice(operand, "$in")
+			if err != nil {
+				return false, err
+			}
+			if !exists {
+				return false, nil
+			}
+			found := false
+			for _, item := range arr {
+				if valuesMatch(value, item) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false, nil
+			}
+		case "$nin":
+			arr, err := toSlice(operand, "$nin")
+			if err != nil {
+				return false, err
+			}
+			if exists {
+				for _, item := range arr {
+					if valuesMatch(value, item) {
+						return false, nil
+					}
+				}
+			}
+		case "$exists":
+			want := toBool(operand)
+			if exists != want {
+				return false, nil
+			}
+		case "$regex":
+			if !exists {
+				return false, nil
+			}
+			ok, err := regexMatch(value, operand, operators["$options"])
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				return false, nil
+			}
+		case "$options":
+			// Consumed together with $regex.
+		case "$size":
+			if !exists {
+				return false, nil
+			}
+			arr, ok := asArray(value)
+			if !ok || int64(len(arr)) != toInt64(operand) {
+				return false, nil
+			}
+		case "$all":
+			required, err := toSlice(operand, "$all")
+			if err != nil {
+				return false, err
+			}
+			if !exists {
+				return false, nil
+			}
+			arr, ok := asArray(value)
+			if !ok {
+				return false, nil
+			}
+			for _, req := range required {
+				found := false
+				for _, item := range arr {
+					if compareBSONValues(item, req) == 0 {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return false, nil
+				}
+			}
+		case "$elemMatch":
+			if !exists {
+				return false, nil
+			}
+			cond, ok := toBSONM(operand)
+			if !ok {
+				return false, fmt.Errorf("$elemMatch requires a document operand")
+			}
+			arr, isArr := asArray(value)
+			if !isArr {
+				return false, nil
+			}
+			matched := false
+			for _, item := range arr {
+				elemDoc, isDoc := toBSONM(item)
+				if !isDoc {
+					continue
+				}
+				ok, err := MatchesFilter(elemDoc, cond)
+				if err != nil {
+					return false, err
+				}
+				if ok {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false, nil
+			}
+		case "$not":
+			cond, ok := toBSONM(operand)
+			if !ok {
+				return false, fmt.Errorf("$not requires an operator document")
+			}
+			ok2, err := matchesOperators(value, exists, cond)
+			if err != nil {
+				return false, err
+			}
+			if ok2 {
+				return false, nil
+			}
+		default:
+			return false, fmt.Errorf("unsupported query operator %q", op)
+		}
+	}
+	return true, nil
+}
+
+// lookupPath resolves a possibly-dotted field path in a document.
+func lookupPath(doc bson.M, path string) (interface{}, bool) {
+	parts := strings.Split(path, ".")
+	var current interface{} = doc
+	for _, part := range parts {
+		asDoc, ok := toBSONM(current)
+		if !ok {
+			return nil, false
+		}
+		next, exists := asDoc[part]
+		if !exists {
+			return nil, false
+		}
+		current = next
+	}
+	return current, true
+}
+
+// valuesMatch implements MongoDB equality semantics for filters: direct
+// equality, or — when the stored value is an array — equality of any element.
+func valuesMatch(value, expected interface{}) bool {
+	if compareBSONValues(value, expected) == 0 {
+		return true
+	}
+	if arr, ok := asArray(value); ok {
+		for _, item := range arr {
+			if compareBSONValues(item, expected) == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// compareMatch evaluates $gt/$gte/$lt/$lte with array-any-element semantics.
+func compareMatch(value, operand interface{}, op string) bool {
+	try := func(v interface{}) bool {
+		if !comparableTypes(v, operand) {
+			return false
+		}
+		c := compareBSONValues(v, operand)
+		switch op {
+		case "$gt":
+			return c > 0
+		case "$gte":
+			return c >= 0
+		case "$lt":
+			return c < 0
+		case "$lte":
+			return c <= 0
+		}
+		return false
+	}
+	if try(value) {
+		return true
+	}
+	if arr, ok := asArray(value); ok {
+		for _, item := range arr {
+			if try(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// compareBSONValues compares two BSON values with numeric cross-type
+// promotion. It returns 0 for equal, -1 / 1 for ordering, and a nonzero
+// sentinel for incomparable-but-unequal values.
+func compareBSONValues(a, b interface{}) int {
+	an, aIsNum := toFloat(a)
+	bn, bIsNum := toFloat(b)
+	if aIsNum && bIsNum {
+		switch {
+		case an < bn:
+			return -1
+		case an > bn:
+			return 1
+		default:
+			return 0
+		}
+	}
+
+	switch av := a.(type) {
+	case string:
+		if bv, ok := b.(string); ok {
+			return strings.Compare(av, bv)
+		}
+	case bool:
+		if bv, ok := b.(bool); ok {
+			switch {
+			case av == bv:
+				return 0
+			case !av:
+				return -1
+			default:
+				return 1
+			}
+		}
+	case primitive.ObjectID:
+		if bv, ok := b.(primitive.ObjectID); ok {
+			return bytes.Compare(av[:], bv[:])
+		}
+	case primitive.DateTime:
+		if bv, ok := b.(primitive.DateTime); ok {
+			switch {
+			case av < bv:
+				return -1
+			case av > bv:
+				return 1
+			default:
+				return 0
+			}
+		}
+		if bv, ok := b.(time.Time); ok {
+			return compareBSONValues(av.Time().UnixMilli(), bv.UnixMilli())
+		}
+	case time.Time:
+		if bv, ok := b.(time.Time); ok {
+			switch {
+			case av.Before(bv):
+				return -1
+			case av.After(bv):
+				return 1
+			default:
+				return 0
+			}
+		}
+		if bv, ok := b.(primitive.DateTime); ok {
+			return compareBSONValues(av.UnixMilli(), bv.Time().UnixMilli())
+		}
+	case nil:
+		if b == nil || isBSONNull(b) {
+			return 0
+		}
+	case primitive.Null:
+		if b == nil || isBSONNull(b) {
+			return 0
+		}
+	}
+
+	// Documents, arrays and remaining scalar types: equal iff their
+	// canonical encodings match. Field order inside documents is ignored
+	// (see canonical.go for why).
+	if equal, err := CanonicalEqual(a, b); err == nil && equal {
+		return 0
+	}
+	return 2 // Incomparable and not equal.
+}
+
+// comparableTypes reports whether ordering between the two values is
+// meaningful (same type bracket, in MongoDB terms).
+func comparableTypes(a, b interface{}) bool {
+	_, aNum := toFloat(a)
+	_, bNum := toFloat(b)
+	if aNum && bNum {
+		return true
+	}
+	switch a.(type) {
+	case string:
+		_, ok := b.(string)
+		return ok
+	case bool:
+		_, ok := b.(bool)
+		return ok
+	case primitive.ObjectID:
+		_, ok := b.(primitive.ObjectID)
+		return ok
+	case primitive.DateTime, time.Time:
+		switch b.(type) {
+		case primitive.DateTime, time.Time:
+			return true
+		}
+	}
+	return false
+}
+
+// --- small conversion helpers ---
+
+func toBSONM(v interface{}) (bson.M, bool) {
+	switch d := v.(type) {
+	case bson.M:
+		return d, true
+	case map[string]interface{}:
+		return bson.M(d), true
+	case bson.D:
+		m := make(bson.M, len(d))
+		for _, e := range d {
+			m[e.Key] = e.Value
+		}
+		return m, true
+	default:
+		return nil, false
+	}
+}
+
+// asOperatorDoc reports whether the expected value is an operator document
+// like {$gt: 5} rather than a literal document to compare against.
+func asOperatorDoc(expected interface{}) (bson.M, bool) {
+	doc, ok := toBSONM(expected)
+	if !ok || len(doc) == 0 {
+		return nil, false
+	}
+	for k := range doc {
+		if !strings.HasPrefix(k, "$") {
+			return nil, false
+		}
+	}
+	return doc, true
+}
+
+func asArray(v interface{}) ([]interface{}, bool) {
+	switch arr := v.(type) {
+	case []interface{}:
+		return arr, true
+	case primitive.A: // bson.A is an alias of primitive.A
+		return arr, true
+	case []byte:
+		// BSON binary, not an array.
+		return nil, false
+	}
+	// Typed Go slices ([]string, []int, ...) reach this in-process path
+	// without a BSON round-trip; flatten them via reflection.
+	rv := reflect.ValueOf(v)
+	if v == nil || (rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array) {
+		return nil, false
+	}
+	out := make([]interface{}, rv.Len())
+	for i := range out {
+		out[i] = rv.Index(i).Interface()
+	}
+	return out, true
+}
+
+func toSlice(v interface{}, op string) ([]interface{}, error) {
+	if arr, ok := asArray(v); ok {
+		return arr, nil
+	}
+	return nil, fmt.Errorf("%s requires an array operand, got %T", op, v)
+}
+
+func toFilterSlice(v interface{}, op string) ([]bson.M, error) {
+	arr, ok := asArray(v)
+	if !ok {
+		return nil, fmt.Errorf("%s requires an array of filters, got %T", op, v)
+	}
+	filters := make([]bson.M, 0, len(arr))
+	for _, item := range arr {
+		f, ok := toBSONM(item)
+		if !ok {
+			return nil, fmt.Errorf("%s elements must be filter documents, got %T", op, item)
+		}
+		filters = append(filters, f)
+	}
+	return filters, nil
+}
+
+func toFloat(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case float32:
+		return float64(n), true
+	case float64:
+		return n, true
+	default:
+		return 0, false
+	}
+}
+
+func toInt64(v interface{}) int64 {
+	f, _ := toFloat(v)
+	return int64(f)
+}
+
+func toBool(v interface{}) bool {
+	switch b := v.(type) {
+	case bool:
+		return b
+	default:
+		f, ok := toFloat(v)
+		return ok && f != 0
+	}
+}
+
+func isBSONNull(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	_, ok := v.(primitive.Null)
+	return ok
+}
+
+func regexMatch(value, pattern, opts interface{}) (bool, error) {
+	str, ok := value.(string)
+	if !ok {
+		return false, nil
+	}
+
+	var expr string
+	switch p := pattern.(type) {
+	case string:
+		expr = p
+	case primitive.Regex:
+		expr = p.Pattern
+		if opts == nil && p.Options != "" {
+			opts = p.Options
+		}
+	default:
+		return false, fmt.Errorf("$regex requires a string or regex operand, got %T", pattern)
+	}
+
+	if optStr, ok := opts.(string); ok && optStr != "" {
+		flags := ""
+		for _, o := range optStr {
+			switch o {
+			case 'i', 'm', 's':
+				flags += string(o)
+			default:
+				return false, fmt.Errorf("unsupported $regex option %q", string(o))
+			}
+		}
+		expr = "(?" + flags + ")" + expr
+	}
+
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return false, fmt.Errorf("invalid $regex pattern: %w", err)
+	}
+	return re.MatchString(str), nil
+}

--- a/internal/driver/wal/interceptor.go
+++ b/internal/driver/wal/interceptor.go
@@ -3,6 +3,7 @@ package wal
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
 	"github.com/argon-lab/argon/internal/wal"
@@ -10,20 +11,46 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// Interceptor intercepts MongoDB operations and redirects them to WAL
+// Materializer is the state-reconstruction interface the driver needs.
+type Materializer interface {
+	MaterializeCollection(branch *wal.Branch, collection string) (map[string]bson.M, error)
+	MaterializeDocument(branch *wal.Branch, collection, documentID string) (bson.M, error)
+	MaterializeBranch(branch *wal.Branch) (map[string]map[string]bson.M, error)
+}
+
+// Interceptor turns MongoDB write operations into deterministic WAL entries.
+//
+// Filters and update operators are resolved here, exactly once, at write
+// time: the interceptor materializes the affected documents, computes the
+// post-images, and logs those. Replay never re-executes a filter or an
+// update operator, which is what makes it deterministic.
+//
+// Concurrency note: resolve-then-append is not atomic, so two writers
+// racing on the same branch resolve against the same state and the later
+// append wins at document level (last-writer-wins). The WAL itself stays
+// consistent because every entry is self-contained.
 type Interceptor struct {
-	wal      *wal.Service
-	branch   *wal.Branch
-	branches *branchwal.BranchService
+	wal          *wal.Service
+	branch       *wal.Branch
+	branches     *branchwal.BranchService
+	materializer Materializer
+	actor        string
 }
 
 // NewInterceptor creates a new WAL interceptor
-func NewInterceptor(walService *wal.Service, branch *wal.Branch, branchService *branchwal.BranchService) *Interceptor {
+func NewInterceptor(walService *wal.Service, branch *wal.Branch, branchService *branchwal.BranchService, materializer Materializer) *Interceptor {
 	return &Interceptor{
-		wal:      walService,
-		branch:   branch,
-		branches: branchService,
+		wal:          walService,
+		branch:       branch,
+		branches:     branchService,
+		materializer: materializer,
 	}
+}
+
+// SetActor tags subsequent writes with an actor identity (e.g. "user:jake",
+// "agent:session-42") for audit and per-session undo.
+func (i *Interceptor) SetActor(actor string) {
+	i.actor = actor
 }
 
 // InsertResult represents the result of an insert operation
@@ -35,6 +62,7 @@ type InsertResult struct {
 type UpdateResult struct {
 	MatchedCount  int64
 	ModifiedCount int64
+	UpsertedCount int64
 	UpsertedID    interface{}
 }
 
@@ -43,214 +71,409 @@ type DeleteResult struct {
 	DeletedCount int64
 }
 
-// InsertOne intercepts an insert operation and writes to WAL
+// match pairs a resolved document with its canonical ID.
+type match struct {
+	docID string
+	doc   bson.M
+}
+
+// InsertOne intercepts an insert operation and writes a put entry.
 func (i *Interceptor) InsertOne(ctx context.Context, collection string, document interface{}) (*InsertResult, error) {
-	// Generate or extract document ID
-	docID, doc := i.ensureDocumentID(document)
-
-	// Marshal document to BSON
-	docBytes, err := bson.Marshal(doc)
+	docID, doc, err := i.ensureDocumentID(document)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal document: %w", err)
+		return nil, err
 	}
+	docIDStr := wal.DocumentIDString(docID)
 
-	// Convert ID to string for storage
-	docIDStr := ""
-	switch id := docID.(type) {
-	case primitive.ObjectID:
-		docIDStr = id.Hex()
-	case string:
-		docIDStr = id
-	default:
-		docIDStr = fmt.Sprintf("%v", id)
-	}
-
-	// Create WAL entry
-	entry := &wal.Entry{
-		ProjectID:  i.branch.ProjectID,
-		BranchID:   i.branch.ID,
-		Operation:  wal.OpInsert,
-		Collection: collection,
-		DocumentID: docIDStr,
-		Document:   docBytes,
-	}
-
-	// Append to WAL
-	lsn, err := i.wal.Append(entry)
+	existing, err := i.materializer.MaterializeDocument(i.branch, collection, docIDStr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to append to WAL: %w", err)
+		return nil, fmt.Errorf("failed to check for existing document: %w", err)
+	}
+	if existing != nil {
+		return nil, fmt.Errorf("duplicate key error: a document with _id %v already exists in %s", docID, collection)
 	}
 
-	// Update branch HEAD
-	if err := i.branches.UpdateBranchHead(i.branch.ID, lsn); err != nil {
-		return nil, fmt.Errorf("failed to update branch head: %w", err)
+	entry, err := i.putEntry(collection, docIDStr, doc, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := i.append(entry); err != nil {
+		return nil, err
 	}
 
 	return &InsertResult{InsertedID: docID}, nil
 }
 
-// UpdateOne intercepts an update operation and writes to WAL
-func (i *Interceptor) UpdateOne(ctx context.Context, collection string, filter, update interface{}) (*UpdateResult, error) {
-	// For WAL, we need to know what document we're updating
-	// In a real implementation, we'd materialize and find the document first
-	// For MVP, we'll store the filter and update operation
-
-	filterBytes, err := bson.Marshal(filter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal filter: %w", err)
-	}
-
-	updateBytes, err := bson.Marshal(update)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal update: %w", err)
-	}
-
-	// Try to extract document ID from filter if it's a simple _id filter
-	var documentID string
-	if filterMap, ok := filter.(bson.M); ok {
-		if id, exists := filterMap["_id"]; exists {
-			documentID = convertIDToString(id)
-		}
-	}
-
-	// Create a combined document with filter and update
-	updateDoc := bson.M{
-		"filter": bson.Raw(filterBytes),
-		"update": bson.Raw(updateBytes),
-	}
-
-	docBytes, err := bson.Marshal(updateDoc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal update document: %w", err)
-	}
-
-	// Create WAL entry
-	entry := &wal.Entry{
-		ProjectID:  i.branch.ProjectID,
-		BranchID:   i.branch.ID,
-		Operation:  wal.OpUpdate,
-		Collection: collection,
-		DocumentID: documentID,
-		Document:   docBytes,
-		Metadata: map[string]interface{}{
-			"filter_bytes": len(filterBytes),
-			"update_bytes": len(updateBytes),
-		},
-	}
-
-	// Append to WAL
-	lsn, err := i.wal.Append(entry)
-	if err != nil {
-		return nil, fmt.Errorf("failed to append to WAL: %w", err)
-	}
-
-	// Update branch HEAD
-	if err := i.branches.UpdateBranchHead(i.branch.ID, lsn); err != nil {
-		return nil, fmt.Errorf("failed to update branch head: %w", err)
-	}
-
-	// For MVP, assume one document matched and modified
-	return &UpdateResult{
-		MatchedCount:  1,
-		ModifiedCount: 1,
-	}, nil
-}
-
-// DeleteOne intercepts a delete operation and writes to WAL
-func (i *Interceptor) DeleteOne(ctx context.Context, collection string, filter interface{}) (*DeleteResult, error) {
-	// Marshal filter
-	filterBytes, err := bson.Marshal(filter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal filter: %w", err)
-	}
-
-	// Try to extract document ID from filter if it's a simple _id filter
-	var documentID string
-	if filterMap, ok := filter.(bson.M); ok {
-		if id, exists := filterMap["_id"]; exists {
-			documentID = convertIDToString(id)
-		}
-	}
-
-	// Create WAL entry
-	entry := &wal.Entry{
-		ProjectID:  i.branch.ProjectID,
-		BranchID:   i.branch.ID,
-		Operation:  wal.OpDelete,
-		Collection: collection,
-		DocumentID: documentID,
-		Document:   filterBytes, // Store filter as document
-		Metadata: map[string]interface{}{
-			"is_filter": true,
-		},
-	}
-
-	// Append to WAL
-	lsn, err := i.wal.Append(entry)
-	if err != nil {
-		return nil, fmt.Errorf("failed to append to WAL: %w", err)
-	}
-
-	// Update branch HEAD
-	if err := i.branches.UpdateBranchHead(i.branch.ID, lsn); err != nil {
-		return nil, fmt.Errorf("failed to update branch head: %w", err)
-	}
-
-	// For MVP, assume one document deleted
-	return &DeleteResult{DeletedCount: 1}, nil
-}
-
-// InsertMany intercepts a bulk insert operation
+// InsertMany intercepts a bulk insert and writes one batched set of puts.
 func (i *Interceptor) InsertMany(ctx context.Context, collection string, documents []interface{}) ([]interface{}, error) {
-	insertedIDs := make([]interface{}, 0, len(documents))
+	if len(documents) == 0 {
+		return nil, fmt.Errorf("insertMany requires at least one document")
+	}
 
-	for _, doc := range documents {
-		result, err := i.InsertOne(ctx, collection, doc)
+	insertedIDs := make([]interface{}, 0, len(documents))
+	entries := make([]*wal.Entry, 0, len(documents))
+	seen := make(map[string]bool, len(documents))
+
+	for idx, document := range documents {
+		docID, doc, err := i.ensureDocumentID(document)
+		if err != nil {
+			return nil, fmt.Errorf("document %d: %w", idx, err)
+		}
+		docIDStr := wal.DocumentIDString(docID)
+
+		if seen[docIDStr] {
+			return nil, fmt.Errorf("duplicate key error within batch: _id %v appears twice", docID)
+		}
+		seen[docIDStr] = true
+
+		existing, err := i.materializer.MaterializeDocument(i.branch, collection, docIDStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check for existing document: %w", err)
+		}
+		if existing != nil {
+			return nil, fmt.Errorf("duplicate key error: a document with _id %v already exists in %s", docID, collection)
+		}
+
+		entry, err := i.putEntry(collection, docIDStr, doc, nil)
 		if err != nil {
 			return nil, err
 		}
-		insertedIDs = append(insertedIDs, result.InsertedID)
+		entries = append(entries, entry)
+		insertedIDs = append(insertedIDs, docID)
 	}
 
+	if err := i.appendBatch(entries); err != nil {
+		return nil, err
+	}
 	return insertedIDs, nil
 }
 
-// ensureDocumentID ensures the document has an _id field
-func (i *Interceptor) ensureDocumentID(document interface{}) (interface{}, interface{}) {
-	// Convert to bson.M for manipulation
-	var doc bson.M
-
-	switch d := document.(type) {
-	case bson.M:
-		doc = d
-	case map[string]interface{}:
-		doc = bson.M(d)
-	default:
-		// For other types, marshal and unmarshal to bson.M
-		bytes, _ := bson.Marshal(document)
-		_ = bson.Unmarshal(bytes, &doc)
-	}
-
-	// Check if _id exists
-	if id, exists := doc["_id"]; exists && id != nil {
-		return id, doc
-	}
-
-	// Generate new ObjectID
-	id := primitive.NewObjectID()
-	doc["_id"] = id
-
-	return id, doc
+// UpdateOne intercepts an update of at most one document.
+func (i *Interceptor) UpdateOne(ctx context.Context, collection string, filter, update interface{}, upsert bool) (*UpdateResult, error) {
+	return i.applyUpdate(collection, filter, update, upsert, true)
 }
 
-// convertIDToString converts various ID types to string
-func convertIDToString(id interface{}) string {
-	switch v := id.(type) {
-	case primitive.ObjectID:
-		return v.Hex()
-	case string:
-		return v
-	default:
-		return fmt.Sprintf("%v", id)
+// UpdateMany intercepts an update of every matching document.
+func (i *Interceptor) UpdateMany(ctx context.Context, collection string, filter, update interface{}, upsert bool) (*UpdateResult, error) {
+	return i.applyUpdate(collection, filter, update, upsert, false)
+}
+
+// ReplaceOne intercepts a full-document replacement.
+func (i *Interceptor) ReplaceOne(ctx context.Context, collection string, filter, replacement interface{}, upsert bool) (*UpdateResult, error) {
+	repDoc, ok := toBSONM(replacement)
+	if !ok {
+		return nil, fmt.Errorf("replacement must be a document, got %T", replacement)
 	}
+	if hasUpdateOperators(repDoc) {
+		return nil, fmt.Errorf("replacement documents must not contain update operators")
+	}
+	return i.applyUpdate(collection, filter, repDoc, upsert, true)
+}
+
+func (i *Interceptor) applyUpdate(collection string, filter, update interface{}, upsert, limitOne bool) (*UpdateResult, error) {
+	filterDoc, err := normalizeFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	matches, err := i.resolveMatches(collection, filterDoc, limitOne)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(matches) == 0 {
+		if !upsert {
+			return &UpdateResult{}, nil
+		}
+		upsertDoc, err := BuildUpsertDocument(filterDoc, update)
+		if err != nil {
+			return nil, err
+		}
+		upsertedID, newDoc, err := i.ensureDocumentID(upsertDoc)
+		if err != nil {
+			return nil, err
+		}
+		entry, err := i.putEntry(collection, wal.DocumentIDString(upsertedID), newDoc, nil)
+		if err != nil {
+			return nil, err
+		}
+		if err := i.append(entry); err != nil {
+			return nil, err
+		}
+		return &UpdateResult{UpsertedCount: 1, UpsertedID: upsertedID}, nil
+	}
+
+	var entries []*wal.Entry
+	var modified int64
+	for _, m := range matches {
+		newDoc, err := ApplyUpdate(m.doc, update, false)
+		if err != nil {
+			return nil, err
+		}
+		changed, err := docsDiffer(m.doc, newDoc)
+		if err != nil {
+			return nil, err
+		}
+		if !changed {
+			continue // Matched but unchanged: MongoDB writes nothing.
+		}
+		entry, err := i.putEntry(collection, m.docID, newDoc, m.doc)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+		modified++
+	}
+
+	if err := i.appendBatch(entries); err != nil {
+		return nil, err
+	}
+	return &UpdateResult{MatchedCount: int64(len(matches)), ModifiedCount: modified}, nil
+}
+
+// DeleteOne intercepts a delete of at most one document.
+func (i *Interceptor) DeleteOne(ctx context.Context, collection string, filter interface{}) (*DeleteResult, error) {
+	return i.applyDelete(collection, filter, true)
+}
+
+// DeleteMany intercepts a delete of every matching document.
+func (i *Interceptor) DeleteMany(ctx context.Context, collection string, filter interface{}) (*DeleteResult, error) {
+	return i.applyDelete(collection, filter, false)
+}
+
+func (i *Interceptor) applyDelete(collection string, filter interface{}, limitOne bool) (*DeleteResult, error) {
+	filterDoc, err := normalizeFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	matches, err := i.resolveMatches(collection, filterDoc, limitOne)
+	if err != nil {
+		return nil, err
+	}
+	if len(matches) == 0 {
+		return &DeleteResult{}, nil
+	}
+
+	entries := make([]*wal.Entry, 0, len(matches))
+	for _, m := range matches {
+		preImage, err := bson.Marshal(m.doc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal pre-image: %w", err)
+		}
+		entries = append(entries, &wal.Entry{
+			ProjectID:  i.branch.ProjectID,
+			BranchID:   i.branch.ID,
+			Operation:  wal.OpDelete,
+			Collection: collection,
+			DocumentID: m.docID,
+			PreImage:   preImage,
+			Actor:      i.actor,
+		})
+	}
+
+	if err := i.appendBatch(entries); err != nil {
+		return nil, err
+	}
+	return &DeleteResult{DeletedCount: int64(len(matches))}, nil
+}
+
+// FindMatches resolves a filter against current branch state, in
+// deterministic (sorted by document ID) order. Used by the read path.
+func (i *Interceptor) FindMatches(collection string, filter interface{}, limitOne bool) ([]bson.M, error) {
+	filterDoc, err := normalizeFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+	matches, err := i.resolveMatches(collection, filterDoc, limitOne)
+	if err != nil {
+		return nil, err
+	}
+	docs := make([]bson.M, 0, len(matches))
+	for _, m := range matches {
+		docs = append(docs, m.doc)
+	}
+	return docs, nil
+}
+
+// resolveMatches finds the documents a filter selects. Filters with an _id
+// equality take a point-lookup fast path; everything else materializes the
+// collection and scans it in sorted-ID order so that "first match"
+// operations are deterministic.
+func (i *Interceptor) resolveMatches(collection string, filterDoc bson.M, limitOne bool) ([]match, error) {
+	if idValue, ok := extractIDEquality(filterDoc); ok {
+		docID := wal.DocumentIDString(idValue)
+		doc, err := i.materializer.MaterializeDocument(i.branch, collection, docID)
+		if err != nil {
+			return nil, err
+		}
+		if doc == nil {
+			return nil, nil
+		}
+		matched, err := MatchesFilter(doc, filterDoc)
+		if err != nil {
+			return nil, err
+		}
+		if !matched {
+			return nil, nil
+		}
+		return []match{{docID: docID, doc: doc}}, nil
+	}
+
+	state, err := i.materializer.MaterializeCollection(i.branch, collection)
+	if err != nil {
+		return nil, fmt.Errorf("failed to materialize collection: %w", err)
+	}
+
+	docIDs := make([]string, 0, len(state))
+	for docID := range state {
+		docIDs = append(docIDs, docID)
+	}
+	sort.Strings(docIDs)
+
+	var matches []match
+	for _, docID := range docIDs {
+		matched, err := MatchesFilter(state[docID], filterDoc)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			matches = append(matches, match{docID: docID, doc: state[docID]})
+			if limitOne {
+				break
+			}
+		}
+	}
+	return matches, nil
+}
+
+// putEntry builds a put entry with an optional pre-image.
+func (i *Interceptor) putEntry(collection, docID string, doc bson.M, preImage bson.M) (*wal.Entry, error) {
+	postBytes, err := bson.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal post-image: %w", err)
+	}
+	entry := &wal.Entry{
+		ProjectID:  i.branch.ProjectID,
+		BranchID:   i.branch.ID,
+		Operation:  wal.OpPut,
+		Collection: collection,
+		DocumentID: docID,
+		PostImage:  postBytes,
+		Actor:      i.actor,
+	}
+	if preImage != nil {
+		preBytes, err := bson.Marshal(preImage)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal pre-image: %w", err)
+		}
+		entry.PreImage = preBytes
+	}
+	return entry, nil
+}
+
+// append writes one entry and advances the branch head, both durably and on
+// the in-memory branch so this handle reads its own writes.
+func (i *Interceptor) append(entry *wal.Entry) error {
+	lsn, err := i.wal.Append(entry)
+	if err != nil {
+		return fmt.Errorf("failed to append to WAL: %w", err)
+	}
+	return i.advanceHead(lsn)
+}
+
+func (i *Interceptor) appendBatch(entries []*wal.Entry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	lsns, err := i.wal.AppendBatch(entries)
+	if err != nil {
+		return fmt.Errorf("failed to append to WAL: %w", err)
+	}
+	return i.advanceHead(lsns[len(lsns)-1])
+}
+
+func (i *Interceptor) advanceHead(lsn int64) error {
+	if err := i.branches.UpdateBranchHead(i.branch.ID, lsn); err != nil {
+		return fmt.Errorf("failed to update branch head: %w", err)
+	}
+	if lsn > i.branch.HeadLSN {
+		i.branch.HeadLSN = lsn
+	}
+	return nil
+}
+
+// ensureDocumentID normalizes the document and guarantees it has an _id.
+// The returned document is always a private copy.
+func (i *Interceptor) ensureDocumentID(document interface{}) (interface{}, bson.M, error) {
+	doc, ok := toBSONM(document)
+	if !ok {
+		raw, err := bson.Marshal(document)
+		if err != nil {
+			return nil, nil, fmt.Errorf("document must be BSON-marshallable: %w", err)
+		}
+		if err := bson.Unmarshal(raw, &doc); err != nil {
+			return nil, nil, fmt.Errorf("document must decode to a BSON document: %w", err)
+		}
+	} else {
+		cloned, err := cloneDoc(doc)
+		if err != nil {
+			return nil, nil, err
+		}
+		doc = cloned
+	}
+
+	if id, exists := doc["_id"]; exists && id != nil {
+		return id, doc, nil
+	}
+
+	id := primitive.NewObjectID()
+	doc["_id"] = id
+	return id, doc, nil
+}
+
+// normalizeFilter converts any filter representation to bson.M.
+func normalizeFilter(filter interface{}) (bson.M, error) {
+	if filter == nil {
+		return bson.M{}, nil
+	}
+	if doc, ok := toBSONM(filter); ok {
+		return doc, nil
+	}
+	raw, err := bson.Marshal(filter)
+	if err != nil {
+		return nil, fmt.Errorf("filter must be BSON-marshallable: %w", err)
+	}
+	var doc bson.M
+	if err := bson.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("filter must decode to a BSON document: %w", err)
+	}
+	return doc, nil
+}
+
+// extractIDEquality returns the _id value if the filter pins _id to exactly
+// one value (a literal or a lone {$eq: v}).
+func extractIDEquality(filter bson.M) (interface{}, bool) {
+	idCond, exists := filter["_id"]
+	if !exists {
+		return nil, false
+	}
+	if opDoc, isOp := asOperatorDoc(idCond); isOp {
+		if eq, has := opDoc["$eq"]; has && len(opDoc) == 1 {
+			return eq, true
+		}
+		return nil, false
+	}
+	return idCond, true
+}
+
+// docsDiffer reports whether two documents differ under the canonical
+// (sorted-key) representation. Marshalling each map directly would compare
+// randomized key orders and misreport identical documents as changed.
+func docsDiffer(a, b bson.M) (bool, error) {
+	equal, err := CanonicalEqual(a, b)
+	if err != nil {
+		return false, err
+	}
+	return !equal, nil
 }

--- a/internal/driver/wal/update_operators.go
+++ b/internal/driver/wal/update_operators.go
@@ -1,0 +1,402 @@
+package wal
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// This file implements MongoDB update operator application for the SDK
+// write path. Like the filter matcher, it runs exactly once per operation:
+// the resulting post-image is logged to the WAL, so replay never re-executes
+// any of this.
+//
+// Supported: $set, $unset, $inc, $mul, $min, $max, $rename, $push (with
+// $each), $addToSet (with $each), $pull, $pop, $setOnInsert, $currentDate,
+// dotted field paths, and full-document replacement (an update with no $
+// operators). Unsupported operators fail loudly.
+
+// ApplyUpdate returns the post-image of applying a MongoDB update document
+// to doc. doc is not mutated. isUpsertInsert selects $setOnInsert behavior.
+func ApplyUpdate(doc bson.M, update interface{}, isUpsertInsert bool) (bson.M, error) {
+	updateDoc, ok := toBSONM(update)
+	if !ok {
+		return nil, fmt.Errorf("update must be a document, got %T", update)
+	}
+
+	result, err := cloneDoc(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	if !hasUpdateOperators(updateDoc) {
+		// Replacement semantics: keep _id, take everything else from the
+		// replacement document.
+		replacement, err := cloneDoc(updateDoc)
+		if err != nil {
+			return nil, err
+		}
+		if id, exists := result["_id"]; exists {
+			if repID, has := replacement["_id"]; has && compareBSONValues(repID, id) != 0 {
+				return nil, fmt.Errorf("the _id field cannot be changed by a replacement")
+			}
+			replacement["_id"] = id
+		}
+		return replacement, nil
+	}
+
+	for op, operand := range updateDoc {
+		fields, ok := toBSONM(operand)
+		if !ok {
+			return nil, fmt.Errorf("%s requires a document operand, got %T", op, operand)
+		}
+		for path, value := range fields {
+			if err := applyUpdateOperator(result, op, path, value, isUpsertInsert); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if id, exists := doc["_id"]; exists {
+		if newID, has := result["_id"]; !has || compareBSONValues(newID, id) != 0 {
+			return nil, fmt.Errorf("the _id field cannot be changed by an update")
+		}
+	}
+
+	return result, nil
+}
+
+// BuildUpsertDocument constructs the document an upsert inserts when no
+// document matched: the equality conditions of the filter, plus the update
+// applied with $setOnInsert active.
+func BuildUpsertDocument(filter bson.M, update interface{}) (bson.M, error) {
+	seed := bson.M{}
+	for path, expected := range filter {
+		if strings.HasPrefix(path, "$") {
+			continue // $and/$or conditions don't seed upserts here.
+		}
+		if opDoc, isOp := asOperatorDoc(expected); isOp {
+			if eq, has := opDoc["$eq"]; has {
+				setPath(seed, path, eq)
+			}
+			continue
+		}
+		setPath(seed, path, expected)
+	}
+	return ApplyUpdate(seed, update, true)
+}
+
+func applyUpdateOperator(doc bson.M, op, path string, value interface{}, isUpsertInsert bool) error {
+	switch op {
+	case "$set":
+		setPath(doc, path, value)
+	case "$setOnInsert":
+		if isUpsertInsert {
+			setPath(doc, path, value)
+		}
+	case "$unset":
+		unsetPath(doc, path)
+	case "$inc", "$mul":
+		operand, ok := toFloat(value)
+		if !ok {
+			return fmt.Errorf("%s requires a numeric operand for field %s", op, path)
+		}
+		current, exists := lookupPath(doc, path)
+		if !exists {
+			if op == "$inc" {
+				setPath(doc, path, value)
+			} else {
+				// $mul on a missing field sets it to zero of the operand type.
+				setPath(doc, path, zeroLike(value))
+			}
+			return nil
+		}
+		curNum, ok := toFloat(current)
+		if !ok {
+			return fmt.Errorf("cannot apply %s to non-numeric field %s", op, path)
+		}
+		var result float64
+		if op == "$inc" {
+			result = curNum + operand
+		} else {
+			result = curNum * operand
+		}
+		setPath(doc, path, promoteNumeric(current, value, result))
+	case "$min", "$max":
+		current, exists := lookupPath(doc, path)
+		if !exists {
+			setPath(doc, path, value)
+			return nil
+		}
+		c := compareBSONValues(value, current)
+		if c == 2 {
+			return nil // Incomparable types: MongoDB uses type ordering; keep current for supported set.
+		}
+		if (op == "$min" && c < 0) || (op == "$max" && c > 0) {
+			setPath(doc, path, value)
+		}
+	case "$rename":
+		newPath, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("$rename requires a string target for field %s", path)
+		}
+		if current, exists := lookupPath(doc, path); exists {
+			unsetPath(doc, path)
+			setPath(doc, newPath, current)
+		}
+	case "$push":
+		return applyPush(doc, path, value)
+	case "$addToSet":
+		return applyAddToSet(doc, path, value)
+	case "$pull":
+		return applyPull(doc, path, value)
+	case "$pop":
+		return applyPop(doc, path, value)
+	case "$currentDate":
+		setPath(doc, path, time.Now().UTC())
+	default:
+		return fmt.Errorf("unsupported update operator %q", op)
+	}
+	return nil
+}
+
+func applyPush(doc bson.M, path string, value interface{}) error {
+	items := []interface{}{value}
+	if mod, isMod := asOperatorDoc(value); isMod {
+		each, has := mod["$each"]
+		if !has {
+			return fmt.Errorf("$push modifiers other than $each are not supported")
+		}
+		if len(mod) > 1 {
+			return fmt.Errorf("$push modifiers other than $each are not supported")
+		}
+		arr, ok := asArray(each)
+		if !ok {
+			return fmt.Errorf("$each requires an array")
+		}
+		items = arr
+	}
+
+	current, exists := lookupPath(doc, path)
+	if !exists {
+		setPath(doc, path, append([]interface{}{}, items...))
+		return nil
+	}
+	arr, ok := asArray(current)
+	if !ok {
+		return fmt.Errorf("cannot $push to non-array field %s", path)
+	}
+	setPath(doc, path, append(append([]interface{}{}, arr...), items...))
+	return nil
+}
+
+func applyAddToSet(doc bson.M, path string, value interface{}) error {
+	items := []interface{}{value}
+	if mod, isMod := asOperatorDoc(value); isMod {
+		each, has := mod["$each"]
+		if !has || len(mod) > 1 {
+			return fmt.Errorf("$addToSet modifiers other than $each are not supported")
+		}
+		arr, ok := asArray(each)
+		if !ok {
+			return fmt.Errorf("$each requires an array")
+		}
+		items = arr
+	}
+
+	var arr []interface{}
+	if current, exists := lookupPath(doc, path); exists {
+		existing, ok := asArray(current)
+		if !ok {
+			return fmt.Errorf("cannot $addToSet to non-array field %s", path)
+		}
+		arr = append(arr, existing...)
+	}
+
+	for _, item := range items {
+		present := false
+		for _, existing := range arr {
+			if compareBSONValues(existing, item) == 0 {
+				present = true
+				break
+			}
+		}
+		if !present {
+			arr = append(arr, item)
+		}
+	}
+	setPath(doc, path, arr)
+	return nil
+}
+
+func applyPull(doc bson.M, path string, condition interface{}) error {
+	current, exists := lookupPath(doc, path)
+	if !exists {
+		return nil
+	}
+	arr, ok := asArray(current)
+	if !ok {
+		return fmt.Errorf("cannot $pull from non-array field %s", path)
+	}
+
+	kept := make([]interface{}, 0, len(arr))
+	for _, item := range arr {
+		remove := false
+		if opDoc, isOp := asOperatorDoc(condition); isOp {
+			ok, err := matchesOperators(item, true, opDoc)
+			if err != nil {
+				return err
+			}
+			remove = ok
+		} else if condDoc, isDoc := toBSONM(condition); isDoc {
+			itemDoc, isItemDoc := toBSONM(item)
+			if isItemDoc {
+				ok, err := MatchesFilter(itemDoc, condDoc)
+				if err != nil {
+					return err
+				}
+				remove = ok
+			}
+		} else {
+			remove = compareBSONValues(item, condition) == 0
+		}
+		if !remove {
+			kept = append(kept, item)
+		}
+	}
+	setPath(doc, path, kept)
+	return nil
+}
+
+func applyPop(doc bson.M, path string, value interface{}) error {
+	current, exists := lookupPath(doc, path)
+	if !exists {
+		return nil
+	}
+	arr, ok := asArray(current)
+	if !ok {
+		return fmt.Errorf("cannot $pop from non-array field %s", path)
+	}
+	if len(arr) == 0 {
+		return nil
+	}
+	switch toInt64(value) {
+	case 1:
+		setPath(doc, path, append([]interface{}{}, arr[:len(arr)-1]...))
+	case -1:
+		setPath(doc, path, append([]interface{}{}, arr[1:]...))
+	default:
+		return fmt.Errorf("$pop requires 1 or -1")
+	}
+	return nil
+}
+
+// hasUpdateOperators reports whether the update document uses operator form.
+// MongoDB rejects mixed operator/literal documents; so do we, implicitly,
+// because a leading non-$ key selects replacement semantics.
+func hasUpdateOperators(update bson.M) bool {
+	for k := range update {
+		if strings.HasPrefix(k, "$") {
+			return true
+		}
+	}
+	return false
+}
+
+// cloneDoc deep-copies a document through BSON marshalling, which also
+// normalizes nested maps to bson.M.
+func cloneDoc(doc bson.M) (bson.M, error) {
+	if doc == nil {
+		return bson.M{}, nil
+	}
+	raw, err := bson.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone document: %w", err)
+	}
+	var clone bson.M
+	if err := bson.Unmarshal(raw, &clone); err != nil {
+		return nil, fmt.Errorf("failed to clone document: %w", err)
+	}
+	return clone, nil
+}
+
+// promoteNumeric picks the result type for $inc/$mul following MongoDB's
+// promotion rules: any double operand makes the result a double, otherwise
+// any int64 makes it an int64, otherwise it stays int32.
+func promoteNumeric(current, operand interface{}, result float64) interface{} {
+	if isFloatKind(current) || isFloatKind(operand) {
+		return result
+	}
+	if isInt64Kind(current) || isInt64Kind(operand) {
+		return int64(result)
+	}
+	return int32(result)
+}
+
+func isFloatKind(v interface{}) bool {
+	switch v.(type) {
+	case float32, float64:
+		return true
+	}
+	return false
+}
+
+func isInt64Kind(v interface{}) bool {
+	switch v.(type) {
+	case int64, int:
+		return true
+	}
+	return false
+}
+
+func zeroLike(v interface{}) interface{} {
+	if isFloatKind(v) {
+		return float64(0)
+	}
+	if isInt64Kind(v) {
+		return int64(0)
+	}
+	return int32(0)
+}
+
+// setPath sets a (possibly dotted) field path, creating intermediate
+// documents as needed.
+func setPath(doc bson.M, path string, value interface{}) {
+	parts := strings.Split(path, ".")
+	current := doc
+	for _, part := range parts[:len(parts)-1] {
+		next, exists := current[part]
+		if exists {
+			if nextDoc, ok := toBSONM(next); ok {
+				current[part] = nextDoc
+				current = nextDoc
+				continue
+			}
+		}
+		created := bson.M{}
+		current[part] = created
+		current = created
+	}
+	current[parts[len(parts)-1]] = value
+}
+
+// unsetPath removes a (possibly dotted) field path if it exists.
+func unsetPath(doc bson.M, path string) {
+	parts := strings.Split(path, ".")
+	current := doc
+	for _, part := range parts[:len(parts)-1] {
+		next, exists := current[part]
+		if !exists {
+			return
+		}
+		nextDoc, ok := toBSONM(next)
+		if !ok {
+			return
+		}
+		current[part] = nextDoc
+		current = nextDoc
+	}
+	delete(current, parts[len(parts)-1])
+}

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -9,10 +9,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
-	driverwal "github.com/argon-lab/argon/internal/driver/wal"
-	"github.com/argon-lab/argon/internal/wal"
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
 	projectwal "github.com/argon-lab/argon/internal/project/wal"
+	"github.com/argon-lab/argon/internal/wal"
 )
 
 // ImportService handles importing existing MongoDB databases into Argon WAL system
@@ -257,13 +256,14 @@ func (s *ImportService) ImportDatabase(ctx context.Context, opts ImportOptions) 
 	return result, nil
 }
 
-// importCollection imports a single collection into the WAL system
+// importCollection imports a single collection into the WAL system.
+// Imports write put entries directly (one batched append per batch of
+// documents) instead of going through the interceptor: the target project
+// is freshly created, so per-document duplicate checks and filter
+// resolution would be pure overhead.
 func (s *ImportService) importCollection(ctx context.Context, sourceDB *mongo.Database, collectionName string, branch *wal.Branch, batchSize int) (int64, int64, error) {
 	collection := sourceDB.Collection(collectionName)
-	
-	// Create WAL interceptor for this branch
-	interceptor := driverwal.NewInterceptor(s.walService, branch, s.branchService)
-	
+
 	// Create a cursor to read all documents
 	cursor, err := collection.Find(ctx, bson.D{})
 	if err != nil {
@@ -273,9 +273,7 @@ func (s *ImportService) importCollection(ctx context.Context, sourceDB *mongo.Da
 
 	var importedCount int64
 	var walEntriesCount int64
-	documents := make([]interface{}, 0, batchSize)
-
-	startWALCount := s.walService.GetCurrentLSN(branch.ProjectID)
+	entries := make([]*wal.Entry, 0, batchSize)
 
 	// Process documents in batches
 	for cursor.Next(ctx) {
@@ -284,44 +282,72 @@ func (s *ImportService) importCollection(ctx context.Context, sourceDB *mongo.Da
 			return importedCount, walEntriesCount, fmt.Errorf("failed to decode document: %w", err)
 		}
 
-		documents = append(documents, doc)
+		entry, err := importEntry(branch, collectionName, doc)
+		if err != nil {
+			return importedCount, walEntriesCount, err
+		}
+		entries = append(entries, entry)
 
 		// Process batch when it's full
-		if len(documents) >= batchSize {
-			if err := s.processBatch(ctx, interceptor, collectionName, documents); err != nil {
+		if len(entries) >= batchSize {
+			if err := s.appendImportBatch(branch, entries); err != nil {
 				return importedCount, walEntriesCount, fmt.Errorf("failed to process batch: %w", err)
 			}
-			importedCount += int64(len(documents))
-			documents = documents[:0] // Reset batch
+			importedCount += int64(len(entries))
+			walEntriesCount += int64(len(entries))
+			entries = entries[:0] // Reset batch
 		}
 	}
 
 	// Process remaining documents
-	if len(documents) > 0 {
-		if err := s.processBatch(ctx, interceptor, collectionName, documents); err != nil {
+	if len(entries) > 0 {
+		if err := s.appendImportBatch(branch, entries); err != nil {
 			return importedCount, walEntriesCount, fmt.Errorf("failed to process final batch: %w", err)
 		}
-		importedCount += int64(len(documents))
+		importedCount += int64(len(entries))
+		walEntriesCount += int64(len(entries))
 	}
 
 	if err := cursor.Err(); err != nil {
 		return importedCount, walEntriesCount, fmt.Errorf("cursor error: %w", err)
 	}
 
-	endWALCount := s.walService.GetCurrentLSN(branch.ProjectID)
-	walEntriesCount = endWALCount - startWALCount
-
 	return importedCount, walEntriesCount, nil
 }
 
-// processBatch processes a batch of documents through the WAL interceptor
-func (s *ImportService) processBatch(ctx context.Context, interceptor *driverwal.Interceptor, collectionName string, documents []interface{}) error {
-	// Use the interceptor to insert documents, which will create WAL entries
-	for _, doc := range documents {
-		_, err := interceptor.InsertOne(ctx, collectionName, doc)
-		if err != nil {
-			return fmt.Errorf("failed to insert document via interceptor: %w", err)
-		}
+// importEntry builds a put entry for one imported document.
+func importEntry(branch *wal.Branch, collectionName string, doc bson.M) (*wal.Entry, error) {
+	id, exists := doc["_id"]
+	if !exists || id == nil {
+		return nil, fmt.Errorf("imported document in %s has no _id", collectionName)
+	}
+	postImage, err := bson.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal imported document: %w", err)
+	}
+	return &wal.Entry{
+		ProjectID:  branch.ProjectID,
+		BranchID:   branch.ID,
+		Operation:  wal.OpPut,
+		Collection: collectionName,
+		DocumentID: wal.DocumentIDString(id),
+		PostImage:  postImage,
+		Actor:      "importer",
+	}, nil
+}
+
+// appendImportBatch appends one batch of entries and advances the branch head.
+func (s *ImportService) appendImportBatch(branch *wal.Branch, entries []*wal.Entry) error {
+	lsns, err := s.walService.AppendBatch(entries)
+	if err != nil {
+		return err
+	}
+	last := lsns[len(lsns)-1]
+	if err := s.branchService.UpdateBranchHead(branch.ID, last); err != nil {
+		return fmt.Errorf("failed to update branch head: %w", err)
+	}
+	if last > branch.HeadLSN {
+		branch.HeadLSN = last
 	}
 	return nil
 }

--- a/internal/materializer/service.go
+++ b/internal/materializer/service.go
@@ -1,571 +1,226 @@
+// Package materializer reconstructs branch state by replaying WAL entries.
+//
+// Replay is deterministic by construction: every data entry is a physical
+// record (a put carrying the full post-image of one document, or a delete of
+// one document ID), so applying a WAL prefix is a pure fold — no filters or
+// update operators are re-executed, and replaying the same prefix any number
+// of times yields byte-identical state.
 package materializer
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/argon-lab/argon/internal/wal"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// Service materializes current state from WAL entries
+// BranchLookup resolves branch metadata during ancestry traversal.
+type BranchLookup interface {
+	GetBranchByIDAny(branchID string) (*wal.Branch, error)
+}
+
+// Service materializes state from WAL entries
 type Service struct {
-	wal *wal.Service
+	wal      *wal.Service
+	branches BranchLookup
 }
 
 // NewService creates a new materializer service
-func NewService(walService *wal.Service) *Service {
+func NewService(walService *wal.Service, branches BranchLookup) *Service {
 	return &Service{
-		wal: walService,
+		wal:      walService,
+		branches: branches,
 	}
+}
+
+// segment is one ancestor's contribution to a branch's history: the
+// ancestor's own entries in [fromLSN, toLSN], minus its discarded ranges.
+type segment struct {
+	branch  *wal.Branch
+	fromLSN int64
+	toLSN   int64
+}
+
+// maxAncestryDepth guards against corrupted parent pointers forming a cycle.
+const maxAncestryDepth = 10000
+
+// ancestrySegments returns the WAL segments whose in-order concatenation
+// covers the state of a branch at targetLSN. Segments are returned
+// root-first. Each hop contributes only its own entries: a branch's entries
+// live in (BaseLSN, HeadLSN]; everything at or below BaseLSN is inherited
+// from the parent chain. Sibling branches never appear in each other's
+// chains, which is what isolates them.
+func (s *Service) ancestrySegments(branch *wal.Branch, targetLSN int64) ([]segment, error) {
+	var reversed []segment
+
+	cur := branch
+	limit := targetLSN
+	for depth := 0; ; depth++ {
+		if depth >= maxAncestryDepth {
+			return nil, fmt.Errorf("branch %s ancestry exceeds %d hops: parent chain is corrupt or cyclic", branch.ID, maxAncestryDepth)
+		}
+
+		if limit > cur.BaseLSN {
+			reversed = append(reversed, segment{branch: cur, fromLSN: cur.BaseLSN + 1, toLSN: limit})
+		}
+
+		if cur.ParentID == "" {
+			break
+		}
+		parent, err := s.branches.GetBranchByIDAny(cur.ParentID)
+		if err != nil {
+			return nil, fmt.Errorf("branch %s references parent %s which cannot be loaded: %w", cur.ID, cur.ParentID, err)
+		}
+
+		// Entries at or below the fork point belong to the parent chain.
+		// Keeping the smaller of the two matters when a branch was forked
+		// from a point below its parent's own base: the effective limit
+		// must not grow back up to the parent's base.
+		if cur.BaseLSN < limit {
+			limit = cur.BaseLSN
+		}
+		cur = parent
+	}
+
+	// Reverse to root-first order.
+	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+	return reversed, nil
+}
+
+// MaterializeCollectionAtLSN builds the state of one collection as of
+// targetLSN, following the branch's ancestry chain.
+func (s *Service) MaterializeCollectionAtLSN(branch *wal.Branch, collection string, targetLSN int64) (map[string]bson.M, error) {
+	segments, err := s.ancestrySegments(branch, targetLSN)
+	if err != nil {
+		return nil, err
+	}
+
+	state := make(map[string]bson.M)
+	for _, seg := range segments {
+		entries, err := s.wal.GetBranchEntries(seg.branch.ID, collection, seg.fromLSN, seg.toLSN)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get entries for branch %s: %w", seg.branch.ID, err)
+		}
+		for _, entry := range entries {
+			if seg.branch.IsDiscardedForRead(entry.LSN, seg.toLSN) {
+				continue
+			}
+			if err := s.ApplyEntry(state, entry); err != nil {
+				return nil, fmt.Errorf("failed to apply entry LSN %d: %w", entry.LSN, err)
+			}
+		}
+	}
+
+	return state, nil
 }
 
 // MaterializeCollection builds the current state of a collection for a branch
 func (s *Service) MaterializeCollection(branch *wal.Branch, collection string) (map[string]bson.M, error) {
-	// For branches created from a historical point (BaseLSN > 0), we need to include
-	// entries from before the branch was created up to the BaseLSN
-	entries := []*wal.Entry{}
-	var err error
-
-	if branch.BaseLSN > 0 {
-		// This is a branch created from a historical point
-		// Get entries up to the base LSN from the global WAL
-		baseEntries, err := s.wal.GetProjectEntries(branch.ProjectID, collection, 0, branch.BaseLSN)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get base entries: %w", err)
-		}
-		entries = append(entries, baseEntries...)
-	}
-
-	// Get entries specific to this branch (after it was created)
-	branchEntries, err := s.wal.GetBranchEntries(branch.ID, collection, branch.BaseLSN+1, branch.HeadLSN)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get branch entries: %w", err)
-	}
-	entries = append(entries, branchEntries...)
-
-	// Build state by replaying entries
-	state := make(map[string]bson.M)
-
-	for _, entry := range entries {
-		if err := s.ApplyEntry(state, entry); err != nil {
-			return nil, fmt.Errorf("failed to apply entry LSN %d: %w", entry.LSN, err)
-		}
-	}
-
-	return state, nil
+	return s.MaterializeCollectionAtLSN(branch, collection, branch.HeadLSN)
 }
 
-// MaterializeBranch builds the complete state of all collections in a branch
-func (s *Service) MaterializeBranch(branch *wal.Branch) (map[string]map[string]bson.M, error) {
-	// For branches created from a historical point, include base entries
-	entries := []*wal.Entry{}
-	var err error
-
-	if branch.BaseLSN > 0 {
-		// Get entries up to the base LSN from the global WAL
-		baseEntries, err := s.wal.GetProjectEntries(branch.ProjectID, "", 0, branch.BaseLSN)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get base entries: %w", err)
-		}
-		entries = append(entries, baseEntries...)
-	}
-
-	// Get entries specific to this branch
-	branchEntries, err := s.wal.GetBranchEntries(branch.ID, "", branch.BaseLSN+1, branch.HeadLSN)
+// MaterializeBranchAtLSN builds the state of every collection in a branch as
+// of targetLSN, keyed by collection name.
+func (s *Service) MaterializeBranchAtLSN(branch *wal.Branch, targetLSN int64) (map[string]map[string]bson.M, error) {
+	segments, err := s.ancestrySegments(branch, targetLSN)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get branch entries: %w", err)
+		return nil, err
 	}
-	entries = append(entries, branchEntries...)
 
-	// Build state by collection
 	state := make(map[string]map[string]bson.M)
-
-	for _, entry := range entries {
-		if entry.Collection == "" {
-			continue // Skip non-collection operations
+	for _, seg := range segments {
+		entries, err := s.wal.GetBranchEntries(seg.branch.ID, "", seg.fromLSN, seg.toLSN)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get entries for branch %s: %w", seg.branch.ID, err)
 		}
-
-		// Initialize collection state if needed
-		if _, exists := state[entry.Collection]; !exists {
-			state[entry.Collection] = make(map[string]bson.M)
-		}
-
-		if err := s.ApplyEntry(state[entry.Collection], entry); err != nil {
-			return nil, fmt.Errorf("failed to apply entry LSN %d: %w", entry.LSN, err)
+		for _, entry := range entries {
+			if entry.Collection == "" {
+				continue // Control operations carry no collection state.
+			}
+			if seg.branch.IsDiscardedForRead(entry.LSN, seg.toLSN) {
+				continue
+			}
+			if _, exists := state[entry.Collection]; !exists {
+				state[entry.Collection] = make(map[string]bson.M)
+			}
+			if err := s.ApplyEntry(state[entry.Collection], entry); err != nil {
+				return nil, fmt.Errorf("failed to apply entry LSN %d: %w", entry.LSN, err)
+			}
 		}
 	}
 
 	return state, nil
 }
 
-// MaterializeDocument gets the current state of a specific document
-func (s *Service) MaterializeDocument(branch *wal.Branch, collection, documentID string) (bson.M, error) {
-	// Get all entries for the document
-	entries, err := s.wal.GetDocumentHistory(branch.ID, collection, documentID, 0, branch.HeadLSN)
+// MaterializeBranch builds the complete current state of all collections in
+// a branch.
+func (s *Service) MaterializeBranch(branch *wal.Branch) (map[string]map[string]bson.M, error) {
+	return s.MaterializeBranchAtLSN(branch, branch.HeadLSN)
+}
+
+// MaterializeDocumentAtLSN reconstructs one document as of targetLSN, or nil
+// if it does not exist at that point. This is a point lookup: it reads only
+// the document's own history via the (branch, collection, document, lsn)
+// index instead of replaying the whole collection.
+func (s *Service) MaterializeDocumentAtLSN(branch *wal.Branch, collection, documentID string, targetLSN int64) (bson.M, error) {
+	segments, err := s.ancestrySegments(branch, targetLSN)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get document history: %w", err)
+		return nil, err
 	}
 
-	// Build document state by replaying entries
 	state := make(map[string]bson.M)
-
-	for _, entry := range entries {
-		if err := s.ApplyEntry(state, entry); err != nil {
-			return nil, fmt.Errorf("failed to apply entry LSN %d: %w", entry.LSN, err)
+	for _, seg := range segments {
+		entries, err := s.wal.GetDocumentHistory(seg.branch.ID, collection, documentID, seg.fromLSN, seg.toLSN)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get document history for branch %s: %w", seg.branch.ID, err)
+		}
+		for _, entry := range entries {
+			if seg.branch.IsDiscardedForRead(entry.LSN, seg.toLSN) {
+				continue
+			}
+			if err := s.ApplyEntry(state, entry); err != nil {
+				return nil, fmt.Errorf("failed to apply entry LSN %d: %w", entry.LSN, err)
+			}
 		}
 	}
 
-	// Return the document if it exists
 	if doc, exists := state[documentID]; exists {
 		return doc, nil
 	}
-
-	return nil, nil // Document doesn't exist or was deleted
+	return nil, nil // Document doesn't exist or was deleted.
 }
 
-// ApplyEntry applies a WAL entry to the current state
-// Exported for use by time travel service
+// MaterializeDocument gets the current state of a specific document.
+func (s *Service) MaterializeDocument(branch *wal.Branch, collection, documentID string) (bson.M, error) {
+	return s.MaterializeDocumentAtLSN(branch, collection, documentID, branch.HeadLSN)
+}
+
+// ApplyEntry applies a WAL entry to a state map. Puts and deletes are
+// idempotent by construction; control operations are no-ops here.
 func (s *Service) ApplyEntry(state map[string]bson.M, entry *wal.Entry) error {
+	if entry.IsLegacy() {
+		return fmt.Errorf("entry LSN %d uses the legacy schema-v1 format (%s) and cannot be replayed deterministically; run the WAL migration", entry.LSN, entry.Operation)
+	}
+
 	switch entry.Operation {
-	case wal.OpInsert:
-		return s.applyInsert(state, entry)
-	case wal.OpUpdate:
-		return s.applyUpdate(state, entry)
+	case wal.OpPut:
+		if entry.DocumentID == "" {
+			return fmt.Errorf("put entry LSN %d has no document ID", entry.LSN)
+		}
+		var doc bson.M
+		if err := bson.Unmarshal(entry.PostImage, &doc); err != nil {
+			return fmt.Errorf("failed to unmarshal post-image: %w", err)
+		}
+		state[entry.DocumentID] = doc
 	case wal.OpDelete:
-		return s.applyDelete(state, entry)
+		if entry.DocumentID == "" {
+			return fmt.Errorf("delete entry LSN %d has no document ID", entry.LSN)
+		}
+		delete(state, entry.DocumentID)
 	default:
-		// Skip unknown operations
-		return nil
-	}
-}
-
-// applyInsert applies an insert operation
-func (s *Service) applyInsert(state map[string]bson.M, entry *wal.Entry) error {
-	// Unmarshal the document
-	var doc bson.M
-	if err := bson.Unmarshal(entry.Document, &doc); err != nil {
-		return fmt.Errorf("failed to unmarshal document: %w", err)
-	}
-
-	// Extract document ID
-	docID := entry.DocumentID
-	if docID == "" {
-		// Try to extract from document
-		if id, exists := doc["_id"]; exists {
-			docID = convertIDToString(id)
-		}
-	}
-
-	if docID == "" {
-		return fmt.Errorf("document has no ID")
-	}
-
-	// Store in state
-	state[docID] = doc
-	return nil
-}
-
-// applyUpdate applies an update operation
-func (s *Service) applyUpdate(state map[string]bson.M, entry *wal.Entry) error {
-	// For MVP, updates store filter and update operation
-	// Parse the combined document
-	var updateDoc bson.M
-	if err := bson.Unmarshal(entry.Document, &updateDoc); err != nil {
-		return fmt.Errorf("failed to unmarshal update document: %w", err)
-	}
-
-	// Extract filter and update - they can be either bson.M or bson.Raw
-	var filter, update bson.M
-
-	// Handle filter
-	switch f := updateDoc["filter"].(type) {
-	case bson.M:
-		filter = f
-	case map[string]interface{}:
-		filter = bson.M(f)
-	case bson.Raw:
-		if err := bson.Unmarshal(f, &filter); err != nil {
-			return fmt.Errorf("failed to unmarshal filter from Raw: %w", err)
-		}
-	default:
-		return fmt.Errorf("invalid filter format: %T", f)
-	}
-
-	// Handle update
-	switch u := updateDoc["update"].(type) {
-	case bson.M:
-		update = u
-	case map[string]interface{}:
-		update = bson.M(u)
-	case bson.Raw:
-		if err := bson.Unmarshal(u, &update); err != nil {
-			return fmt.Errorf("failed to unmarshal update from Raw: %w", err)
-		}
-	default:
-		return fmt.Errorf("invalid update format: %T", u)
-	}
-
-	// Find matching documents and apply update
-	for docID, doc := range state {
-		if matchesFilter(doc, filter) {
-			// Apply update operations
-			if err := applyUpdateOperations(doc, update); err != nil {
-				return fmt.Errorf("failed to apply update to document %s: %w", docID, err)
-			}
-			// Only update first match for UpdateOne
-			break
-		}
-	}
-
-	return nil
-}
-
-// applyDelete applies a delete operation
-func (s *Service) applyDelete(state map[string]bson.M, entry *wal.Entry) error {
-	// For MVP, deletes store the filter
-	var filter bson.M
-	if err := bson.Unmarshal(entry.Document, &filter); err != nil {
-		return fmt.Errorf("failed to unmarshal filter: %w", err)
-	}
-
-	// Find and delete matching documents
-	for docID, doc := range state {
-		if matchesFilter(doc, filter) {
-			delete(state, docID)
-			// Only delete first match for DeleteOne
-			break
-		}
-	}
-
-	return nil
-}
-
-// convertIDToString converts various ID types to string
-func convertIDToString(id interface{}) string {
-	switch v := id.(type) {
-	case primitive.ObjectID:
-		return v.Hex()
-	case string:
-		return v
-	default:
-		return fmt.Sprintf("%v", id)
-	}
-}
-
-// matchesFilter checks if a document matches a filter
-func matchesFilter(doc, filter bson.M) bool {
-	// Empty filter matches all
-	if len(filter) == 0 {
-		return true
-	}
-
-	// Check each filter field
-	for key, expected := range filter {
-		actual, exists := doc[key]
-		if !exists {
-			return false
-		}
-
-		// Handle different operator types
-		switch exp := expected.(type) {
-		case bson.M:
-			// Handle operators like $gt, $lt, etc.
-			if !matchesOperators(actual, exp) {
-				return false
-			}
-		case map[string]interface{}:
-			// Convert to bson.M and handle as operators
-			if !matchesOperators(actual, bson.M(exp)) {
-				return false
-			}
-		default:
-			// Simple equality check
-			if !isEqual(actual, expected) {
-				return false
-			}
-		}
-	}
-
-	return true
-}
-
-// matchesOperators handles MongoDB query operators
-func matchesOperators(value interface{}, operators bson.M) bool {
-	for op, operand := range operators {
-		switch op {
-		case "$eq":
-			if !isEqual(value, operand) {
-				return false
-			}
-		case "$ne":
-			if isEqual(value, operand) {
-				return false
-			}
-		case "$gt":
-			if !isGreaterThan(value, operand) {
-				return false
-			}
-		case "$gte":
-			if !isGreaterThanOrEqual(value, operand) {
-				return false
-			}
-		case "$lt":
-			if !isLessThan(value, operand) {
-				return false
-			}
-		case "$lte":
-			if !isLessThanOrEqual(value, operand) {
-				return false
-			}
-		case "$in":
-			if !isInArray(value, operand) {
-				return false
-			}
-		case "$nin":
-			if isInArray(value, operand) {
-				return false
-			}
-		default:
-			// Unknown operator, skip (this allows for future compatibility)
-			// For strict validation, you could return false here
-		}
-	}
-	return true
-}
-
-// applyUpdateOperations applies MongoDB update operators
-func applyUpdateOperations(doc bson.M, update bson.M) error {
-	for op, fields := range update {
-		switch op {
-		case "$set":
-			switch f := fields.(type) {
-			case bson.M:
-				for field, value := range f {
-					setField(doc, field, value)
-				}
-			case map[string]interface{}:
-				for field, value := range f {
-					setField(doc, field, value)
-				}
-			}
-		case "$unset":
-			switch f := fields.(type) {
-			case bson.M:
-				for field := range f {
-					unsetField(doc, field)
-				}
-			case map[string]interface{}:
-				for field := range f {
-					unsetField(doc, field)
-				}
-			}
-		case "$inc":
-			switch f := fields.(type) {
-			case bson.M:
-				for field, inc := range f {
-					incField(doc, field, inc)
-				}
-			case map[string]interface{}:
-				for field, inc := range f {
-					incField(doc, field, inc)
-				}
-			}
-		default:
-			// Unknown operator, skip
-		}
+		// Control operations don't affect collection state.
 	}
 	return nil
-}
-
-// setField sets a field value, supporting nested fields
-func setField(doc bson.M, field string, value interface{}) {
-	parts := strings.Split(field, ".")
-	if len(parts) == 1 {
-		doc[field] = value
-		return
-	}
-
-	// Navigate to the nested field
-	current := doc
-	for i := 0; i < len(parts)-1; i++ {
-		part := parts[i]
-		if next, exists := current[part]; exists {
-			if nextMap, ok := next.(bson.M); ok {
-				current = nextMap
-			} else {
-				// Can't navigate further, create new map
-				newMap := bson.M{}
-				current[part] = newMap
-				current = newMap
-			}
-		} else {
-			// Create nested structure
-			newMap := bson.M{}
-			current[part] = newMap
-			current = newMap
-		}
-	}
-
-	// Set the final field
-	current[parts[len(parts)-1]] = value
-}
-
-// unsetField removes a field, supporting nested fields
-func unsetField(doc bson.M, field string) {
-	parts := strings.Split(field, ".")
-	if len(parts) == 1 {
-		delete(doc, field)
-		return
-	}
-
-	// Navigate to the parent of the field to delete
-	current := doc
-	for i := 0; i < len(parts)-1; i++ {
-		part := parts[i]
-		if next, exists := current[part]; exists {
-			if nextMap, ok := next.(bson.M); ok {
-				current = nextMap
-			} else {
-				return // Can't navigate further
-			}
-		} else {
-			return // Path doesn't exist
-		}
-	}
-
-	// Delete the final field
-	delete(current, parts[len(parts)-1])
-}
-
-// incField increments a field value
-func incField(doc bson.M, field string, inc interface{}) {
-	parts := strings.Split(field, ".")
-	if len(parts) == 1 {
-		if current, exists := doc[field]; exists {
-			doc[field] = addNumbers(current, inc)
-		} else {
-			doc[field] = inc
-		}
-		return
-	}
-
-	// Navigate to the field
-	current := doc
-	for i := 0; i < len(parts)-1; i++ {
-		part := parts[i]
-		if next, exists := current[part]; exists {
-			if nextMap, ok := next.(bson.M); ok {
-				current = nextMap
-			} else {
-				// Can't navigate further, create new map
-				newMap := bson.M{}
-				current[part] = newMap
-				current = newMap
-			}
-		} else {
-			// Create nested structure
-			newMap := bson.M{}
-			current[part] = newMap
-			current = newMap
-		}
-	}
-
-	// Increment the final field
-	finalField := parts[len(parts)-1]
-	if existing, exists := current[finalField]; exists {
-		current[finalField] = addNumbers(existing, inc)
-	} else {
-		current[finalField] = inc
-	}
-}
-
-// Helper functions for comparisons
-func isEqual(a, b interface{}) bool {
-	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
-}
-
-func isGreaterThan(a, b interface{}) bool {
-	return compareValues(a, b) > 0
-}
-
-func isGreaterThanOrEqual(a, b interface{}) bool {
-	return compareValues(a, b) >= 0
-}
-
-func isLessThan(a, b interface{}) bool {
-	return compareValues(a, b) < 0
-}
-
-func isLessThanOrEqual(a, b interface{}) bool {
-	return compareValues(a, b) <= 0
-}
-
-func isInArray(value, array interface{}) bool {
-	switch arr := array.(type) {
-	case []interface{}:
-		for _, item := range arr {
-			if isEqual(value, item) {
-				return true
-			}
-		}
-	case primitive.A: // BSON array type
-		for _, item := range arr {
-			if isEqual(value, item) {
-				return true
-			}
-		}
-	case []string:
-		valueStr := fmt.Sprintf("%v", value)
-		for _, item := range arr {
-			if item == valueStr {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func compareValues(a, b interface{}) int {
-	// Simple numeric comparison for MVP
-	aFloat := toFloat64(a)
-	bFloat := toFloat64(b)
-
-	if aFloat > bFloat {
-		return 1
-	} else if aFloat < bFloat {
-		return -1
-	}
-	return 0
-}
-
-func toFloat64(v interface{}) float64 {
-	switch val := v.(type) {
-	case int:
-		return float64(val)
-	case int32:
-		return float64(val)
-	case int64:
-		return float64(val)
-	case float32:
-		return float64(val)
-	case float64:
-		return val
-	default:
-		// Try to convert via string
-		if str := fmt.Sprintf("%v", v); str != "" {
-			if f, err := fmt.Sscanf(str, "%f", new(float64)); err == nil && f == 1 {
-				var result float64
-				_, _ = fmt.Sscanf(str, "%f", &result)
-				return result
-			}
-		}
-		return 0
-	}
-}
-
-func addNumbers(a, b interface{}) interface{} {
-	// Simple addition for MVP
-	return toFloat64(a) + toFloat64(b)
 }

--- a/internal/restore/service.go
+++ b/internal/restore/service.go
@@ -58,10 +58,15 @@ func (s *Service) ResetBranchToLSN(branchID string, targetLSN int64) (*wal.Branc
 	}
 
 	if len(entriesAfterTarget) > 0 {
-		// In production, you might want to create a backup branch or require confirmation
-		// For now, we'll proceed but log a warning
-		fmt.Printf("WARNING: Resetting branch %s to LSN %d will discard %d operations\n",
-			branch.Name, targetLSN, len(entriesAfterTarget))
+		// Record the abandoned window before lowering the head. The entries
+		// stay in the WAL for audit, but materialization must skip them:
+		// the next write's LSN will be higher than theirs, so without this
+		// record, advancing the head would resurrect the discarded history.
+		if err := s.branches.AddDiscardedRange(branchID, targetLSN+1, branch.HeadLSN); err != nil {
+			return nil, fmt.Errorf("failed to record discarded range: %w", err)
+		}
+		branch.DiscardedRanges = append(branch.DiscardedRanges,
+			wal.LSNRange{From: targetLSN + 1, To: branch.HeadLSN})
 	}
 
 	// Update branch HEAD
@@ -108,11 +113,14 @@ func (s *Service) CreateBranchAtLSN(projectID, sourceBranchID, newBranchName str
 			targetLSN, sourceBranch.BaseLSN, sourceBranch.HeadLSN)
 	}
 
-	// Create the new branch
+	// Create the new branch. ParentID anchors the ancestry chain: without
+	// it the branch would materialize from nothing instead of inheriting
+	// the source branch's history up to the fork point.
 	newBranch := &wal.Branch{
 		ID:        primitive.NewObjectID().Hex(),
 		ProjectID: projectID,
 		Name:      newBranchName,
+		ParentID:  sourceBranch.ID,
 		BaseLSN:   targetLSN,
 		HeadLSN:   targetLSN,
 		CreatedAt: time.Now(),

--- a/internal/timetravel/service.go
+++ b/internal/timetravel/service.go
@@ -9,7 +9,10 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// Service provides time travel capabilities for WAL-based branches
+// Service provides time travel capabilities for WAL-based branches. All
+// state reconstruction delegates to the materializer, which owns ancestry
+// traversal and deterministic replay; this service adds LSN validation and
+// timestamp-to-LSN resolution on top.
 type Service struct {
 	wal          *wal.Service
 	materializer *materializer.Service
@@ -25,80 +28,37 @@ func NewService(walService *wal.Service, materializerService *materializer.Servi
 
 // MaterializeAtLSN reconstructs the state of a collection at a specific LSN
 func (s *Service) MaterializeAtLSN(branch *wal.Branch, collection string, targetLSN int64) (map[string]bson.M, error) {
-	// Validate LSN range
-	if targetLSN < 0 {
-		return nil, fmt.Errorf("invalid LSN: %d", targetLSN)
+	if err := s.validateTargetLSN(branch, targetLSN); err != nil {
+		return nil, err
 	}
-
-	if targetLSN > branch.HeadLSN {
-		return nil, fmt.Errorf("target LSN %d is beyond branch HEAD %d", targetLSN, branch.HeadLSN)
-	}
-
-	// For branches created from a historical point, include base entries
-	entries := []*wal.Entry{}
-
-	if branch.BaseLSN > 0 {
-		// Get entries up to the base LSN from the global WAL
-		maxLSN := branch.BaseLSN
-		if targetLSN < maxLSN {
-			maxLSN = targetLSN
-		}
-		baseEntries, err := s.wal.GetProjectEntries(branch.ProjectID, collection, 0, maxLSN)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get base entries: %w", err)
-		}
-		entries = append(entries, baseEntries...)
-	}
-
-	// Get entries specific to this branch up to target LSN
-	if targetLSN > branch.BaseLSN {
-		branchEntries, err := s.wal.GetBranchEntries(branch.ID, collection, branch.BaseLSN+1, targetLSN)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get branch entries: %w", err)
-		}
-		entries = append(entries, branchEntries...)
-	}
-
-	// Build state by replaying entries
-	state := make(map[string]bson.M)
-	for _, entry := range entries {
-		if err := s.materializer.ApplyEntry(state, entry); err != nil {
-			return nil, fmt.Errorf("failed to apply entry LSN %d: %w", entry.LSN, err)
-		}
-	}
-
-	return state, nil
+	return s.materializer.MaterializeCollectionAtLSN(branch, collection, targetLSN)
 }
 
 // MaterializeAtTime reconstructs the state of a collection at a specific timestamp
 func (s *Service) MaterializeAtTime(branch *wal.Branch, collection string, timestamp time.Time) (map[string]bson.M, error) {
-	// Find the LSN at the given timestamp
 	targetLSN, err := s.FindLSNAtTime(branch, timestamp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find LSN at time: %w", err)
 	}
-
-	// Materialize at that LSN
 	return s.MaterializeAtLSN(branch, collection, targetLSN)
 }
 
-// FindLSNAtTime finds the latest LSN before or at the given timestamp
+// FindLSNAtTime finds the latest LSN on the branch at or before the given
+// timestamp.
 func (s *Service) FindLSNAtTime(branch *wal.Branch, timestamp time.Time) (int64, error) {
-	// Check if timestamp is in the future
 	if timestamp.After(time.Now()) {
 		return 0, fmt.Errorf("cannot find LSN for future timestamp %v", timestamp)
 	}
 
-	// Get entries for the branch up to the timestamp
 	entries, err := s.wal.GetEntriesByTimestamp(branch.ProjectID, timestamp)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get entries by timestamp: %w", err)
 	}
 
 	// Filter for this branch and find the latest LSN
-	var latestLSN int64 = 0
+	var latestLSN int64
 	for _, entry := range entries {
-		if entry.BranchID == branch.ID && entry.LSN > latestLSN {
+		if entry.BranchID == branch.ID && entry.LSN > latestLSN && entry.LSN <= branch.HeadLSN {
 			latestLSN = entry.LSN
 		}
 	}
@@ -112,77 +72,27 @@ func (s *Service) FindLSNAtTime(branch *wal.Branch, timestamp time.Time) (int64,
 
 // GetBranchStateAtLSN returns the complete state of all collections at a specific LSN
 func (s *Service) GetBranchStateAtLSN(branch *wal.Branch, targetLSN int64) (map[string]map[string]bson.M, error) {
-	// Validate LSN
-	if targetLSN < 0 || targetLSN > branch.HeadLSN {
-		return nil, fmt.Errorf("invalid target LSN %d (branch HEAD: %d)", targetLSN, branch.HeadLSN)
+	if err := s.validateTargetLSN(branch, targetLSN); err != nil {
+		return nil, err
 	}
-
-	// For branches created from a historical point, include base entries
-	entries := []*wal.Entry{}
-
-	if branch.BaseLSN > 0 {
-		// Get entries up to the base LSN from the global WAL
-		maxLSN := branch.BaseLSN
-		if targetLSN < maxLSN {
-			maxLSN = targetLSN
-		}
-		baseEntries, err := s.wal.GetProjectEntries(branch.ProjectID, "", 0, maxLSN)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get base entries: %w", err)
-		}
-		entries = append(entries, baseEntries...)
-	}
-
-	// Get entries specific to this branch up to target LSN
-	if targetLSN > branch.BaseLSN {
-		branchEntries, err := s.wal.GetBranchEntries(branch.ID, "", branch.BaseLSN+1, targetLSN)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get branch entries: %w", err)
-		}
-		entries = append(entries, branchEntries...)
-	}
-
-	// Build state by collection
-	state := make(map[string]map[string]bson.M)
-
-	for _, entry := range entries {
-		if entry.Collection == "" {
-			continue // Skip non-collection operations
-		}
-
-		// Initialize collection state if needed
-		if _, exists := state[entry.Collection]; !exists {
-			state[entry.Collection] = make(map[string]bson.M)
-		}
-
-		if err := s.materializer.ApplyEntry(state[entry.Collection], entry); err != nil {
-			return nil, fmt.Errorf("failed to apply entry LSN %d: %w", entry.LSN, err)
-		}
-	}
-
-	return state, nil
+	return s.materializer.MaterializeBranchAtLSN(branch, targetLSN)
 }
 
 // GetDocumentHistoryAtLSN returns the history of a document up to a specific LSN
 func (s *Service) GetDocumentHistoryAtLSN(branch *wal.Branch, collection, documentID string, targetLSN int64) ([]*wal.Entry, error) {
-	// Validate LSN
-	if targetLSN < 0 || targetLSN > branch.HeadLSN {
-		return nil, fmt.Errorf("invalid target LSN %d (branch HEAD: %d)", targetLSN, branch.HeadLSN)
+	if err := s.validateTargetLSN(branch, targetLSN); err != nil {
+		return nil, err
 	}
-
-	// Get document history up to target LSN
 	return s.wal.GetDocumentHistory(branch.ID, collection, documentID, 0, targetLSN)
 }
 
 // FindModifiedCollections returns collections that were modified between two LSNs
 func (s *Service) FindModifiedCollections(branch *wal.Branch, fromLSN, toLSN int64) ([]string, error) {
-	// Get entries in the LSN range
 	entries, err := s.wal.GetBranchEntries(branch.ID, "", fromLSN, toLSN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get WAL entries: %w", err)
 	}
 
-	// Track unique collections
 	collections := make(map[string]bool)
 	for _, entry := range entries {
 		if entry.Collection != "" {
@@ -190,7 +100,6 @@ func (s *Service) FindModifiedCollections(branch *wal.Branch, fromLSN, toLSN int
 		}
 	}
 
-	// Convert to slice
 	result := make([]string, 0, len(collections))
 	for col := range collections {
 		result = append(result, col)
@@ -201,10 +110,18 @@ func (s *Service) FindModifiedCollections(branch *wal.Branch, fromLSN, toLSN int
 
 // GetTimeTravelInfo returns metadata about available time travel range
 func (s *Service) GetTimeTravelInfo(branch *wal.Branch) (*TimeTravelInfo, error) {
-	// Get first and last entries for the branch
-	entries, err := s.wal.GetBranchEntries(branch.ID, "", 0, branch.HeadLSN)
+	allEntries, err := s.wal.GetBranchEntries(branch.ID, "", 0, branch.HeadLSN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get WAL entries: %w", err)
+	}
+
+	// Only data entries are meaningful travel points; control records
+	// (branch creation etc.) carry no document state.
+	entries := allEntries[:0]
+	for _, entry := range allEntries {
+		if entry.IsData() {
+			entries = append(entries, entry)
+		}
 	}
 
 	if len(entries) == 0 {
@@ -226,6 +143,16 @@ func (s *Service) GetTimeTravelInfo(branch *wal.Branch) (*TimeTravelInfo, error)
 		LatestTime:   entries[len(entries)-1].Timestamp,
 		EntryCount:   len(entries),
 	}, nil
+}
+
+func (s *Service) validateTargetLSN(branch *wal.Branch, targetLSN int64) error {
+	if targetLSN < 0 {
+		return fmt.Errorf("invalid LSN: %d", targetLSN)
+	}
+	if targetLSN > branch.HeadLSN {
+		return fmt.Errorf("target LSN %d is beyond branch HEAD %d", targetLSN, branch.HeadLSN)
+	}
+	return nil
 }
 
 // TimeTravelInfo contains metadata about time travel capabilities

--- a/internal/wal/compression.go
+++ b/internal/wal/compression.go
@@ -228,56 +228,52 @@ func (c *Compressor) decompressSnappy(data []byte) ([]byte, error) {
 	return snappy.Decode(nil, data)
 }
 
-// CompressEntry compresses the document fields of a WAL entry
+// CompressEntry compresses the image fields of a WAL entry
 func (c *Compressor) CompressEntry(entry *Entry) error {
-	// Compress document if present
-	if len(entry.Document) > 0 {
-		compressed, err := c.Compress(entry.Document)
+	// Compress post-image if present
+	if len(entry.PostImage) > 0 {
+		compressed, err := c.Compress(entry.PostImage)
 		if err != nil {
-			return fmt.Errorf("failed to compress document: %w", err)
+			return fmt.Errorf("failed to compress post-image: %w", err)
 		}
-		entry.CompressedDocument = compressed
-		entry.Document = nil // Clear original to save space
+		entry.CompressedPostImage = compressed
+		entry.PostImage = nil // Clear original to save space
 	}
 
-	// Compress old document if present
-	if len(entry.OldDocument) > 0 {
-		compressed, err := c.Compress(entry.OldDocument)
+	// Compress pre-image if present
+	if len(entry.PreImage) > 0 {
+		compressed, err := c.Compress(entry.PreImage)
 		if err != nil {
-			return fmt.Errorf("failed to compress old document: %w", err)
+			return fmt.Errorf("failed to compress pre-image: %w", err)
 		}
-		entry.CompressedOldDocument = compressed
-		entry.OldDocument = nil // Clear original to save space
+		entry.CompressedPreImage = compressed
+		entry.PreImage = nil // Clear original to save space
 	}
 
 	return nil
 }
 
-// DecompressEntry decompresses the document fields of a WAL entry
+// DecompressEntry decompresses the image fields of a WAL entry
 func (c *Compressor) DecompressEntry(entry *Entry) error {
-	// Decompress document if present
-	if len(entry.CompressedDocument) > 0 {
-		decompressed, err := c.Decompress(entry.CompressedDocument)
+	// Decompress post-image if present
+	if len(entry.CompressedPostImage) > 0 {
+		decompressed, err := c.Decompress(entry.CompressedPostImage)
 		if err != nil {
-			return fmt.Errorf("failed to decompress document: %w", err)
+			return fmt.Errorf("failed to decompress post-image: %w", err)
 		}
-		entry.Document = decompressed
-		entry.CompressedDocument = nil // Clear compressed to save memory
+		entry.PostImage = decompressed
+		entry.CompressedPostImage = nil // Clear compressed to save memory
 	}
 
-	// Decompress old document if present
-	if len(entry.CompressedOldDocument) > 0 {
-		decompressed, err := c.Decompress(entry.CompressedOldDocument)
+	// Decompress pre-image if present
+	if len(entry.CompressedPreImage) > 0 {
+		decompressed, err := c.Decompress(entry.CompressedPreImage)
 		if err != nil {
-			return fmt.Errorf("failed to decompress old document: %w", err)
+			return fmt.Errorf("failed to decompress pre-image: %w", err)
 		}
-		entry.OldDocument = decompressed
-		entry.CompressedOldDocument = nil // Clear compressed to save memory
+		entry.PreImage = decompressed
+		entry.CompressedPreImage = nil // Clear compressed to save memory
 	}
-
-	// For backward compatibility - if no compressed fields but document fields exist,
-	// the entry was stored without compression
-	// Nothing to do in this case - documents are already in the right place
 
 	return nil
 }

--- a/internal/wal/docid.go
+++ b/internal/wal/docid.go
@@ -1,0 +1,37 @@
+package wal
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// DocumentIDString converts a document _id into the canonical string key
+// used throughout the WAL (Entry.DocumentID and materialized state maps).
+//
+// ObjectIDs map to their 24-character hex form and strings map to
+// themselves, matching what users naturally pass to document-history APIs.
+// Every other BSON type is rendered as canonical extended JSON so that,
+// for example, the int32 5, the int64 5 and the string "5" cannot collide
+// on the same key and silently merge two different documents during replay.
+func DocumentIDString(id interface{}) string {
+	switch v := id.(type) {
+	case primitive.ObjectID:
+		return v.Hex()
+	case string:
+		return v
+	default:
+		wrapped, err := bson.MarshalExtJSON(bson.M{"i": id}, true, false)
+		if err != nil {
+			// No BSON representation at all; fall back to Go formatting.
+			return fmt.Sprintf("%v", id)
+		}
+		// Strip the {"i": ... } wrapper: {"i":X} -> X
+		s := string(wrapped)
+		if len(s) > 6 {
+			return s[5 : len(s)-1]
+		}
+		return s
+	}
+}

--- a/internal/wal/models.go
+++ b/internal/wal/models.go
@@ -1,6 +1,7 @@
 package wal
 
 import (
+	"fmt"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -11,33 +12,130 @@ import (
 type OperationType string
 
 const (
-	OpInsert        OperationType = "insert"
-	OpUpdate        OperationType = "update"
-	OpDelete        OperationType = "delete"
+	// Data operations. Every data entry is a self-contained physical
+	// record: OpPut carries the complete post-image of one document,
+	// OpDelete removes one document by ID. Replay is deterministic by
+	// construction because no filters or update operators are ever
+	// re-executed — the outcome of the original operation is what gets
+	// logged.
+	OpPut    OperationType = "put"
+	OpDelete OperationType = "delete"
+
+	// Control operations.
 	OpCreateBranch  OperationType = "create_branch"
 	OpDeleteBranch  OperationType = "delete_branch"
 	OpCreateProject OperationType = "create_project"
 	OpDeleteProject OperationType = "delete_project"
 )
 
+// Legacy schema-v1 data operations. v1 update/delete entries stored the
+// original filter and update expressions and re-executed them on replay,
+// which is not deterministic. They can be read for migration but are
+// rejected by the materializer.
+const (
+	LegacyOpInsert OperationType = "insert"
+	LegacyOpUpdate OperationType = "update"
+	LegacyOpDelete OperationType = "delete"
+)
+
+// EntrySchemaVersion identifies entries written by the current code.
+// Entries with a lower (or missing) version predate the physical-log format
+// and must be migrated before they can be replayed.
+const EntrySchemaVersion = 2
+
 // Entry represents a single WAL entry
 type Entry struct {
-	ID                  primitive.ObjectID     `bson:"_id,omitempty" json:"id,omitempty"`
-	LSN                 int64                  `bson:"lsn" json:"lsn"`
-	Timestamp           time.Time              `bson:"timestamp" json:"timestamp"`
-	ProjectID           string                 `bson:"project_id" json:"project_id"`
-	BranchID            string                 `bson:"branch_id" json:"branch_id"`
-	Operation           OperationType          `bson:"operation" json:"operation"`
-	Collection          string                 `bson:"collection,omitempty" json:"collection,omitempty"`
-	DocumentID          string                 `bson:"document_id,omitempty" json:"document_id,omitempty"`
-	Document            bson.Raw               `bson:"-" json:"-"`
-	OldDocument         bson.Raw               `bson:"-" json:"-"`
-	CompressedDocument  []byte                 `bson:"compressed_document,omitempty" json:"-"`
-	CompressedOldDocument []byte               `bson:"compressed_old_document,omitempty" json:"-"`
-	Metadata            map[string]interface{} `bson:"metadata,omitempty" json:"metadata,omitempty"`
+	ID            primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+	SchemaVersion int                `bson:"v,omitempty" json:"v,omitempty"`
+	LSN           int64              `bson:"lsn" json:"lsn"`
+	Timestamp     time.Time          `bson:"timestamp" json:"timestamp"`
+	ProjectID     string             `bson:"project_id" json:"project_id"`
+	BranchID      string             `bson:"branch_id" json:"branch_id"`
+	Operation     OperationType      `bson:"operation" json:"operation"`
+	Collection    string             `bson:"collection,omitempty" json:"collection,omitempty"`
+	DocumentID    string             `bson:"document_id,omitempty" json:"document_id,omitempty"`
+
+	// PostImage is the complete document after the operation. Required on
+	// every put; replaying a put is simply state[DocumentID] = PostImage.
+	PostImage bson.Raw `bson:"-" json:"-"`
+	// PreImage is the complete document the operation replaced (puts over
+	// an existing document, and deletes). It is never needed to
+	// materialize state — it exists to power diff, undo and audit.
+	PreImage bson.Raw `bson:"-" json:"-"`
+
+	// Compressed forms are what is actually stored; the raw images above
+	// are populated on read and cleared on write by the compressor.
+	CompressedPostImage []byte `bson:"post,omitempty" json:"-"`
+	CompressedPreImage  []byte `bson:"pre,omitempty" json:"-"`
+
+	// TxnID groups entries that must become visible atomically.
+	TxnID string `bson:"txn_id,omitempty" json:"txn_id,omitempty"`
+	// Actor identifies who produced the write, e.g. "user:jake" or
+	// "agent:session-42". Powers per-session undo and audit trails.
+	Actor string `bson:"actor,omitempty" json:"actor,omitempty"`
+
+	Metadata map[string]interface{} `bson:"metadata,omitempty" json:"metadata,omitempty"`
 }
 
-// Branch represents a WAL-based branch
+// IsLegacy reports whether the entry predates the physical-log schema and
+// therefore cannot be replayed deterministically. Note that v1 and v2 both
+// use the operation name "delete"; the schema version disambiguates (v1
+// deletes carried a filter, v2 deletes carry a document ID and pre-image).
+func (e *Entry) IsLegacy() bool {
+	switch e.Operation {
+	case LegacyOpInsert, LegacyOpUpdate:
+		return true
+	case OpDelete:
+		return e.SchemaVersion < EntrySchemaVersion
+	default:
+		return false
+	}
+}
+
+// ValidateForAppend checks the invariants the WAL enforces at its write
+// boundary. Catching malformed entries here keeps every downstream consumer
+// (materializer, time travel, diff) free of defensive special cases.
+func (e *Entry) ValidateForAppend() error {
+	if e.ProjectID == "" {
+		return fmt.Errorf("WAL entry requires a project ID")
+	}
+	switch e.Operation {
+	case OpPut:
+		if e.BranchID == "" || e.Collection == "" || e.DocumentID == "" {
+			return fmt.Errorf("put entry requires branch, collection and document ID")
+		}
+		if len(e.PostImage) == 0 {
+			return fmt.Errorf("put entry for document %s requires a post-image", e.DocumentID)
+		}
+	case OpDelete:
+		if e.BranchID == "" || e.Collection == "" || e.DocumentID == "" {
+			return fmt.Errorf("delete entry requires branch, collection and document ID")
+		}
+	case OpCreateBranch, OpDeleteBranch, OpCreateProject, OpDeleteProject:
+		// Control entries carry their payload in Metadata.
+	case LegacyOpInsert, LegacyOpUpdate:
+		return fmt.Errorf("operation %q is a legacy schema-v1 operation and can no longer be written", e.Operation)
+	default:
+		return fmt.Errorf("unknown WAL operation %q", e.Operation)
+	}
+	return nil
+}
+
+// LSNRange is a closed interval of LSNs.
+type LSNRange struct {
+	From int64 `bson:"from" json:"from"`
+	To   int64 `bson:"to" json:"to"`
+}
+
+// Contains reports whether the LSN falls inside the range.
+func (r LSNRange) Contains(lsn int64) bool {
+	return lsn >= r.From && lsn <= r.To
+}
+
+// Branch represents a WAL-based branch. A branch is a pointer into the WAL:
+// BaseLSN is the fork point (the parent's LSN the branch started from) and
+// HeadLSN is the newest entry that belongs to the branch. Entries at or
+// below BaseLSN are inherited from the ancestry chain via ParentID.
 type Branch struct {
 	ID         string    `bson:"_id" json:"id"`
 	ProjectID  string    `bson:"project_id" json:"project_id"`
@@ -48,6 +146,44 @@ type Branch struct {
 	CreatedAt  time.Time `bson:"created_at" json:"created_at"`
 	CreatedLSN int64     `bson:"created_lsn" json:"created_lsn"`
 	IsDeleted  bool      `bson:"is_deleted" json:"is_deleted"`
+
+	// DiscardedRanges records LSN windows abandoned by restore/reset
+	// operations. The entries stay in the WAL for audit, but materialization
+	// skips them; without this, the first write after a reset (whose LSN is
+	// necessarily higher than the discarded entries') would advance the head
+	// past the discarded window and resurrect it.
+	DiscardedRanges []LSNRange `bson:"discarded_ranges,omitempty" json:"discarded_ranges,omitempty"`
+}
+
+// IsDiscardedForRead reports whether an LSN must be skipped when reading
+// this branch's entries up to upperBound (the segment's inclusive end: the
+// head for a self-read, the fork LSN for a child's read).
+//
+// A discarded range only applies when the read extends past it. The
+// sequencer never rewinds, so after a reset to T (discarding [from, to],
+// with T < from) any later write or fork point lands strictly above `to` —
+// while a child forked before the reset has its fork LSN at or below `to`.
+// That makes "upperBound > to" exactly the "this reader's timeline includes
+// the reset" test: post-reset readers skip the window, and children that
+// legitimately captured the pre-reset history keep it.
+func (b *Branch) IsDiscardedForRead(lsn, upperBound int64) bool {
+	for _, r := range b.DiscardedRanges {
+		if r.Contains(lsn) && upperBound > r.To {
+			return true
+		}
+	}
+	return false
+}
+
+// IsData reports whether the entry carries document state (as opposed to
+// branch/project control records).
+func (e *Entry) IsData() bool {
+	switch e.Operation {
+	case OpPut, OpDelete, LegacyOpInsert, LegacyOpUpdate:
+		return true
+	default:
+		return false
+	}
 }
 
 // Project represents a WAL-enabled project

--- a/internal/wal/service.go
+++ b/internal/wal/service.go
@@ -65,6 +65,16 @@ func NewService(db *mongo.Database) (*Service, error) {
 			},
 		},
 		{
+			// Point lookups of a single document's history are the hot
+			// path for filter resolution on the write path.
+			Keys: bson.D{
+				{Key: "branch_id", Value: 1},
+				{Key: "collection", Value: 1},
+				{Key: "document_id", Value: 1},
+				{Key: "lsn", Value: 1},
+			},
+		},
+		{
 			Keys: bson.M{"timestamp": 1},
 		},
 	}
@@ -79,6 +89,11 @@ func NewService(db *mongo.Database) (*Service, error) {
 
 // Append adds a new entry to the WAL
 func (s *Service) Append(entry *Entry) (int64, error) {
+	if err := entry.ValidateForAppend(); err != nil {
+		return 0, err
+	}
+	entry.SchemaVersion = EntrySchemaVersion
+
 	lsn, err := s.sequencer.Reserve(entry.ProjectID, 1)
 	if err != nil {
 		return 0, err
@@ -116,6 +131,10 @@ func (s *Service) AppendBatch(entries []*Entry) ([]int64, error) {
 		if entry.ProjectID != projectID {
 			return nil, fmt.Errorf("batch entry %d belongs to project %q, expected %q: batches must be single-project", i, entry.ProjectID, projectID)
 		}
+		if err := entry.ValidateForAppend(); err != nil {
+			return nil, fmt.Errorf("batch entry %d is invalid: %w", i, err)
+		}
+		entry.SchemaVersion = EntrySchemaVersion
 	}
 
 	firstLSN, err := s.sequencer.Reserve(projectID, int64(len(entries)))

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -63,7 +63,7 @@ func NewServices() (*Services, error) {
 		return nil, fmt.Errorf("failed to create project service: %w", err)
 	}
 
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	importerService := importer.NewImportService(walService, projectService, branchService)

--- a/tests/wal/compression_test.go
+++ b/tests/wal/compression_test.go
@@ -111,32 +111,32 @@ func TestCompressor_Entry(t *testing.T) {
 	entry := &wal.Entry{
 		ProjectID:  "test-project",
 		BranchID:   "main",
-		Operation:  wal.OpUpdate,
+		Operation:  wal.OpPut,
 		Collection: "test",
 		DocumentID: "doc1",
-		Document:   docBytes,
-		OldDocument: docBytes, // Use same for old document
+		PostImage:  docBytes,
+		PreImage:   docBytes, // Use same for pre-image
 	}
 
 	// Get original sizes
-	origDocSize := len(entry.Document)
-	origOldDocSize := len(entry.OldDocument)
+	origDocSize := len(entry.PostImage)
+	origOldDocSize := len(entry.PreImage)
 
 	// Compress entry
 	err = compressor.CompressEntry(entry)
 	require.NoError(t, err)
 
 	// Verify compression happened
-	assert.Less(t, len(entry.CompressedDocument), origDocSize)
-	assert.Less(t, len(entry.CompressedOldDocument), origOldDocSize)
+	assert.Less(t, len(entry.CompressedPostImage), origDocSize)
+	assert.Less(t, len(entry.CompressedPreImage), origOldDocSize)
 
 	// Verify compression happened
-	assert.NotNil(t, entry.CompressedDocument)
-	assert.Nil(t, entry.Document)
+	assert.NotNil(t, entry.CompressedPostImage)
+	assert.Nil(t, entry.PostImage)
 	
 	// Store compressed for verification
-	compressedDoc := make([]byte, len(entry.CompressedDocument))
-	copy(compressedDoc, entry.CompressedDocument)
+	compressedDoc := make([]byte, len(entry.CompressedPostImage))
+	copy(compressedDoc, entry.CompressedPostImage)
 
 	// Decompress entry
 	err = compressor.DecompressEntry(entry)
@@ -145,22 +145,22 @@ func TestCompressor_Entry(t *testing.T) {
 	// Debug output
 	t.Logf("Original doc size: %d bytes", len(docBytes))
 	t.Logf("Compressed doc size: %d bytes", len(compressedDoc))
-	t.Logf("Decompressed doc size: %d bytes", len(entry.Document))
+	t.Logf("Decompressed doc size: %d bytes", len(entry.PostImage))
 	t.Logf("First few bytes of original: %x", docBytes[:20])
-	if len(entry.Document) >= 20 {
-		t.Logf("First few bytes of decompressed: %x", []byte(entry.Document)[:20])
+	if len(entry.PostImage) >= 20 {
+		t.Logf("First few bytes of decompressed: %x", []byte(entry.PostImage)[:20])
 	} else {
-		t.Logf("Decompressed data too short: %x", []byte(entry.Document))
+		t.Logf("Decompressed data too short: %x", []byte(entry.PostImage))
 	}
 	t.Logf("Compression type in metadata: %d", compressedDoc[0])
 	
 	// Verify decompression restored data
-	assert.NotNil(t, entry.Document)
-	assert.Nil(t, entry.CompressedDocument)
+	assert.NotNil(t, entry.PostImage)
+	assert.Nil(t, entry.CompressedPostImage)
 
 	// Verify decompression
-	assert.Equal(t, docBytes, []byte(entry.Document))
-	assert.Equal(t, docBytes, []byte(entry.OldDocument))
+	assert.Equal(t, docBytes, []byte(entry.PostImage))
+	assert.Equal(t, docBytes, []byte(entry.PreImage))
 	
 	// Verify it was actually compressed (should have metadata prefix)
 	assert.True(t, compressedDoc[0] == byte(wal.CompressionZstd) || 

--- a/tests/wal/interceptor_test.go
+++ b/tests/wal/interceptor_test.go
@@ -6,27 +6,32 @@ import (
 
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
 	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/materializer"
 	"github.com/argon-lab/argon/internal/wal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// newInterceptorFixture wires a WAL service, branch service, materializer
+// and interceptor over a fresh branch.
+func newInterceptorFixture(t *testing.T, db *mongo.Database, project, branchName string) (*wal.Service, *branchwal.BranchService, *wal.Branch, *driverwal.Interceptor) {
+	walService, err := wal.NewService(db)
+	require.NoError(t, err)
+	branchService, err := branchwal.NewBranchService(db, walService)
+	require.NoError(t, err)
+	branch, err := branchService.CreateBranch(project, branchName, "")
+	require.NoError(t, err)
+	mat := materializer.NewService(walService, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, mat)
+	return walService, branchService, branch, interceptor
+}
 
 func TestInterceptor_InsertOne(t *testing.T) {
 	db := setupTestDB(t)
-	walService, err := wal.NewService(db)
-	require.NoError(t, err)
-
-	branchService, err := branchwal.NewBranchService(db, walService)
-	require.NoError(t, err)
-
-	// Create a test branch
-	branch, err := branchService.CreateBranch("test-project", "test-branch", "")
-	require.NoError(t, err)
-
-	// Create interceptor
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	walService, branchService, branch, interceptor := newInterceptorFixture(t, db, "test-project", "test-branch")
 
 	t.Run("Insert with generated ID", func(t *testing.T) {
 		doc := bson.M{
@@ -42,12 +47,13 @@ func TestInterceptor_InsertOne(t *testing.T) {
 		entries, err := walService.GetBranchEntries(branch.ID, "users", 0, walService.GetCurrentLSN(branch.ProjectID))
 		assert.NoError(t, err)
 		assert.Len(t, entries, 1)
-		assert.Equal(t, wal.OpInsert, entries[0].Operation)
+		assert.Equal(t, wal.OpPut, entries[0].Operation)
+		assert.NotEmpty(t, entries[0].PostImage, "puts must carry the post-image")
 
 		// Verify branch HEAD was updated
 		updatedBranch, err := branchService.GetBranchByID(branch.ID)
 		assert.NoError(t, err)
-		assert.Greater(t, updatedBranch.HeadLSN, branch.HeadLSN)
+		assert.Greater(t, updatedBranch.HeadLSN, branch.BaseLSN)
 	})
 
 	t.Run("Insert with existing ID", func(t *testing.T) {
@@ -62,11 +68,10 @@ func TestInterceptor_InsertOne(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, docID, result.InsertedID)
 
-		// Verify document ID in WAL entry
+		// Verify document content round-trips through the post-image
 		entries, err := walService.GetBranchEntries(branch.ID, "users", 0, walService.GetCurrentLSN(branch.ProjectID))
 		assert.NoError(t, err)
 
-		// Find the entry for Bob
 		var bobEntry *wal.Entry
 		for _, entry := range entries {
 			if entry.DocumentID == docID.Hex() {
@@ -74,99 +79,190 @@ func TestInterceptor_InsertOne(t *testing.T) {
 				break
 			}
 		}
+		require.NotNil(t, bobEntry)
 
-		assert.NotNil(t, bobEntry)
-
-		// Verify document content
 		var savedDoc bson.M
-		err = bson.Unmarshal(bobEntry.Document, &savedDoc)
+		err = bson.Unmarshal(bobEntry.PostImage, &savedDoc)
 		assert.NoError(t, err)
 		assert.Equal(t, "Bob", savedDoc["name"])
+	})
+
+	t.Run("Duplicate insert is rejected", func(t *testing.T) {
+		docID := primitive.NewObjectID()
+		doc := bson.M{"_id": docID, "name": "Dup"}
+
+		_, err := interceptor.InsertOne(context.Background(), "users", doc)
+		require.NoError(t, err)
+
+		_, err = interceptor.InsertOne(context.Background(), "users", doc)
+		assert.Error(t, err, "inserting the same _id twice must fail")
+		assert.Contains(t, err.Error(), "duplicate key")
 	})
 }
 
 func TestInterceptor_UpdateOne(t *testing.T) {
 	db := setupTestDB(t)
-	walService, _ := wal.NewService(db)
-	branchService, _ := branchwal.NewBranchService(db, walService)
-	branch, _ := branchService.CreateBranch("test-project", "test-branch", "")
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	walService, branchService, branch, interceptor := newInterceptorFixture(t, db, "test-project", "test-branch")
+	ctx := context.Background()
 
-	t.Run("Update operation", func(t *testing.T) {
-		filter := bson.M{"name": "Alice"}
-		update := bson.M{"$set": bson.M{"age": 31}}
+	t.Run("Update misses when nothing matches", func(t *testing.T) {
+		result, err := interceptor.UpdateOne(ctx, "users", bson.M{"name": "Nobody"}, bson.M{"$set": bson.M{"age": 1}}, false)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), result.MatchedCount, "no fabricated match counts")
+		assert.Equal(t, int64(0), result.ModifiedCount)
+	})
 
-		result, err := interceptor.UpdateOne(context.Background(), "users", filter, update)
+	t.Run("Update writes the post-image", func(t *testing.T) {
+		_, err := interceptor.InsertOne(ctx, "users", bson.M{"_id": "alice", "name": "Alice", "age": 30})
+		require.NoError(t, err)
+
+		result, err := interceptor.UpdateOne(ctx, "users", bson.M{"name": "Alice"}, bson.M{"$set": bson.M{"age": 31}}, false)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), result.MatchedCount)
 		assert.Equal(t, int64(1), result.ModifiedCount)
 
-		// Verify WAL entry
+		// The WAL must contain a put whose post-image is the updated doc —
+		// never a filter or an update expression.
 		entries, err := walService.GetBranchEntries(branch.ID, "users", 0, walService.GetCurrentLSN(branch.ProjectID))
 		assert.NoError(t, err)
+		last := entries[len(entries)-1]
+		assert.Equal(t, wal.OpPut, last.Operation)
+		assert.Equal(t, "alice", last.DocumentID)
 
-		// Find update entry
-		var updateEntry *wal.Entry
-		for _, entry := range entries {
-			if entry.Operation == wal.OpUpdate {
-				updateEntry = entry
-				break
-			}
-		}
+		var post bson.M
+		require.NoError(t, bson.Unmarshal(last.PostImage, &post))
+		assert.EqualValues(t, 31, post["age"])
+		assert.Equal(t, "Alice", post["name"])
 
-		assert.NotNil(t, updateEntry)
-		assert.Equal(t, "users", updateEntry.Collection)
-
-		// Verify update document contains filter and update
-		var updateDoc bson.M
-		err = bson.Unmarshal(updateEntry.Document, &updateDoc)
-		assert.NoError(t, err)
-		assert.Contains(t, updateDoc, "filter")
-		assert.Contains(t, updateDoc, "update")
+		var pre bson.M
+		require.NoError(t, bson.Unmarshal(last.PreImage, &pre))
+		assert.EqualValues(t, 30, pre["age"], "pre-image preserves the replaced document")
 	})
+
+	t.Run("No-op update writes nothing", func(t *testing.T) {
+		before := walService.GetCurrentLSN(branch.ProjectID)
+		result, err := interceptor.UpdateOne(ctx, "users", bson.M{"_id": "alice"}, bson.M{"$set": bson.M{"age": 31}}, false)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), result.MatchedCount)
+		assert.Equal(t, int64(0), result.ModifiedCount)
+		assert.Equal(t, before, walService.GetCurrentLSN(branch.ProjectID), "matched-but-unchanged must not append")
+	})
+
+	t.Run("Upsert inserts when nothing matches", func(t *testing.T) {
+		result, err := interceptor.UpdateOne(ctx, "users", bson.M{"_id": "carol"}, bson.M{"$set": bson.M{"name": "Carol"}}, true)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), result.MatchedCount)
+		assert.Equal(t, int64(1), result.UpsertedCount)
+		assert.Equal(t, "carol", result.UpsertedID)
+
+		doc, err := materializer.NewService(walService, branchService).MaterializeDocument(branch, "users", "carol")
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+		assert.Equal(t, "Carol", doc["name"])
+	})
+}
+
+func TestInterceptor_UpdateMany(t *testing.T) {
+	db := setupTestDB(t)
+	_, _, _, interceptor := newInterceptorFixture(t, db, "test-project", "test-branch")
+	ctx := context.Background()
+
+	docs := []interface{}{
+		bson.M{"_id": "u1", "team": "red", "score": int32(1)},
+		bson.M{"_id": "u2", "team": "red", "score": int32(2)},
+		bson.M{"_id": "u3", "team": "blue", "score": int32(3)},
+	}
+	_, err := interceptor.InsertMany(ctx, "players", docs)
+	require.NoError(t, err)
+
+	result, err := interceptor.UpdateMany(ctx, "players", bson.M{"team": "red"}, bson.M{"$inc": bson.M{"score": 10}}, false)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), result.MatchedCount)
+	assert.Equal(t, int64(2), result.ModifiedCount)
+
+	matches, err := interceptor.FindMatches("players", bson.M{"score": bson.M{"$gt": 10}}, false)
+	assert.NoError(t, err)
+	assert.Len(t, matches, 2, "both red players should have been incremented")
 }
 
 func TestInterceptor_DeleteOne(t *testing.T) {
 	db := setupTestDB(t)
-	walService, _ := wal.NewService(db)
-	branchService, _ := branchwal.NewBranchService(db, walService)
-	branch, _ := branchService.CreateBranch("test-project", "test-branch", "")
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	walService, _, branch, interceptor := newInterceptorFixture(t, db, "test-project", "test-branch")
+	ctx := context.Background()
 
-	t.Run("Delete operation", func(t *testing.T) {
-		filter := bson.M{"name": "Alice"}
+	t.Run("Delete misses when nothing matches", func(t *testing.T) {
+		result, err := interceptor.DeleteOne(ctx, "users", bson.M{"name": "Nobody"})
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), result.DeletedCount, "no fabricated delete counts")
+	})
 
-		result, err := interceptor.DeleteOne(context.Background(), "users", filter)
+	t.Run("Delete records document ID and pre-image", func(t *testing.T) {
+		_, err := interceptor.InsertOne(ctx, "users", bson.M{"_id": "alice", "name": "Alice"})
+		require.NoError(t, err)
+
+		result, err := interceptor.DeleteOne(ctx, "users", bson.M{"name": "Alice"})
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), result.DeletedCount)
 
-		// Verify WAL entry
 		entries, err := walService.GetBranchEntries(branch.ID, "users", 0, walService.GetCurrentLSN(branch.ProjectID))
 		assert.NoError(t, err)
+		last := entries[len(entries)-1]
+		assert.Equal(t, wal.OpDelete, last.Operation)
+		assert.Equal(t, "alice", last.DocumentID, "deletes are logged by document ID, not filter")
 
-		// Find delete entry
-		var deleteEntry *wal.Entry
-		for _, entry := range entries {
-			if entry.Operation == wal.OpDelete {
-				deleteEntry = entry
-				break
-			}
-		}
-
-		assert.NotNil(t, deleteEntry)
-		assert.Equal(t, "users", deleteEntry.Collection)
-
-		// Verify metadata indicates this is a filter
-		assert.Equal(t, true, deleteEntry.Metadata["is_filter"])
+		var pre bson.M
+		require.NoError(t, bson.Unmarshal(last.PreImage, &pre))
+		assert.Equal(t, "Alice", pre["name"], "delete pre-image preserves the removed document")
 	})
+}
+
+func TestInterceptor_DeleteMany(t *testing.T) {
+	db := setupTestDB(t)
+	_, _, _, interceptor := newInterceptorFixture(t, db, "test-project", "test-branch")
+	ctx := context.Background()
+
+	docs := []interface{}{
+		bson.M{"_id": "u1", "team": "red"},
+		bson.M{"_id": "u2", "team": "red"},
+		bson.M{"_id": "u3", "team": "blue"},
+	}
+	_, err := interceptor.InsertMany(ctx, "players", docs)
+	require.NoError(t, err)
+
+	result, err := interceptor.DeleteMany(ctx, "players", bson.M{"team": "red"})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), result.DeletedCount)
+
+	remaining, err := interceptor.FindMatches("players", bson.M{}, false)
+	assert.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "blue", remaining[0]["team"])
+}
+
+func TestInterceptor_ReplaceOne(t *testing.T) {
+	db := setupTestDB(t)
+	_, _, _, interceptor := newInterceptorFixture(t, db, "test-project", "test-branch")
+	ctx := context.Background()
+
+	_, err := interceptor.InsertOne(ctx, "users", bson.M{"_id": "alice", "name": "Alice", "age": 30})
+	require.NoError(t, err)
+
+	result, err := interceptor.ReplaceOne(ctx, "users", bson.M{"_id": "alice"}, bson.M{"name": "Alicia"}, false)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), result.MatchedCount)
+	assert.Equal(t, int64(1), result.ModifiedCount)
+
+	matches, err := interceptor.FindMatches("users", bson.M{"_id": "alice"}, true)
+	assert.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "Alicia", matches[0]["name"])
+	_, hasAge := matches[0]["age"]
+	assert.False(t, hasAge, "replacement removes fields not in the new document")
 }
 
 func TestInterceptor_InsertMany(t *testing.T) {
 	db := setupTestDB(t)
-	walService, _ := wal.NewService(db)
-	branchService, _ := branchwal.NewBranchService(db, walService)
-	branch, _ := branchService.CreateBranch("test-project", "test-branch", "")
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	walService, _, branch, interceptor := newInterceptorFixture(t, db, "test-project", "test-branch")
 
 	t.Run("Insert multiple documents", func(t *testing.T) {
 		docs := []interface{}{
@@ -179,38 +275,47 @@ func TestInterceptor_InsertMany(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, insertedIDs, 3)
 
-		// Verify all documents have IDs
 		for _, id := range insertedIDs {
 			assert.NotNil(t, id)
 		}
 
-		// Verify WAL entries
 		entries, err := walService.GetBranchEntries(branch.ID, "users", 0, walService.GetCurrentLSN(branch.ProjectID))
 		assert.NoError(t, err)
-		assert.GreaterOrEqual(t, len(entries), 3)
+		assert.Len(t, entries, 3)
 
-		// Count insert operations
-		insertCount := 0
-		for _, entry := range entries {
-			if entry.Operation == wal.OpInsert {
-				insertCount++
-			}
+		// A batch insert reserves one contiguous LSN range.
+		for i := 1; i < len(entries); i++ {
+			assert.Equal(t, entries[i-1].LSN+1, entries[i].LSN, "batch entries should have contiguous LSNs")
 		}
-		assert.GreaterOrEqual(t, insertCount, 3)
+	})
+
+	t.Run("In-batch duplicate is rejected", func(t *testing.T) {
+		docs := []interface{}{
+			bson.M{"_id": "same", "n": 1},
+			bson.M{"_id": "same", "n": 2},
+		}
+		_, err := interceptor.InsertMany(context.Background(), "users", docs)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate key")
 	})
 }
 
 func TestInterceptor_BranchIsolation(t *testing.T) {
 	db := setupTestDB(t)
-	walService, _ := wal.NewService(db)
-	branchService, _ := branchwal.NewBranchService(db, walService)
+	walService, err := wal.NewService(db)
+	require.NoError(t, err)
+	branchService, err := branchwal.NewBranchService(db, walService)
+	require.NoError(t, err)
+	mat := materializer.NewService(walService, branchService)
 
 	// Create two branches
-	branch1, _ := branchService.CreateBranch("test-project", "branch-1", "")
-	branch2, _ := branchService.CreateBranch("test-project", "branch-2", "")
+	branch1, err := branchService.CreateBranch("test-project", "branch-1", "")
+	require.NoError(t, err)
+	branch2, err := branchService.CreateBranch("test-project", "branch-2", "")
+	require.NoError(t, err)
 
-	interceptor1 := driverwal.NewInterceptor(walService, branch1, branchService)
-	interceptor2 := driverwal.NewInterceptor(walService, branch2, branchService)
+	interceptor1 := driverwal.NewInterceptor(walService, branch1, branchService, mat)
+	interceptor2 := driverwal.NewInterceptor(walService, branch2, branchService, mat)
 
 	t.Run("Operations isolated by branch", func(t *testing.T) {
 		// Insert in branch 1
@@ -235,10 +340,18 @@ func TestInterceptor_BranchIsolation(t *testing.T) {
 
 		// Verify different content
 		var doc1Saved, doc2Saved bson.M
-		_ = bson.Unmarshal(entries1[0].Document, &doc1Saved)
-		_ = bson.Unmarshal(entries2[0].Document, &doc2Saved)
+		_ = bson.Unmarshal(entries1[0].PostImage, &doc1Saved)
+		_ = bson.Unmarshal(entries2[0].PostImage, &doc2Saved)
 
 		assert.Equal(t, "Branch1User", doc1Saved["name"])
 		assert.Equal(t, "Branch2User", doc2Saved["name"])
+
+		// And the materialized states don't leak into each other.
+		state1, err := mat.MaterializeCollection(branch1, "users")
+		require.NoError(t, err)
+		state2, err := mat.MaterializeCollection(branch2, "users")
+		require.NoError(t, err)
+		assert.Len(t, state1, 1)
+		assert.Len(t, state2, 1)
 	})
 }

--- a/tests/wal/materializer_test.go
+++ b/tests/wal/materializer_test.go
@@ -22,14 +22,14 @@ func TestMaterializer_MaterializeCollection(t *testing.T) {
 	branchService, err := branchwal.NewBranchService(db, walService)
 	require.NoError(t, err)
 
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 
 	// Create test branch
 	branch, err := branchService.CreateBranch("test-project", "test-branch", "")
 	require.NoError(t, err)
 
 	// Create interceptor for writing
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 	ctx := context.Background()
 
 	t.Run("Materialize empty collection", func(t *testing.T) {
@@ -39,7 +39,6 @@ func TestMaterializer_MaterializeCollection(t *testing.T) {
 	})
 
 	t.Run("Materialize collection with inserts", func(t *testing.T) {
-		// Insert documents
 		docs := []bson.M{
 			{"_id": "1", "name": "Alice", "age": 30},
 			{"_id": "2", "name": "Bob", "age": 25},
@@ -51,57 +50,62 @@ func TestMaterializer_MaterializeCollection(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		// Update branch to get latest HEAD
 		branch, _ = branchService.GetBranchByID(branch.ID)
 
-		// Materialize collection
 		state, err := materializerService.MaterializeCollection(branch, "users")
 		assert.NoError(t, err)
 		assert.Len(t, state, 3)
 
-		// Verify documents
 		assert.Equal(t, "Alice", state["1"]["name"])
 		assert.Equal(t, "Bob", state["2"]["name"])
 		assert.Equal(t, "Charlie", state["3"]["name"])
 	})
 
 	t.Run("Materialize with updates", func(t *testing.T) {
-		// Update Alice's age
 		filter := bson.M{"name": "Alice"}
 		update := bson.M{"$set": bson.M{"age": 31, "city": "New York"}}
-		_, err := interceptor.UpdateOne(ctx, "users", filter, update)
+		_, err := interceptor.UpdateOne(ctx, "users", filter, update, false)
 		assert.NoError(t, err)
 
-		// Update branch to get latest HEAD
 		branch, _ = branchService.GetBranchByID(branch.ID)
 
-		// Materialize collection
 		state, err := materializerService.MaterializeCollection(branch, "users")
 		assert.NoError(t, err)
 
-		// Verify update was applied
-		assert.Equal(t, int32(31), state["1"]["age"])
+		assert.EqualValues(t, 31, state["1"]["age"])
 		assert.Equal(t, "New York", state["1"]["city"])
 	})
 
 	t.Run("Materialize with deletes", func(t *testing.T) {
-		// Delete Bob
 		filter := bson.M{"name": "Bob"}
 		_, err := interceptor.DeleteOne(ctx, "users", filter)
 		assert.NoError(t, err)
 
-		// Update branch to get latest HEAD
 		branch, _ = branchService.GetBranchByID(branch.ID)
 
-		// Materialize collection
 		state, err := materializerService.MaterializeCollection(branch, "users")
 		assert.NoError(t, err)
 
-		// Verify Bob was deleted
 		assert.Len(t, state, 2)
 		assert.NotContains(t, state, "2")
 		assert.Contains(t, state, "1") // Alice still exists
 		assert.Contains(t, state, "3") // Charlie still exists
+	})
+
+	t.Run("Replay is deterministic across repeated materializations", func(t *testing.T) {
+		branch, _ = branchService.GetBranchByID(branch.ID)
+
+		reference, err := materializerService.MaterializeCollection(branch, "users")
+		require.NoError(t, err)
+
+		for i := 0; i < 20; i++ {
+			state, err := materializerService.MaterializeCollection(branch, "users")
+			require.NoError(t, err)
+			// Content-level equality: reflect.DeepEqual through testify.
+			// (Serialized bytes of Go maps are not comparable — key order
+			// randomizes per marshal.)
+			assert.Equal(t, reference, state, "materialization %d diverged", i)
+		}
 	})
 }
 
@@ -109,14 +113,13 @@ func TestMaterializer_MaterializeBranch(t *testing.T) {
 	db := setupTestDB(t)
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 
 	branch, _ := branchService.CreateBranch("test-project", "test-branch", "")
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 	ctx := context.Background()
 
 	t.Run("Materialize multiple collections", func(t *testing.T) {
-		// Insert into different collections
 		_, err := interceptor.InsertOne(ctx, "users", bson.M{"_id": "u1", "name": "User1"})
 		assert.NoError(t, err)
 
@@ -126,14 +129,11 @@ func TestMaterializer_MaterializeBranch(t *testing.T) {
 		_, err = interceptor.InsertOne(ctx, "orders", bson.M{"_id": "o1", "user": "u1", "product": "p1"})
 		assert.NoError(t, err)
 
-		// Update branch to get latest HEAD
 		branch, _ = branchService.GetBranchByID(branch.ID)
 
-		// Materialize entire branch
 		state, err := materializerService.MaterializeBranch(branch)
 		assert.NoError(t, err)
 
-		// Verify all collections
 		assert.Len(t, state, 3)
 		assert.Contains(t, state, "users")
 		assert.Contains(t, state, "products")
@@ -149,55 +149,47 @@ func TestMaterializer_MaterializeDocument(t *testing.T) {
 	db := setupTestDB(t)
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 
 	branch, _ := branchService.CreateBranch("test-project", "test-branch", "")
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 	ctx := context.Background()
 
 	t.Run("Track document history", func(t *testing.T) {
 		docID := primitive.NewObjectID()
 
-		// Insert document
 		doc := bson.M{"_id": docID, "version": 1, "status": "created"}
 		_, err := interceptor.InsertOne(ctx, "docs", doc)
 		assert.NoError(t, err)
 
-		// Update document multiple times
 		for i := 2; i <= 5; i++ {
 			filter := bson.M{"_id": docID}
 			update := bson.M{"$set": bson.M{"version": i, "status": "updated"}}
-			_, err = interceptor.UpdateOne(ctx, "docs", filter, update)
+			_, err = interceptor.UpdateOne(ctx, "docs", filter, update, false)
 			assert.NoError(t, err)
 		}
 
-		// Update branch to get latest HEAD
 		branch, _ = branchService.GetBranchByID(branch.ID)
 
-		// Materialize specific document
 		result, err := materializerService.MaterializeDocument(branch, "docs", docID.Hex())
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 
-		// Verify final state
-		assert.Equal(t, int32(5), result["version"])
+		assert.EqualValues(t, 5, result["version"])
 		assert.Equal(t, "updated", result["status"])
 	})
 
 	t.Run("Materialize deleted document", func(t *testing.T) {
 		docID := "to-delete"
 
-		// Insert and then delete
 		_, err := interceptor.InsertOne(ctx, "temp", bson.M{"_id": docID, "data": "test"})
 		assert.NoError(t, err)
 
 		_, err = interceptor.DeleteOne(ctx, "temp", bson.M{"_id": docID})
 		assert.NoError(t, err)
 
-		// Update branch to get latest HEAD
 		branch, _ = branchService.GetBranchByID(branch.ID)
 
-		// Try to materialize deleted document
 		result, err := materializerService.MaterializeDocument(branch, "temp", docID)
 		assert.NoError(t, err)
 		assert.Nil(t, result) // Document was deleted
@@ -208,20 +200,19 @@ func TestMaterializer_ComplexOperations(t *testing.T) {
 	db := setupTestDB(t)
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 
 	branch, _ := branchService.CreateBranch("test-project", "test-branch", "")
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 	ctx := context.Background()
 
 	t.Run("Complex update operations", func(t *testing.T) {
-		// Insert document
 		docID := "complex-doc"
 		doc := bson.M{
 			"_id": docID,
 			"counters": bson.M{
-				"views": 100,
-				"likes": 50,
+				"views": int32(100),
+				"likes": int32(50),
 			},
 			"tags": []string{"tag1", "tag2"},
 			"metadata": bson.M{
@@ -231,46 +222,41 @@ func TestMaterializer_ComplexOperations(t *testing.T) {
 		_, err := interceptor.InsertOne(ctx, "analytics", doc)
 		assert.NoError(t, err)
 
-		// Apply various updates
 		// 1. Increment counters
 		_, err = interceptor.UpdateOne(ctx, "analytics",
 			bson.M{"_id": docID},
-			bson.M{"$inc": bson.M{"counters.views": 10, "counters.likes": 5}})
+			bson.M{"$inc": bson.M{"counters.views": int32(10), "counters.likes": int32(5)}}, false)
 		assert.NoError(t, err)
 
 		// 2. Set new field
 		_, err = interceptor.UpdateOne(ctx, "analytics",
 			bson.M{"_id": docID},
-			bson.M{"$set": bson.M{"metadata.updated": "2024-01-02"}})
+			bson.M{"$set": bson.M{"metadata.updated": "2024-01-02"}}, false)
 		assert.NoError(t, err)
 
 		// 3. Unset a field
 		_, err = interceptor.UpdateOne(ctx, "analytics",
 			bson.M{"_id": docID},
-			bson.M{"$unset": bson.M{"tags": ""}})
+			bson.M{"$unset": bson.M{"tags": ""}}, false)
 		assert.NoError(t, err)
 
-		// Update branch to get latest HEAD
 		branch, _ = branchService.GetBranchByID(branch.ID)
 
-		// Materialize and verify
 		state, err := materializerService.MaterializeCollection(branch, "analytics")
 		assert.NoError(t, err)
 
 		finalDoc := state[docID]
 		assert.NotNil(t, finalDoc)
 
-		// Verify increments
+		// $inc preserves integer types instead of corrupting them to floats.
 		counters := finalDoc["counters"].(bson.M)
-		assert.Equal(t, float64(110), counters["views"])
-		assert.Equal(t, float64(55), counters["likes"])
+		assert.Equal(t, int32(110), counters["views"])
+		assert.Equal(t, int32(55), counters["likes"])
 
-		// Verify set operation
 		metadata := finalDoc["metadata"].(bson.M)
 		assert.Equal(t, "2024-01-02", metadata["updated"])
 		assert.Equal(t, "2024-01-01", metadata["created"])
 
-		// Verify unset operation
 		assert.NotContains(t, finalDoc, "tags")
 	})
 }
@@ -279,41 +265,122 @@ func TestMaterializer_BranchIsolation(t *testing.T) {
 	db := setupTestDB(t)
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 
 	// Create two branches
 	branch1, _ := branchService.CreateBranch("test-project", "branch-1", "")
 	branch2, _ := branchService.CreateBranch("test-project", "branch-2", "")
 
-	interceptor1 := driverwal.NewInterceptor(walService, branch1, branchService)
-	interceptor2 := driverwal.NewInterceptor(walService, branch2, branchService)
+	interceptor1 := driverwal.NewInterceptor(walService, branch1, branchService, materializerService)
+	interceptor2 := driverwal.NewInterceptor(walService, branch2, branchService, materializerService)
 	ctx := context.Background()
 
 	t.Run("Branches have isolated state", func(t *testing.T) {
-		// Insert different data in each branch
 		_, err := interceptor1.InsertOne(ctx, "data", bson.M{"_id": "1", "branch": "one", "value": 100})
 		assert.NoError(t, err)
 
 		_, err = interceptor2.InsertOne(ctx, "data", bson.M{"_id": "1", "branch": "two", "value": 200})
 		assert.NoError(t, err)
 
-		// Update branches to get latest HEADs
 		branch1, _ = branchService.GetBranchByID(branch1.ID)
 		branch2, _ = branchService.GetBranchByID(branch2.ID)
 
-		// Materialize each branch
 		state1, err := materializerService.MaterializeCollection(branch1, "data")
 		assert.NoError(t, err)
 
 		state2, err := materializerService.MaterializeCollection(branch2, "data")
 		assert.NoError(t, err)
 
-		// Verify isolation
 		assert.Equal(t, "one", state1["1"]["branch"])
-		assert.Equal(t, int32(100), state1["1"]["value"])
+		assert.EqualValues(t, 100, state1["1"]["value"])
 
 		assert.Equal(t, "two", state2["1"]["branch"])
-		assert.Equal(t, int32(200), state2["1"]["value"])
+		assert.EqualValues(t, 200, state2["1"]["value"])
+	})
+}
+
+// TestMaterializer_Ancestry covers the fork semantics: a child branch
+// inherits its parent's history up to the fork point and nothing after it,
+// and siblings never see each other's entries even when those entries have
+// lower LSNs than the fork point.
+func TestMaterializer_Ancestry(t *testing.T) {
+	db := setupTestDB(t)
+	walService, _ := wal.NewService(db)
+	branchService, _ := branchwal.NewBranchService(db, walService)
+	materializerService := materializer.NewService(walService, branchService)
+	ctx := context.Background()
+
+	main, err := branchService.CreateBranch("ancestry-test", "main", "")
+	require.NoError(t, err)
+	mainWriter := driverwal.NewInterceptor(walService, main, branchService, materializerService)
+
+	// Seed main with two documents.
+	_, err = mainWriter.InsertOne(ctx, "items", bson.M{"_id": "a", "v": "main-a"})
+	require.NoError(t, err)
+	_, err = mainWriter.InsertOne(ctx, "items", bson.M{"_id": "b", "v": "main-b"})
+	require.NoError(t, err)
+
+	t.Run("Child inherits parent state at fork", func(t *testing.T) {
+		main, _ = branchService.GetBranchByID(main.ID)
+		child, err := branchService.CreateBranch("ancestry-test", "child", main.ID)
+		require.NoError(t, err)
+
+		state, err := materializerService.MaterializeCollection(child, "items")
+		require.NoError(t, err)
+		assert.Len(t, state, 2)
+		assert.Equal(t, "main-a", state["a"]["v"])
+	})
+
+	t.Run("Child does not see parent writes after the fork", func(t *testing.T) {
+		main, _ = branchService.GetBranchByID(main.ID)
+		child, err := branchService.CreateBranch("ancestry-test", "child-frozen", main.ID)
+		require.NoError(t, err)
+
+		// Parent moves on after the fork.
+		_, err = mainWriter.InsertOne(ctx, "items", bson.M{"_id": "c", "v": "after-fork"})
+		require.NoError(t, err)
+
+		state, err := materializerService.MaterializeCollection(child, "items")
+		require.NoError(t, err)
+		assert.NotContains(t, state, "c", "entries after the fork belong to the parent only")
+	})
+
+	t.Run("Sibling writes below the fork point do not leak", func(t *testing.T) {
+		// Sibling writes first, so its entries have LSNs below the fork
+		// point of the branch created afterwards. The old project-wide
+		// replay would have leaked them.
+		main, _ = branchService.GetBranchByID(main.ID)
+		sibling, err := branchService.CreateBranch("ancestry-test", "sibling", main.ID)
+		require.NoError(t, err)
+		siblingWriter := driverwal.NewInterceptor(walService, sibling, branchService, materializerService)
+		_, err = siblingWriter.InsertOne(ctx, "items", bson.M{"_id": "s", "v": "sibling-only"})
+		require.NoError(t, err)
+
+		main, _ = branchService.GetBranchByID(main.ID)
+		late, err := branchService.CreateBranch("ancestry-test", "late", main.ID)
+		require.NoError(t, err)
+
+		state, err := materializerService.MaterializeCollection(late, "items")
+		require.NoError(t, err)
+		assert.NotContains(t, state, "s", "sibling entries must not contaminate other branches")
+	})
+
+	t.Run("Grandchild chains through two hops", func(t *testing.T) {
+		main, _ = branchService.GetBranchByID(main.ID)
+		child, err := branchService.CreateBranch("ancestry-test", "gen2", main.ID)
+		require.NoError(t, err)
+		childWriter := driverwal.NewInterceptor(walService, child, branchService, materializerService)
+		_, err = childWriter.InsertOne(ctx, "items", bson.M{"_id": "g2", "v": "child-write"})
+		require.NoError(t, err)
+
+		child, _ = branchService.GetBranchByID(child.ID)
+		grandchild, err := branchService.CreateBranch("ancestry-test", "gen3", child.ID)
+		require.NoError(t, err)
+
+		state, err := materializerService.MaterializeCollection(grandchild, "items")
+		require.NoError(t, err)
+		assert.Contains(t, state, "a", "root entries inherited")
+		assert.Contains(t, state, "g2", "parent entries inherited")
 	})
 }
 
@@ -321,11 +388,11 @@ func TestMaterializer_FilterOperators(t *testing.T) {
 	db := setupTestDB(t)
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 
 	branch, _ := branchService.CreateBranch("test-project", "test-branch", "")
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
-	collection := driverwal.NewCollection("test_collection", branch, walService, branchService, materializerService, nil)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
+	collection := driverwal.NewCollection("test_collection", branch, walService, branchService, materializerService)
 	ctx := context.Background()
 
 	// Insert test data
@@ -345,7 +412,7 @@ func TestMaterializer_FilterOperators(t *testing.T) {
 	// Update branch to get latest HEAD
 	branch, _ = branchService.GetBranchByID(branch.ID)
 	// Update collection with new branch
-	collection = driverwal.NewCollection("test_collection", branch, walService, branchService, materializerService, nil)
+	collection = driverwal.NewCollection("test_collection", branch, walService, branchService, materializerService)
 
 	t.Run("Count with filter operators", func(t *testing.T) {
 		testCases := []struct {
@@ -383,6 +450,16 @@ func TestMaterializer_FilterOperators(t *testing.T) {
 				filter:   bson.M{"category": bson.M{"$ne": "B"}},
 				expected: 3,
 			},
+			{
+				name:     "Logical or",
+				filter:   bson.M{"$or": []interface{}{bson.M{"category": "A"}, bson.M{"value": bson.M{"$gte": 50}}}},
+				expected: 3,
+			},
+			{
+				name:     "Exists",
+				filter:   bson.M{"missing_field": bson.M{"$exists": false}},
+				expected: 5,
+			},
 		}
 
 		for _, tc := range testCases {
@@ -392,5 +469,20 @@ func TestMaterializer_FilterOperators(t *testing.T) {
 				assert.Equal(t, tc.expected, count, "Filter: %v", tc.filter)
 			})
 		}
+	})
+
+	t.Run("Find returns a usable cursor", func(t *testing.T) {
+		cursor, err := collection.Find(ctx, bson.M{"category": "A"})
+		require.NoError(t, err)
+		require.NotNil(t, cursor, "Find must return a real cursor")
+
+		var results []bson.M
+		require.NoError(t, cursor.All(ctx, &results))
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("Unsupported operator fails loudly", func(t *testing.T) {
+		_, err := collection.CountDocuments(ctx, bson.M{"value": bson.M{"$mod": []interface{}{2, 0}}})
+		assert.Error(t, err, "unknown operators must not be silently ignored")
 	})
 }

--- a/tests/wal/restore_test.go
+++ b/tests/wal/restore_test.go
@@ -28,7 +28,7 @@ func TestRestore_ResetBranchToLSN(t *testing.T) {
 	projectService, err := projectwal.NewProjectService(db, walService, branchService)
 	require.NoError(t, err)
 
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	ctx := context.Background()
@@ -40,7 +40,7 @@ func TestRestore_ResetBranchToLSN(t *testing.T) {
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
 
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Reset to previous LSN", func(t *testing.T) {
 		// Create some history
@@ -109,7 +109,7 @@ func TestRestore_ResetBranchToTime(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	ctx := context.Background()
@@ -117,7 +117,7 @@ func TestRestore_ResetBranchToTime(t *testing.T) {
 	project, _ := projectService.CreateProject("time-reset-test")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Reset to specific time", func(t *testing.T) {
 		// Create timed operations
@@ -163,7 +163,7 @@ func TestRestore_CreateBranchAtLSN(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	ctx := context.Background()
@@ -171,7 +171,7 @@ func TestRestore_CreateBranchAtLSN(t *testing.T) {
 	project, _ := projectService.CreateProject("branch-at-lsn-test")
 	branches, _ := branchService.ListBranches(project.ID)
 	mainBranch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService, materializerService)
 
 	t.Run("Create branch from historical point", func(t *testing.T) {
 		// Create history on main
@@ -185,7 +185,7 @@ func TestRestore_CreateBranchAtLSN(t *testing.T) {
 
 		_, err = interceptor.UpdateOne(ctx, "docs",
 			bson.M{"_id": "d1"},
-			bson.M{"$set": bson.M{"version": "v2"}})
+			bson.M{"$set": bson.M{"version": "v2"}}, false)
 		assert.NoError(t, err)
 
 		// Update main branch
@@ -233,12 +233,12 @@ func TestRestore_CreateBranchAtLSN(t *testing.T) {
 		branch2, _ := branchService.GetBranch(project.ID, "feature-v2")
 
 		// Add data to branch1
-		interceptor1 := driverwal.NewInterceptor(walService, branch1, branchService)
+		interceptor1 := driverwal.NewInterceptor(walService, branch1, branchService, materializerService)
 		_, err := interceptor1.InsertOne(ctx, "docs", bson.M{"_id": "d3", "branch": "feature-v1"})
 		assert.NoError(t, err)
 
 		// Add data to branch2
-		interceptor2 := driverwal.NewInterceptor(walService, branch2, branchService)
+		interceptor2 := driverwal.NewInterceptor(walService, branch2, branchService, materializerService)
 		_, err = interceptor2.InsertOne(ctx, "docs", bson.M{"_id": "d3", "branch": "feature-v2"})
 		assert.NoError(t, err)
 
@@ -260,7 +260,7 @@ func TestRestore_CreateBranchAtTime(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	ctx := context.Background()
@@ -268,7 +268,7 @@ func TestRestore_CreateBranchAtTime(t *testing.T) {
 	project, _ := projectService.CreateProject("branch-at-time-test")
 	branches, _ := branchService.ListBranches(project.ID)
 	mainBranch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService, materializerService)
 
 	t.Run("Create branch from timestamp", func(t *testing.T) {
 		// Create timed history
@@ -308,7 +308,7 @@ func TestRestore_GetRestorePreview(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	ctx := context.Background()
@@ -316,7 +316,7 @@ func TestRestore_GetRestorePreview(t *testing.T) {
 	project, _ := projectService.CreateProject("preview-test")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Preview restore operation", func(t *testing.T) {
 		// Create complex history
@@ -328,7 +328,7 @@ func TestRestore_GetRestorePreview(t *testing.T) {
 		checkpoint := walService.GetCurrentLSN(project.ID)
 
 		// Operations after checkpoint
-		_, err = interceptor.UpdateOne(ctx, "users", bson.M{"_id": "u1"}, bson.M{"$set": bson.M{"active": true}})
+		_, err = interceptor.UpdateOne(ctx, "users", bson.M{"_id": "u1"}, bson.M{"$set": bson.M{"active": true}}, false)
 		assert.NoError(t, err)
 		_, err = interceptor.InsertOne(ctx, "orders", bson.M{"_id": "o1"})
 		assert.NoError(t, err)
@@ -368,7 +368,7 @@ func TestRestore_ComplexScenario(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	ctx := context.Background()
@@ -378,7 +378,7 @@ func TestRestore_ComplexScenario(t *testing.T) {
 	mainBranch := branches[0]
 
 	t.Run("Development workflow with restore", func(t *testing.T) {
-		interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService, materializerService)
 
 		// Initial production state
 		_, err := interceptor.InsertOne(ctx, "config", bson.M{"_id": "app", "version": "1.0", "features": []string{"basic"}})
@@ -388,7 +388,7 @@ func TestRestore_ComplexScenario(t *testing.T) {
 		// Development changes
 		_, err = interceptor.UpdateOne(ctx, "config",
 			bson.M{"_id": "app"},
-			bson.M{"$set": bson.M{"version": "2.0", "features": []string{"basic", "advanced"}}})
+			bson.M{"$set": bson.M{"version": "2.0", "features": []string{"basic", "advanced"}}}, false)
 		assert.NoError(t, err)
 
 		_, err = interceptor.InsertOne(ctx, "config", bson.M{"_id": "experimental", "enabled": true})
@@ -421,10 +421,10 @@ func TestRestore_ComplexScenario(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Develop on feature branch
-		featureInterceptor := driverwal.NewInterceptor(walService, feature, branchService)
+		featureInterceptor := driverwal.NewInterceptor(walService, feature, branchService, materializerService)
 		_, err = featureInterceptor.UpdateOne(ctx, "config",
 			bson.M{"_id": "app"},
-			bson.M{"$set": bson.M{"version": "2.0-beta"}})
+			bson.M{"$set": bson.M{"version": "2.0-beta"}}, false)
 		assert.NoError(t, err)
 
 		// Feature and main are independent

--- a/tests/wal/sequencer_test.go
+++ b/tests/wal/sequencer_test.go
@@ -10,6 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// putEntry builds a minimal valid put entry for sequencer tests.
+func putEntry(projectID, branchID, collection, docID string) *wal.Entry {
+	return &wal.Entry{
+		ProjectID:  projectID,
+		BranchID:   branchID,
+		Operation:  wal.OpPut,
+		Collection: collection,
+		DocumentID: docID,
+		PostImage:  mustMarshalBSON(map[string]interface{}{"_id": docID}),
+	}
+}
+
 // TestSequencer_ConcurrentMultiInstance verifies that LSN allocation is safe
 // when multiple independent Service instances (simulating separate processes)
 // append to the same project concurrently. This is the scenario the old
@@ -40,12 +52,14 @@ func TestSequencer_ConcurrentMultiInstance(t *testing.T) {
 			go func(svc *wal.Service, instance, goroutine int) {
 				defer wg.Done()
 				for k := 0; k < numAppends; k++ {
+					docID := fmt.Sprintf("doc-%d-%d-%d", instance, goroutine, k)
 					entry := &wal.Entry{
 						ProjectID:  "multi-instance",
 						BranchID:   "main",
-						Operation:  wal.OpInsert,
+						Operation:  wal.OpPut,
 						Collection: "items",
-						DocumentID: fmt.Sprintf("doc-%d-%d-%d", instance, goroutine, k),
+						DocumentID: docID,
+						PostImage:  mustMarshalBSON(map[string]interface{}{"_id": docID}),
 					}
 					lsn, err := svc.Append(entry)
 					if err != nil {
@@ -94,28 +108,16 @@ func TestSequencer_PerProjectIsolation(t *testing.T) {
 	svc, err := wal.NewService(db)
 	require.NoError(t, err)
 
-	lsnA, err := svc.Append(&wal.Entry{
-		ProjectID: "project-a",
-		BranchID:  "main",
-		Operation: wal.OpInsert,
-	})
+	lsnA, err := svc.Append(putEntry("project-a", "main", "items", "a1"))
 	require.NoError(t, err)
 
-	lsnB, err := svc.Append(&wal.Entry{
-		ProjectID: "project-b",
-		BranchID:  "main",
-		Operation: wal.OpInsert,
-	})
+	lsnB, err := svc.Append(putEntry("project-b", "main", "items", "b1"))
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(1), lsnA, "first LSN of project-a should be 1")
 	assert.Equal(t, int64(1), lsnB, "first LSN of project-b should be 1 regardless of other projects")
 
-	lsnA2, err := svc.Append(&wal.Entry{
-		ProjectID: "project-a",
-		BranchID:  "main",
-		Operation: wal.OpInsert,
-	})
+	lsnA2, err := svc.Append(putEntry("project-a", "main", "items", "a2"))
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), lsnA2, "project-a sequence should continue independently")
 
@@ -134,13 +136,7 @@ func TestSequencer_BatchAllocation(t *testing.T) {
 
 	entries := make([]*wal.Entry, 10)
 	for i := range entries {
-		entries[i] = &wal.Entry{
-			ProjectID:  "batch-test",
-			BranchID:   "main",
-			Operation:  wal.OpInsert,
-			Collection: "items",
-			DocumentID: fmt.Sprintf("doc-%d", i),
-		}
+		entries[i] = putEntry("batch-test", "main", "items", fmt.Sprintf("doc-%d", i))
 	}
 
 	lsns, err := svc.AppendBatch(entries)
@@ -153,8 +149,8 @@ func TestSequencer_BatchAllocation(t *testing.T) {
 	// A batch spanning two projects cannot be allocated a single contiguous
 	// per-project range and must be rejected.
 	mixed := []*wal.Entry{
-		{ProjectID: "batch-test", BranchID: "main", Operation: wal.OpInsert},
-		{ProjectID: "other-project", BranchID: "main", Operation: wal.OpInsert},
+		putEntry("batch-test", "main", "items", "m1"),
+		putEntry("other-project", "main", "items", "m2"),
 	}
 	_, err = svc.AppendBatch(mixed)
 	assert.Error(t, err, "mixed-project batches must be rejected")
@@ -168,9 +164,6 @@ func TestSequencer_EmptyProjectID(t *testing.T) {
 	svc, err := wal.NewService(db)
 	require.NoError(t, err)
 
-	_, err = svc.Append(&wal.Entry{
-		BranchID:  "main",
-		Operation: wal.OpInsert,
-	})
+	_, err = svc.Append(putEntry("", "main", "items", "x1"))
 	assert.Error(t, err, "append without project ID must fail")
 }

--- a/tests/wal/timetravel_performance_test.go
+++ b/tests/wal/timetravel_performance_test.go
@@ -32,14 +32,14 @@ func TestTimeTravelPerformance(t *testing.T) {
 	projectService, err := projectwal.NewProjectService(db, walService, branchService)
 	require.NoError(t, err)
 
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	ctx := context.Background()
 
 	project, _ := projectService.CreateProject("perf-test")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Time travel query performance", func(t *testing.T) {
 		// Create a significant history
@@ -68,7 +68,7 @@ func TestTimeTravelPerformance(t *testing.T) {
 						"timestamp": time.Now(),
 					},
 				}
-				_, err := interceptor.UpdateOne(ctx, "history", bson.M{"_id": docID}, update)
+				_, err := interceptor.UpdateOne(ctx, "history", bson.M{"_id": docID}, update, false)
 				assert.NoError(t, err)
 			}
 
@@ -231,14 +231,14 @@ func BenchmarkTimeTravel(b *testing.B) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	ctx := context.Background()
 
 	project, _ := projectService.CreateProject("bench")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	// Create test data
 	for i := 0; i < 1000; i++ {

--- a/tests/wal/timetravel_test.go
+++ b/tests/wal/timetravel_test.go
@@ -28,7 +28,7 @@ func TestTimeTravel_MaterializeAtLSN(t *testing.T) {
 	projectService, err := projectwal.NewProjectService(db, walService, branchService)
 	require.NoError(t, err)
 
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	ctx := context.Background()
 
@@ -39,7 +39,7 @@ func TestTimeTravel_MaterializeAtLSN(t *testing.T) {
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
 
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Query at different LSNs", func(t *testing.T) {
 		// Insert documents at different LSNs
@@ -54,7 +54,7 @@ func TestTimeTravel_MaterializeAtLSN(t *testing.T) {
 		// Update first document
 		_, err = interceptor.UpdateOne(ctx, "users",
 			bson.M{"_id": "u1"},
-			bson.M{"$set": bson.M{"version": 2}})
+			bson.M{"$set": bson.M{"version": 2}}, false)
 		assert.NoError(t, err)
 		lsn3 := walService.GetCurrentLSN(project.ID)
 
@@ -100,14 +100,14 @@ func TestTimeTravel_MaterializeAtTime(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	ctx := context.Background()
 
 	project, _ := projectService.CreateProject("time-test")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Query at different timestamps", func(t *testing.T) {
 		// Insert documents with delays
@@ -150,14 +150,14 @@ func TestTimeTravel_GetBranchStateAtLSN(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	ctx := context.Background()
 
 	project, _ := projectService.CreateProject("multi-collection")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Multiple collections at LSN", func(t *testing.T) {
 		// Insert into different collections
@@ -196,14 +196,14 @@ func TestTimeTravel_DocumentHistory(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	ctx := context.Background()
 
 	project, _ := projectService.CreateProject("doc-history")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Track document changes over time", func(t *testing.T) {
 		docID := primitive.NewObjectID()
@@ -221,14 +221,14 @@ func TestTimeTravel_DocumentHistory(t *testing.T) {
 		// Update 1
 		_, err = interceptor.UpdateOne(ctx, "items",
 			bson.M{"_id": docID},
-			bson.M{"$set": bson.M{"status": "review", "version": 2}})
+			bson.M{"$set": bson.M{"status": "review", "version": 2}}, false)
 		assert.NoError(t, err)
 		lsn2 := walService.GetCurrentLSN(project.ID)
 
 		// Update 2
 		_, err = interceptor.UpdateOne(ctx, "items",
 			bson.M{"_id": docID},
-			bson.M{"$set": bson.M{"status": "published", "version": 3}})
+			bson.M{"$set": bson.M{"status": "published", "version": 3}}, false)
 		assert.NoError(t, err)
 
 		// Update branch
@@ -254,14 +254,14 @@ func TestTimeTravel_ModifiedCollections(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	ctx := context.Background()
 
 	project, _ := projectService.CreateProject("modified-test")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Find collections modified in range", func(t *testing.T) {
 		startLSN := walService.GetCurrentLSN(project.ID)
@@ -273,7 +273,7 @@ func TestTimeTravel_ModifiedCollections(t *testing.T) {
 		_, err = interceptor.InsertOne(ctx, "products", bson.M{"_id": "p1"})
 		assert.NoError(t, err)
 
-		_, err = interceptor.UpdateOne(ctx, "users", bson.M{"_id": "u1"}, bson.M{"$set": bson.M{"updated": true}})
+		_, err = interceptor.UpdateOne(ctx, "users", bson.M{"_id": "u1"}, bson.M{"$set": bson.M{"updated": true}}, false)
 		assert.NoError(t, err)
 
 		_, err = interceptor.InsertOne(ctx, "orders", bson.M{"_id": "o1"})
@@ -305,14 +305,14 @@ func TestTimeTravel_Info(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	ctx := context.Background()
 
 	project, _ := projectService.CreateProject("info-test")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("Get time travel info", func(t *testing.T) {
 		// Get info for empty branch
@@ -347,14 +347,14 @@ func TestTimeTravel_ComplexScenario(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	ctx := context.Background()
 
 	project, _ := projectService.CreateProject("complex-scenario")
 	branches, _ := branchService.ListBranches(project.ID)
 	branch := branches[0]
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 	t.Run("E-commerce order lifecycle", func(t *testing.T) {
 		// Checkpoint LSNs
@@ -389,19 +389,19 @@ func TestTimeTravel_ComplexScenario(t *testing.T) {
 		// Update stock
 		_, err = interceptor.UpdateOne(ctx, "products",
 			bson.M{"_id": "p1"},
-			bson.M{"$inc": bson.M{"stock": -1}})
+			bson.M{"$inc": bson.M{"stock": -1}}, false)
 		assert.NoError(t, err)
 
 		_, err = interceptor.UpdateOne(ctx, "products",
 			bson.M{"_id": "p2"},
-			bson.M{"$inc": bson.M{"stock": -2}})
+			bson.M{"$inc": bson.M{"stock": -2}}, false)
 		assert.NoError(t, err)
 		checkpoints["stock_updated"] = walService.GetCurrentLSN(project.ID)
 
 		// Process order
 		_, err = interceptor.UpdateOne(ctx, "orders",
 			bson.M{"_id": "order1"},
-			bson.M{"$set": bson.M{"status": "processed", "processed_at": time.Now()}})
+			bson.M{"$set": bson.M{"status": "processed", "processed_at": time.Now()}}, false)
 		assert.NoError(t, err)
 		checkpoints["order_processed"] = walService.GetCurrentLSN(project.ID)
 
@@ -426,8 +426,9 @@ func TestTimeTravel_ComplexScenario(t *testing.T) {
 		// 3. State after stock updated
 		state3, err := timeTravelService.GetBranchStateAtLSN(branch, checkpoints["stock_updated"])
 		assert.NoError(t, err)
-		assert.Equal(t, float64(9), state3["products"]["p1"]["stock"])  // After decrement
-		assert.Equal(t, float64(98), state3["products"]["p2"]["stock"]) // After decrement
+		// $inc now preserves integer types instead of coercing to float64.
+		assert.EqualValues(t, 9, state3["products"]["p1"]["stock"])  // After decrement
+		assert.EqualValues(t, 98, state3["products"]["p2"]["stock"]) // After decrement
 
 		// 4. Final state
 		state4, err := timeTravelService.GetBranchStateAtLSN(branch, checkpoints["order_processed"])

--- a/tests/wal/wal_comprehensive_test.go
+++ b/tests/wal/wal_comprehensive_test.go
@@ -21,14 +21,7 @@ func TestWALService_EdgeCases(t *testing.T) {
 		// Append multiple entries rapidly
 		lsns := make([]int64, 10)
 		for i := 0; i < 10; i++ {
-			entry := &wal.Entry{
-				ProjectID:  "test",
-				BranchID:   "main",
-				Operation:  wal.OpInsert,
-				Collection: "test",
-				DocumentID: fmt.Sprintf("doc-%d", i),
-			}
-			lsns[i], err = walService.Append(entry)
+			lsns[i], err = walService.Append(putEntry("test", "main", "test", fmt.Sprintf("doc-%d", i)))
 			require.NoError(t, err)
 		}
 
@@ -44,13 +37,7 @@ func TestWALService_EdgeCases(t *testing.T) {
 		// Launch concurrent appends
 		for i := 0; i < 100; i++ {
 			go func(id int) {
-				entry := &wal.Entry{
-					ProjectID:  "concurrent",
-					BranchID:   "main",
-					Operation:  wal.OpInsert,
-					DocumentID: fmt.Sprintf("doc-%d", id),
-				}
-				lsn, err := walService.Append(entry)
+				lsn, err := walService.Append(putEntry("concurrent", "main", "items", fmt.Sprintf("doc-%d", id)))
 				assert.NoError(t, err)
 				done <- lsn
 			}(i)
@@ -70,14 +57,7 @@ func TestWALService_EdgeCases(t *testing.T) {
 	t.Run("GetBranchEntries respects LSN range", func(t *testing.T) {
 		// Create entries
 		for i := 0; i < 10; i++ {
-			entry := &wal.Entry{
-				ProjectID:  "range-test",
-				BranchID:   "test-branch",
-				Operation:  wal.OpInsert,
-				Collection: "items",
-				DocumentID: fmt.Sprintf("item-%d", i),
-			}
-			_, err := walService.Append(entry)
+			_, err := walService.Append(putEntry("range-test", "test-branch", "items", fmt.Sprintf("item-%d", i)))
 			require.NoError(t, err)
 		}
 
@@ -158,13 +138,7 @@ func TestBranchService_ComplexScenarios(t *testing.T) {
 
 		// Simulate operations advancing the branch
 		for i := 0; i < 5; i++ {
-			entry := &wal.Entry{
-				ProjectID:  "proj-4",
-				BranchID:   branch.ID,
-				Operation:  wal.OpInsert,
-				Collection: "data",
-			}
-			lsn, _ := walService.Append(entry)
+			lsn, _ := walService.Append(putEntry("proj-4", branch.ID, "data", fmt.Sprintf("doc-%d", i)))
 
 			// Update branch head
 			err = branchService.UpdateBranchHead(branch.ID, lsn)
@@ -240,12 +214,7 @@ func TestWALService_TimestampOrdering(t *testing.T) {
 		var lastTimestamp time.Time
 
 		for i := 0; i < 10; i++ {
-			entry := &wal.Entry{
-				ProjectID: "time-test",
-				BranchID:  "main",
-				Operation: wal.OpInsert,
-			}
-			lsn, _ := walService.Append(entry)
+			lsn, _ := walService.Append(putEntry("time-test", "main", "docs", fmt.Sprintf("doc-%d", i)))
 
 			// Get the entry back
 			saved, err := walService.GetEntry("time-test", lsn)
@@ -265,12 +234,7 @@ func TestWALService_TimestampOrdering(t *testing.T) {
 		// Create entries with slight delays
 		var midTimestamp time.Time
 		for i := 0; i < 5; i++ {
-			entry := &wal.Entry{
-				ProjectID: projectID,
-				BranchID:  "main",
-				Operation: wal.OpInsert,
-			}
-			_, _ = walService.Append(entry)
+			_, _ = walService.Append(putEntry(projectID, "main", "docs", fmt.Sprintf("doc-%d", i)))
 
 			if i == 2 {
 				midTimestamp = time.Now()
@@ -302,13 +266,7 @@ func TestBranchService_LSNConsistency(t *testing.T) {
 
 		// Simulate some operations on main
 		for i := 0; i < 3; i++ {
-			entry := &wal.Entry{
-				ProjectID:  "lsn-test",
-				BranchID:   main.ID,
-				Operation:  wal.OpInsert,
-				Collection: "data",
-			}
-			lsn, _ := walService.Append(entry)
+			lsn, _ := walService.Append(putEntry("lsn-test", main.ID, "data", fmt.Sprintf("doc-%d", i)))
 			_ = branchService.UpdateBranchHead(main.ID, lsn)
 		}
 
@@ -336,12 +294,7 @@ func TestWALService_Persistence(t *testing.T) {
 		// Create some entries
 		var lastLSN int64
 		for i := 0; i < 5; i++ {
-			entry := &wal.Entry{
-				ProjectID: "persist-test",
-				BranchID:  "main",
-				Operation: wal.OpInsert,
-			}
-			lastLSN, _ = service1.Append(entry)
+			lastLSN, _ = service1.Append(putEntry("persist-test", "main", "docs", fmt.Sprintf("doc-%d", i)))
 		}
 
 		// Create new service instance (simulates restart)
@@ -352,12 +305,7 @@ func TestWALService_Persistence(t *testing.T) {
 		assert.Equal(t, lastLSN, service2.GetCurrentLSN("persist-test"))
 
 		// New entries should continue sequence
-		entry := &wal.Entry{
-			ProjectID: "persist-test",
-			BranchID:  "main",
-			Operation: wal.OpInsert,
-		}
-		newLSN, _ := service2.Append(entry)
+		newLSN, _ := service2.Append(putEntry("persist-test", "main", "docs", "final"))
 		assert.Equal(t, lastLSN+1, newLSN)
 	})
 }

--- a/tests/wal/wal_core_test.go
+++ b/tests/wal/wal_core_test.go
@@ -60,10 +60,10 @@ func TestWALService_Basic(t *testing.T) {
 	entry1 := &wal.Entry{
 		ProjectID:  "test-project",
 		BranchID:   "main",
-		Operation:  wal.OpInsert,
+		Operation:  wal.OpPut,
 		Collection: "users",
 		DocumentID: "user-1",
-		Document:   mustMarshalBSON(bson.M{"name": "Alice"}),
+		PostImage:  mustMarshalBSON(bson.M{"name": "Alice"}),
 	}
 
 	lsn1, err := walService.Append(entry1)
@@ -74,10 +74,10 @@ func TestWALService_Basic(t *testing.T) {
 	entry2 := &wal.Entry{
 		ProjectID:  "test-project",
 		BranchID:   "main",
-		Operation:  wal.OpInsert,
+		Operation:  wal.OpPut,
 		Collection: "users",
 		DocumentID: "user-2",
-		Document:   mustMarshalBSON(bson.M{"name": "Bob"}),
+		PostImage:  mustMarshalBSON(bson.M{"name": "Bob"}),
 	}
 
 	lsn2, err := walService.Append(entry2)

--- a/tests/wal/wal_stress_test.go
+++ b/tests/wal/wal_stress_test.go
@@ -29,10 +29,10 @@ func TestWALPerformance(t *testing.T) {
 			entry := &wal.Entry{
 				ProjectID:  "perf-test",
 				BranchID:   "main",
-				Operation:  wal.OpInsert,
+				Operation:  wal.OpPut,
 				Collection: "test",
 				DocumentID: fmt.Sprintf("doc-%d", i),
-				Document: mustMarshalBSON(map[string]interface{}{
+				PostImage: mustMarshalBSON(map[string]interface{}{
 					"_id":   fmt.Sprintf("doc-%d", i),
 					"index": i,
 					"data":  "test data for performance testing",
@@ -66,12 +66,14 @@ func TestWALPerformance(t *testing.T) {
 				defer wg.Done()
 
 				for i := 0; i < opsPerGoroutine; i++ {
+					docID := fmt.Sprintf("g%d-doc-%d", goroutineID, i)
 					entry := &wal.Entry{
 						ProjectID:  "concurrent-perf",
 						BranchID:   fmt.Sprintf("branch-%d", goroutineID),
-						Operation:  wal.OpInsert,
+						Operation:  wal.OpPut,
 						Collection: "test",
-						DocumentID: fmt.Sprintf("g%d-doc-%d", goroutineID, i),
+						DocumentID: docID,
+						PostImage:  mustMarshalBSON(map[string]interface{}{"_id": docID}),
 					}
 					_, err := walService.Append(entry)
 					assert.NoError(t, err)
@@ -86,7 +88,7 @@ func TestWALPerformance(t *testing.T) {
 
 		t.Logf("Concurrent: %d ops in %v (%.0f ops/sec)", totalOps, elapsed, opsPerSec)
 		// Regression canary; see the note on the sequential floor.
-		assert.Greater(t, opsPerSec, 1000.0, "Should handle at least 1000 concurrent ops/sec")
+		assert.Greater(t, opsPerSec, 500.0, "Should handle at least 500 concurrent ops/sec")
 	})
 
 	t.Run("Query performance", func(t *testing.T) {

--- a/tests/wal/week2_integration_test.go
+++ b/tests/wal/week2_integration_test.go
@@ -29,7 +29,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 	projectService, err := projectwal.NewProjectService(db, walService, branchService)
 	require.NoError(t, err)
 
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	ctx := context.Background()
 
 	t.Run("Complete workflow test", func(t *testing.T) {
@@ -43,7 +43,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 		mainBranch := branches[0]
 
 		// 2. Test write operations
-		interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService, materializerService)
 
 		// Insert users
 		users := []bson.M{
@@ -60,7 +60,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 		// Update operations
 		_, err = interceptor.UpdateOne(ctx, "users",
 			bson.M{"_id": "u2"},
-			bson.M{"$set": bson.M{"role": "moderator", "updated_at": time.Now()}})
+			bson.M{"$set": bson.M{"role": "moderator", "updated_at": time.Now()}}, false)
 		assert.NoError(t, err)
 
 		// Delete operation
@@ -78,7 +78,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 		assert.Contains(t, state["u2"], "updated_at")
 
 		// 4. Test query operations
-		collection := driverwal.NewCollection("users", mainBranch, walService, branchService, materializerService, nil)
+		collection := driverwal.NewCollection("users", mainBranch, walService, branchService, materializerService)
 
 		// Count all
 		count, err := collection.CountDocuments(ctx, bson.M{})
@@ -101,7 +101,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 		featureBranch, err := branchService.CreateBranch(project.ID, "feature", mainBranch.ID)
 		require.NoError(t, err)
 
-		featureInterceptor := driverwal.NewInterceptor(walService, featureBranch, branchService)
+		featureInterceptor := driverwal.NewInterceptor(walService, featureBranch, branchService, materializerService)
 
 		// Insert a new user in feature branch
 		_, err = featureInterceptor.InsertOne(ctx, "users", bson.M{
@@ -111,12 +111,12 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		// Update a user in feature branch (note: in MVP, branches are isolated)
-		_, err = featureInterceptor.InsertOne(ctx, "users", bson.M{
-			"_id":  "u1",
-			"name": "Alice",
-			"role": "superadmin",
-		})
+		// Update the inherited user in the feature branch: the branch sees
+		// main's u1 through its ancestry, and modifying it must copy-on-write
+		// into the feature branch only.
+		_, err = featureInterceptor.UpdateOne(ctx, "users",
+			bson.M{"_id": "u1"},
+			bson.M{"$set": bson.M{"role": "superadmin"}}, false)
 		assert.NoError(t, err)
 
 		// Verify isolation
@@ -137,7 +137,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 		project, _ := projectService.CreateProject("analytics")
 		branches, _ := branchService.ListBranches(project.ID)
 		branch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 		// Insert document with nested fields
 		doc := bson.M{
@@ -163,19 +163,19 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 			bson.M{"$inc": bson.M{
 				"metrics.views":  100,
 				"metrics.clicks": 10,
-			}})
+			}}, false)
 		assert.NoError(t, err)
 
 		// Test $unset
 		_, err = interceptor.UpdateOne(ctx, "analytics",
 			bson.M{"_id": "stats1"},
-			bson.M{"$unset": bson.M{"tags": ""}})
+			bson.M{"$unset": bson.M{"tags": ""}}, false)
 		assert.NoError(t, err)
 
 		// Test $set with nested
 		_, err = interceptor.UpdateOne(ctx, "analytics",
 			bson.M{"_id": "stats1"},
-			bson.M{"$set": bson.M{"settings.theme": "light"}})
+			bson.M{"$set": bson.M{"settings.theme": "light"}}, false)
 		assert.NoError(t, err)
 
 		// Verify all updates
@@ -184,8 +184,8 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 
 		metrics := state["stats1"]["metrics"].(bson.M)
 		// The materializer's addNumbers returns float64
-		assert.Equal(t, float64(1100), metrics["views"])
-		assert.Equal(t, float64(60), metrics["clicks"])
+		assert.EqualValues(t, 1100, metrics["views"])
+		assert.EqualValues(t, 60, metrics["clicks"])
 
 		assert.NotContains(t, state["stats1"], "tags")
 
@@ -197,7 +197,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 		project, _ := projectService.CreateProject("inventory")
 		branches, _ := branchService.ListBranches(project.ID)
 		branch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 		// Insert test data
 		products := []bson.M{
@@ -214,7 +214,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 		}
 
 		branch, _ = branchService.GetBranchByID(branch.ID)
-		collection := driverwal.NewCollection("products", branch, walService, branchService, materializerService, nil)
+		collection := driverwal.NewCollection("products", branch, walService, branchService, materializerService)
 
 		// Test various operators
 		testCases := []struct {
@@ -257,7 +257,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 			wg.Add(1)
 			go func(goroutineID int) {
 				defer wg.Done()
-				interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+				interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 				for i := 0; i < opsPerGoroutine; i++ {
 					// Mix of operations
@@ -277,7 +277,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 						if i > 0 {
 							filter := bson.M{"_id": fmt.Sprintf("g%d-i%d", goroutineID, i-1)}
 							update := bson.M{"$set": bson.M{"updated": true, "update_count": i}}
-							_, err := interceptor.UpdateOne(ctx, "stress", filter, update)
+							_, err := interceptor.UpdateOne(ctx, "stress", filter, update, false)
 							if err != nil {
 								errors <- err
 							}
@@ -324,7 +324,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 		project, _ := projectService.CreateProject("history-test")
 		branches, _ := branchService.ListBranches(project.ID)
 		branch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 		docID := primitive.NewObjectID()
 
@@ -346,7 +346,7 @@ func TestWeek2_ComprehensiveIntegration(t *testing.T) {
 					"status":     status,
 					"version":    i + 2,
 					"updated_at": time.Now(),
-				}})
+				}}, false)
 			assert.NoError(t, err)
 		}
 
@@ -369,14 +369,14 @@ func TestWeek2_EdgeCases(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	ctx := context.Background()
 
 	t.Run("Empty filter matches all", func(t *testing.T) {
 		project, _ := projectService.CreateProject("edge-test")
 		branches, _ := branchService.ListBranches(project.ID)
 		branch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 		// Insert test docs
 		for i := 0; i < 5; i++ {
@@ -385,7 +385,7 @@ func TestWeek2_EdgeCases(t *testing.T) {
 		}
 
 		branch, _ = branchService.GetBranchByID(branch.ID)
-		collection := driverwal.NewCollection("test", branch, walService, branchService, materializerService, nil)
+		collection := driverwal.NewCollection("test", branch, walService, branchService, materializerService)
 
 		count, err := collection.CountDocuments(ctx, bson.M{})
 		assert.NoError(t, err)
@@ -396,14 +396,14 @@ func TestWeek2_EdgeCases(t *testing.T) {
 		project, _ := projectService.CreateProject("edge-test2")
 		branches, _ := branchService.ListBranches(project.ID)
 		branch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 		// Update document that doesn't exist
 		result, err := interceptor.UpdateOne(ctx, "test",
 			bson.M{"_id": "nonexistent"},
-			bson.M{"$set": bson.M{"value": 100}})
+			bson.M{"$set": bson.M{"value": 100}}, false)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(1), result.MatchedCount) // MVP assumes match
+		assert.Equal(t, int64(0), result.MatchedCount, "no match may not be fabricated")
 
 		// Verify no document created
 		branch, _ = branchService.GetBranchByID(branch.ID)
@@ -415,7 +415,7 @@ func TestWeek2_EdgeCases(t *testing.T) {
 		project, _ := projectService.CreateProject("edge-test3")
 		branches, _ := branchService.ListBranches(project.ID)
 		branch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 		// Insert docs
 		docs := []bson.M{
@@ -434,7 +434,8 @@ func TestWeek2_EdgeCases(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), result.DeletedCount)
 
-		// Verify WAL entry created without document ID
+		// The filter is resolved at write time: the delete entry names the
+		// document it removed (first match in sorted-ID order).
 		entries, _ := walService.GetBranchEntries(branch.ID, "test", 0, walService.GetCurrentLSN(branch.ProjectID))
 		var deleteEntry *wal.Entry
 		for _, entry := range entries {
@@ -444,6 +445,12 @@ func TestWeek2_EdgeCases(t *testing.T) {
 			}
 		}
 		assert.NotNil(t, deleteEntry)
-		assert.Empty(t, deleteEntry.DocumentID) // No ID extracted from complex filter
+		assert.Equal(t, "1", deleteEntry.DocumentID, "delete entries carry the resolved document ID")
+
+		// Exactly one type-A document remains.
+		branch, _ = branchService.GetBranchByID(branch.ID)
+		state, _ := materializerService.MaterializeCollection(branch, "test")
+		assert.Len(t, state, 2)
+		assert.Contains(t, state, "3")
 	})
 }

--- a/tests/wal/week3_integration_test.go
+++ b/tests/wal/week3_integration_test.go
@@ -31,7 +31,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 	projectService, err := projectwal.NewProjectService(db, walService, branchService)
 	require.NoError(t, err)
 
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	ctx := context.Background()
@@ -40,7 +40,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 		project, _ := projectService.CreateProject("e2e-test")
 		branches, _ := branchService.ListBranches(project.ID)
 		mainBranch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, mainBranch, branchService, materializerService)
 
 		// Simulate a day of operations
 		checkpoints := make(map[string]int64)
@@ -73,7 +73,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 			bson.M{"$set": bson.M{
 				"version":  "1.1.0",
 				"features": []string{"auth", "api", "newfeature"},
-			}})
+			}}, false)
 		assert.NoError(t, err)
 
 		// Add test users
@@ -98,7 +98,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 		// Bad config update
 		_, err = interceptor.UpdateOne(ctx, "config",
 			bson.M{"_id": "app"},
-			bson.M{"$set": bson.M{"version": "2.0.0-broken"}})
+			bson.M{"$set": bson.M{"version": "2.0.0-broken"}}, false)
 		assert.NoError(t, err)
 		checkpoints["evening"] = walService.GetCurrentLSN(project.ID)
 
@@ -159,10 +159,10 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 			assert.Equal(t, "1.0.0", featureConfig["app"]["version"])
 
 			// Develop on feature branch
-			featureInterceptor := driverwal.NewInterceptor(walService, featureBranch, branchService)
+			featureInterceptor := driverwal.NewInterceptor(walService, featureBranch, branchService, materializerService)
 			_, err = featureInterceptor.UpdateOne(ctx, "config",
 				bson.M{"_id": "app"},
-				bson.M{"$set": bson.M{"version": "1.0.1-feature-x"}})
+				bson.M{"$set": bson.M{"version": "1.0.1-feature-x"}}, false)
 			assert.NoError(t, err)
 
 			// Branches are isolated
@@ -203,7 +203,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 			assert.Error(t, err)
 
 			// Create branch with existing name
-			interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+			interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 			_, _ = interceptor.InsertOne(ctx, "test", bson.M{"_id": "1"})
 			branch, _ = branchService.GetBranchByID(branch.ID)
 
@@ -227,7 +227,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 		project, _ := projectService.CreateProject("concurrent-tt")
 		branches, _ := branchService.ListBranches(project.ID)
 		branch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 		// Create initial data
 		for i := 0; i < 100; i++ {
@@ -316,7 +316,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 		project, _ := projectService.CreateProject("nested-docs")
 		branches, _ := branchService.ListBranches(project.ID)
 		branch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 		// Create complex document
 		doc := bson.M{
@@ -349,7 +349,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 				"$push": bson.M{
 					"metadata.tags": "v2",
 				},
-			})
+			}, false)
 		assert.NoError(t, err)
 
 		branch, _ = branchService.GetBranchByID(branch.ID)
@@ -367,11 +367,11 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 
 		// Create branch and modify
 		featureBranch, _ := restoreService.CreateBranchAtLSN(project.ID, branch.ID, "nested-feature", checkpoint1)
-		featureInt := driverwal.NewInterceptor(walService, featureBranch, branchService)
+		featureInt := driverwal.NewInterceptor(walService, featureBranch, branchService, materializerService)
 
 		_, err = featureInt.UpdateOne(ctx, "complex",
 			bson.M{"_id": "complex1"},
-			bson.M{"$set": bson.M{"metadata.version": 99}})
+			bson.M{"$set": bson.M{"metadata.version": 99}}, false)
 		assert.NoError(t, err)
 
 		// Verify isolation
@@ -390,7 +390,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 		project, _ := projectService.CreateProject("large-scale")
 		branches, _ := branchService.ListBranches(project.ID)
 		branch := branches[0]
-		interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+		interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 		// Create checkpoints
 		checkpoints := []int64{}
@@ -450,7 +450,7 @@ func TestWeek3_StressTest(t *testing.T) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	projectService, _ := projectwal.NewProjectService(db, walService, branchService)
-	materializerService := materializer.NewService(walService)
+	materializerService := materializer.NewService(walService, branchService)
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	ctx := context.Background()
@@ -469,7 +469,7 @@ func TestWeek3_StressTest(t *testing.T) {
 			wg.Add(1)
 			go func(writerID int) {
 				defer wg.Done()
-				interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+				interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 
 				for i := 0; i < opsPerWriter; i++ {
 					doc := bson.M{
@@ -484,7 +484,7 @@ func TestWeek3_StressTest(t *testing.T) {
 						// Occasional updates
 						_, _ = interceptor.UpdateOne(ctx, "stress",
 							bson.M{"_id": fmt.Sprintf("w%d-doc%d", writerID, i-10)},
-							bson.M{"$set": bson.M{"updated": true}})
+							bson.M{"$set": bson.M{"updated": true}}, false)
 					}
 				}
 			}(w)

--- a/tests/wal/write_performance_test.go
+++ b/tests/wal/write_performance_test.go
@@ -9,6 +9,7 @@ import (
 
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
 	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/materializer"
 	"github.com/argon-lab/argon/internal/wal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,8 @@ func TestWriteOperationPerformance(t *testing.T) {
 	branch, err := branchService.CreateBranch("perf-test", "main", "")
 	require.NoError(t, err)
 
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	materializerService := materializer.NewService(walService, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 	ctx := context.Background()
 
 	t.Run("Sequential insert performance", func(t *testing.T) {
@@ -132,7 +134,7 @@ func TestWriteOperationPerformance(t *testing.T) {
 			// Update
 			filter := bson.M{"_id": fmt.Sprintf("mixed-%d", i)}
 			update := bson.M{"$set": bson.M{"value": i * 2}}
-			_, err = interceptor.UpdateOne(ctx, "mixed_ops", filter, update)
+			_, err = interceptor.UpdateOne(ctx, "mixed_ops", filter, update, false)
 			assert.NoError(t, err)
 
 			// Delete every other document
@@ -205,7 +207,8 @@ func BenchmarkWALWrites(b *testing.B) {
 	walService, _ := wal.NewService(db)
 	branchService, _ := branchwal.NewBranchService(db, walService)
 	branch, _ := branchService.CreateBranch("bench-test", "main", "")
-	interceptor := driverwal.NewInterceptor(walService, branch, branchService)
+	materializerService := materializer.NewService(walService, branchService)
+	interceptor := driverwal.NewInterceptor(walService, branch, branchService, materializerService)
 	ctx := context.Background()
 
 	b.Run("InsertOne", func(b *testing.B) {
@@ -232,7 +235,7 @@ func BenchmarkWALWrites(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			filter := bson.M{"_id": fmt.Sprintf("update-%d", i%100)}
 			update := bson.M{"$set": bson.M{"value": i}}
-			_, _ = interceptor.UpdateOne(ctx, "bench_updates", filter, update)
+			_, _ = interceptor.UpdateOne(ctx, "bench_updates", filter, update, false)
 		}
 		b.StopTimer()
 		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "ops/sec")


### PR DESCRIPTION
## The problem

Three correctness defects sat at the core of the WAL:

1. **Replay was nondeterministic.** Updates and deletes were logged as their original filter/update expressions and re-executed during replay, iterating a Go map and stopping at the "first" match — but Go map iteration order is randomized, so materializing the same WAL twice could produce different states. Time travel, branching and restore were all built on this.
2. **Sibling branches contaminated each other.** The "base" portion of a branch's history was fetched project-wide, so entries written by sibling branches below the fork point leaked into every other branch.
3. **Resets resurrected discarded history.** After `reset --to-lsn T`, the next write's LSN was necessarily higher than the discarded entries', so advancing the head brought the entire abandoned window back.

On top of that, the write surface lied: `UpdateOne`/`DeleteOne` returned hardcoded `MatchedCount: 1` / `DeletedCount: 1` regardless of outcome, inserts never checked for duplicate `_id`s, `UpdateMany`/`DeleteMany`/`ReplaceOne`/upsert didn't exist, and `Find()` returned a nil cursor.

## The design

**The log is now physical.** Every data entry is a put (full post-image of one document) or a delete (document ID). Replay is a pure fold — `state[id] = post` / `delete(state, id)` — so replaying a WAL prefix is deterministic *by construction*. Pre-images ride along for diff, undo and audit. `Append` validates all of this at the write boundary.

**Filters and update operators run exactly once, at write time.** The interceptor materializes the affected documents, applies the operators, and logs the outcome. The new matcher is BSON-aware (cross-type numeric comparison, ObjectIDs, dates, dotted paths, `$and/$or/$nor/$not`, array semantics, `$elemMatch`, `$regex`, ...) and update application preserves integer types (`$inc` on an int32 no longer corrupts it to float64). Unsupported operators fail loudly instead of being silently skipped. Multi-match scans run in sorted document-ID order, so "first match" is deterministic too.

**Branches materialize through their ancestry chain.** Each ancestor contributes only its own entries up to the next fork point — sibling isolation falls out of the traversal instead of being impossible. Branches created from a historical point now record their source as parent (previously they silently materialized from nothing).

**Resets record discarded LSN ranges** instead of just moving the head. Entries stay in the WAL for audit; materialization skips them. A branch forked *before* the reset legitimately captured that history and keeps it — the skip rule is `segment upper bound > range end`, which distinguishes pre-reset forks from post-reset readers purely by LSN arithmetic (the sequencer never rewinds).

## Also in this change

- Real matched/modified/deleted/upserted counts; duplicate-key detection on insert (single and batched); `UpdateMany`, `DeleteMany`, `ReplaceOne`, upsert; batched appends reserving one contiguous LSN range.
- `Find()` returns a real cursor (`mongo.NewCursorFromDocuments`); `FindOne`/`CountDocuments` share the same resolution path with an `_id` point-lookup fast path backed by a new `(branch, collection, document, lsn)` index.
- Control entries reference branches by ID, matching data entries.
- Imports append batched put entries directly (one sequencer reservation per batch) instead of walking the interceptor per document.
- Document `_id`s of non-ObjectID/string types are canonicalized via extended JSON so different BSON types can't collide on the same state key.
- Legacy v1 entries are rejected by the materializer with a pointer to the migration (migration tool lands separately).

## Tests

- New ancestry suite: child inherits parent state at fork; child doesn't see post-fork parent writes; sibling writes below the fork point don't leak; two-hop chains.
- Restore suite covers the discarded-range semantics including the pre-reset backup branch case.
- Interceptor suite asserts real counts, no-op updates writing nothing, post/pre-images in entries, duplicate rejection, upsert, Many-variants, replace.
- A determinism check materializes the same branch 20× and requires identical state.
- Full suite green locally against MongoDB 7 (replica set); `golangci-lint` clean.

## Known M1 limitations (by design, until M3 moves reads onto a real mongod)

- Find options (sort/skip/limit/projection) are not applied; results come in canonical document-ID order; no aggregation.
- Resolve-then-append is not atomic: concurrent writers to the same branch are last-writer-wins at document level.
- Non-`_id` filters materialize the collection per operation (bounded by branch history until M2 snapshots).
