### PR TITLE
Replay determinism property tests, v1 WAL migration, architecture docs

### DIFF
--- a/cli/cmd/migrate.go
+++ b/cli/cmd/migrate.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate-wal",
+	Short: "Migrate a project's WAL from schema v1 to v2",
+	Long: `Rewrites legacy schema-v1 WAL entries (which stored filter/update
+expressions) into the v2 physical-log format (full post/pre-images) in
+place, preserving LSNs. v2 replay refuses legacy entries because they
+cannot be replayed deterministically; run this once per project after
+upgrading.
+
+The migration is idempotent: running it again finds nothing to rewrite.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+
+		fmt.Printf("Migrating WAL for project %q (%s)...\n", project.Name, project.ID)
+		result, err := services.Migrate.MigrateProject(context.Background(), project.ID)
+		if err != nil {
+			return fmt.Errorf("migration failed: %w", err)
+		}
+
+		fmt.Printf("Done.\n")
+		fmt.Printf("  Branches visited:  %d\n", result.BranchesVisited)
+		fmt.Printf("  Entries rewritten: %d\n", result.EntriesRewritten)
+		fmt.Printf("  Entries removed:   %d (no-op legacy operations)\n", result.EntriesRemoved)
+		return nil
+	},
+}
+
+func init() {
+	migrateCmd.Flags().StringP("project", "p", "", "Project name to migrate (required)")
+	rootCmd.AddCommand(migrateCmd)
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,452 +2,197 @@
 
 ## Overview
 
-Argon is a Git-like version control system for MongoDB, designed specifically for ML/AI workflows. It provides instant branching, efficient storage, and seamless integration with ML tools.
+Argon is a Git-like version control layer for MongoDB: branch, time-travel,
+diff and restore your data the way you manage code. It is built on a
+write-ahead log (WAL) whose replay is **deterministic by construction**, with
+branches implemented as pointers into that log.
 
-## Table of Contents
+This document describes the system as implemented today. Where a capability
+is planned but not built, it says so explicitly.
 
-1. [System Architecture](#system-architecture)
-2. [Core Components](#core-components)
-3. [Data Flow](#data-flow)
-4. [Storage Architecture](#storage-architecture)
-5. [Branching Mechanism](#branching-mechanism)
-6. [Performance Design](#performance-design)
-7. [Security Architecture](#security-architecture)
-8. [Scaling Strategy](#scaling-strategy)
+## Design principles
 
-## System Architecture
+1. **Determinism first.** Replaying the same WAL prefix any number of times
+   yields the same state. Every consumer (time travel, branching, restore,
+   diff) is built on this property, so it is enforced structurally, not by
+   convention.
+2. **Physical log, not logical log.** The WAL records outcomes (full
+   document images), never expressions (filters / update operators).
+   Expressions are resolved exactly once, at write time.
+3. **Branches are pointers.** Creating a branch writes one metadata document
+   — O(1), no data copying. State is reconstructed on demand by replaying
+   the branch's ancestry chain.
+4. **Ordering, never density.** LSN sequences may contain gaps (failed
+   writes, migrated no-ops). Consumers rely only on order.
 
-### High-Level Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         Client Layer                             │
-├─────────────────┬──────────────────┬────────────────────────────┤
-│   CLI (Go)      │   REST API       │   SDKs                     │
-│   argonctl      │   (Python)       │   Python/JS/Go            │
-└────────┬────────┴────────┬─────────┴──────────┬─────────────────┘
-         │                 │                     │
-         └─────────────────┴─────────────────────┘
-                           │
-┌──────────────────────────┴──────────────────────────────────────┐
-│                      Service Layer                               │
-├─────────────────┬──────────────────┬────────────────────────────┤
-│  Branch Engine  │  Storage Engine  │   Worker Pool              │
-│     (Go)        │      (Go)        │      (Go)                  │
-├─────────────────┼──────────────────┼────────────────────────────┤
-│ • Branch ops    │ • Compression    │ • Change processing        │
-│ • Merge logic   │ • Deduplication  │ • Background tasks         │
-│ • Isolation     │ • Cloud storage  │ • Garbage collection       │
-└────────┬────────┴────────┬─────────┴──────────┬─────────────────┘
-         │                 │                     │
-┌────────┴─────────────────┴─────────────────────┴────────────────┐
-│                       Data Layer                                 │
-├─────────────────────────┬───────────────────────────────────────┤
-│      MongoDB            │         Object Storage                │
-├─────────────────────────┼───────────────────────────────────────┤
-│ • Change streams        │ • S3 / GCS / Azure                    │
-│ • Metadata storage      │ • Local filesystem                    │
-│ • Branch tracking       │ • Compressed objects                  │
-└─────────────────────────┴───────────────────────────────────────┘
-```
-
-### Technology Stack
-
-- **Performance Layer (Go)**
-  - Branch engine
-  - Storage engine
-  - Worker pool
-  - CLI tool
-
-- **Productivity Layer (Python)**
-  - REST API (FastAPI)
-  - ML integrations
-  - Web dashboard (planned)
-
-- **Data Layer**
-  - MongoDB 4.4+ (change streams)
-  - Object storage (S3/GCS/Azure/Local)
-
-## Core Components
-
-### 1. Branch Engine (Go)
-
-Handles all branch-related operations with sub-500ms performance target.
-
-```go
-// Key interfaces
-type BranchEngine interface {
-    CreateBranch(name string, from string) (*Branch, error)
-    MergeBranch(source, target string, strategy MergeStrategy) error
-    DeleteBranch(name string) error
-    ListBranches() ([]*Branch, error)
-}
-
-type Branch struct {
-    ID           string
-    Name         string
-    Parent       string
-    CreatedAt    time.Time
-    LastActivity time.Time
-    Status       BranchStatus
-}
-```
-
-**Responsibilities:**
-- Branch creation and deletion
-- Merge operations
-- Conflict resolution
-- Branch metadata management
-
-### 2. Storage Engine (Go)
-
-Manages efficient storage with copy-on-write and compression.
-
-```go
-type StorageEngine interface {
-    Store(key string, data []byte) error
-    Retrieve(key string) ([]byte, error)
-    Delete(key string) error
-    Exists(key string) bool
-}
-
-type StorageBackend interface {
-    Put(ctx context.Context, key string, data []byte) error
-    Get(ctx context.Context, key string) ([]byte, error)
-    Delete(ctx context.Context, key string) error
-    List(ctx context.Context, prefix string) ([]string, error)
-}
-```
-
-**Features:**
-- ZSTD compression (42%+ savings)
-- Content-addressable storage
-- Deduplication
-- Multi-backend support
-
-### 3. Worker Pool (Go)
-
-Processes MongoDB change streams and background tasks.
-
-```go
-type WorkerPool struct {
-    workers    []*Worker
-    jobQueue   chan Job
-    resultChan chan Result
-    config     WorkerConfig
-}
-
-type Job interface {
-    Execute(ctx context.Context) (Result, error)
-    GetPriority() int
-    GetTimeout() time.Duration
-}
-```
-
-**Responsibilities:**
-- Change stream processing
-- Asynchronous operations
-- Batch processing
-- Garbage collection
-
-### 4. REST API (Python)
-
-Provides HTTP interface for all operations.
-
-```python
-# FastAPI application structure
-app = FastAPI(title="Argon API", version="1.0.0")
-
-@app.post("/branches")
-async def create_branch(branch: BranchCreate) -> BranchResponse:
-    """Create a new branch from source"""
-    pass
-
-@app.get("/branches/{branch_id}/changes")
-async def get_changes(
-    branch_id: str, 
-    limit: int = 100,
-    offset: int = 0
-) -> ChangesResponse:
-    """Get change history for a branch"""
-    pass
-```
-
-## Data Flow
-
-### Branch Creation Flow
+## System components
 
 ```
-1. Client Request
-   └─> API validates request
-       └─> Branch Engine checks permissions
-           └─> Create branch metadata in MongoDB
-               └─> Initialize change stream listener
-                   └─> Worker pool starts processing
-                       └─> Return success to client
-
-2. Background Processing
-   └─> Worker captures changes
-       └─> Storage engine compresses data
-           └─> Store in object storage
-               └─> Update branch statistics
+┌────────────────────────────────────────────────────────────┐
+│  Clients: CLI (argonctl) · Go SDK · Python SDK · REST API  │
+└──────────────────────────────┬─────────────────────────────┘
+                               │
+┌──────────────────────────────▼─────────────────────────────┐
+│  Core services (Go, internal/)                             │
+│  ├─ wal.Service          append/query the log              │
+│  ├─ wal.Sequencer        distributed LSN allocation        │
+│  ├─ branch.Service       branch metadata & ancestry        │
+│  ├─ materializer         deterministic replay              │
+│  ├─ timetravel           historical state queries          │
+│  ├─ restore              reset / branch-from-history       │
+│  ├─ driver (interceptor) write-time filter resolution      │
+│  ├─ importer             bulk import into put entries      │
+│  └─ migrate              v1 → v2 WAL migration             │
+└──────────────────────────────┬─────────────────────────────┘
+                               │
+┌──────────────────────────────▼─────────────────────────────┐
+│  MongoDB (storage)                                         │
+│  wal_log · wal_branches · wal_projects · wal_counters      │
+└────────────────────────────────────────────────────────────┘
 ```
 
-### Data Write Flow
+## The WAL
 
-```
-1. Application writes to MongoDB
-   └─> Change stream captures operation
-       └─> Worker pool receives change
-           └─> Determine affected branches
-               └─> Apply branch isolation rules
-                   └─> Compress and store change
-                       └─> Update branch metadata
-```
+### Entry format (schema v2)
 
-### Data Read Flow
+Every data entry is a self-contained physical record about exactly one
+document:
 
-```
-1. Application queries MongoDB
-   └─> Branch context determines data visibility
-       └─> Apply branch-specific filters
-           └─> Merge with base data if needed
-               └─> Return filtered results
-```
+| Field | Meaning |
+|---|---|
+| `lsn` | Position in the project's sequence (unique per project) |
+| `project_id`, `branch_id` | Ownership; branch IDs everywhere, including control entries |
+| `operation` | `put` \| `delete` \| control ops (`create_branch`, ...) |
+| `collection`, `document_id` | The document the entry is about |
+| `post` | Compressed full post-image (required on every put) |
+| `pre` | Compressed pre-image (puts over existing docs, deletes) — powers diff, undo, audit |
+| `txn_id` | Reserved: atomic-visibility grouping |
+| `actor` | Who wrote it (`user:...`, `agent:...`, `importer`) |
+| `v` | Schema version (2) |
 
-## Storage Architecture
+Replay is a pure fold: `put` ⇒ `state[document_id] = post`, `delete` ⇒
+`delete(state, document_id)`. No filter or update operator is ever
+re-executed during replay — that is what makes materialization
+deterministic. `Append` validates these invariants at the write boundary.
 
-### Object Storage Layout
+Post/pre-images are compressed per entry (zstd by default, with gzip/snappy
+variants and a "don't compress if it doesn't help" floor).
 
-```
-/argon-storage/
-├── branches/
-│   ├── main/
-│   │   ├── metadata.json
-│   │   └── collections/
-│   │       ├── users/
-│   │       │   ├── chunk-00001.zst
-│   │       │   └── chunk-00002.zst
-│   │       └── products/
-│   │           └── chunk-00001.zst
-│   └── feature-branch/
-│       ├── metadata.json
-│       └── changes/
-│           ├── 2025-07-18-00001.zst
-│           └── 2025-07-18-00002.zst
-├── snapshots/
-│   └── snap-123456/
-│       └── full-backup.zst
-└── temp/
-    └── merge-ops/
-```
+### LSN allocation
 
-### Compression Strategy
+LSNs are reserved through an atomic `findOneAndUpdate($inc)` on a per-project
+counter document (`wal_counters`), so any number of Argon processes can write
+concurrently without collisions. Failed writes leave gaps; reservations are
+never rolled back (a rollback under concurrency could hand a used LSN to a
+later writer). Batches reserve one contiguous range and must be
+single-project.
 
-```go
-type CompressionConfig struct {
-    Algorithm string // "zstd", "gzip", "none"
-    Level     int    // 1-9 for gzip, 1-22 for zstd
-    MinSize   int    // Minimum size to compress
-}
+## Branches and ancestry
 
-// Achieved compression ratios:
-// - JSON documents: 60-80% reduction
-// - Binary data: 20-40% reduction
-// - Already compressed: 0-5% reduction
-```
+A branch is `(id, parent_id, base_lsn, head_lsn, discarded_ranges)`:
 
-### Storage Optimization
+- `base_lsn` — the fork point: the parent-chain LSN this branch started from.
+- `head_lsn` — the newest entry belonging to this branch. Writers advance it
+  with `$max` (monotonic under concurrency); only restore may lower it.
+- A branch's own entries live in `(base_lsn, head_lsn]`. Everything at or
+  below `base_lsn` is inherited from the ancestry chain via `parent_id`.
 
-1. **Deduplication**: Content-addressable storage with SHA-256
-2. **Chunking**: Large collections split into manageable chunks
-3. **Tiering**: Hot/cold data separation
-4. **Caching**: LRU cache for frequently accessed objects
+**Materialization** walks the chain root-first: each ancestor contributes
+only its own entries up to the next fork point. Sibling branches never
+appear in each other's chains — isolation falls out of the traversal.
+Deleted parents still anchor their descendants' history (branch metadata is
+soft-deleted).
 
-## Branching Mechanism
+### Reset and discarded ranges
 
-### Current Architecture (v1.0) - Collection Prefixing
+`reset --to-lsn T` records the abandoned window `[T+1, old_head]` in the
+branch's `discarded_ranges` and lowers the head. The entries stay in the WAL
+for audit; materialization skips them.
 
-Each branch maintains isolated data through collection prefixing:
+The skip rule is `segment upper bound > range end`: because the sequencer
+never rewinds, any post-reset write or fork lands strictly above the
+discarded window, while a branch forked *before* the reset has its fork
+point at or below it. Pre-reset forks therefore keep the history they
+legitimately captured, and post-reset readers never resurrect it.
 
-```javascript
-// Original collection: "users"
-// Branch "feature-x": "branch_feature_x_users"
+## Write path (SDK / interceptor)
 
-db.users.insert({name: "John"})        // Goes to main
-db.branch_feature_x_users.insert(...)  // Goes to feature-x
-```
+Applications write through the Argon driver wrapper, which resolves each
+operation against current branch state and logs the outcome:
 
-### Future Architecture (v2.0) - WAL-Based Branching
+1. Resolve the filter. `_id` equality takes a point-lookup fast path over
+   the `(branch, collection, document, lsn)` index; other filters
+   materialize the collection and scan in **sorted document-ID order**, so
+   "first match" is deterministic.
+2. Apply update operators to produce the post-image (`$set`, `$unset`,
+   `$inc`, `$mul`, `$min`, `$max`, `$rename`, `$push`, `$addToSet`, `$pull`,
+   `$pop`, `$setOnInsert`, `$currentDate`; integer types are preserved).
+3. Append put/delete entries (batched operations reserve one LSN range) and
+   advance the branch head.
 
-We're implementing a Write-Ahead Log (WAL) architecture for the open-source version:
+Real results are returned (matched/modified/deleted/upserted counts,
+duplicate-key errors on insert). Unsupported query or update operators fail
+loudly rather than being silently ignored.
 
-```javascript
-// All operations go through WAL
-// Branches are just pointers to LSN (Log Sequence Number)
-branch: {
-  name: "feature-x",
-  headLSN: 12345,  // Points to position in WAL
-  baseLSN: 12000   // Where branch was created
-}
-```
+The filter matcher supports implicit equality, `$eq/$ne/$gt/$gte/$lt/$lte`,
+`$in/$nin`, `$exists`, `$regex`, `$size`, `$all`, `$elemMatch`,
+`$and/$or/$nor/$not`, dotted paths and array-any-element semantics, with
+BSON-aware cross-type numeric comparison.
 
-**Benefits of WAL approach:**
-- Branch creation: 500ms → 10ms (50x faster)
-- Storage: 10GB → 1.3GB for 10 branches (87% reduction)
-- True time-travel capabilities
-- Complete audit trail
+## Migration from schema v1
 
-[See detailed WAL implementation plan →](5_WEEK_WAL_IMPLEMENTATION_PLAN.md)
+v1 logged updates/deletes as expressions and re-executed them on replay —
+which was not deterministic (Go map iteration order). The materializer
+refuses v1 data entries with an error; `argon migrate-wal --project <name>`
+rewrites them in place (parents before children, LSNs preserved, no-op
+entries removed). Migration is idempotent.
 
-### Copy-on-Write Implementation
+## Consistency model (current, honest)
 
-```go
-type CopyOnWrite struct {
-    baseData   map[string][]byte
-    branchData map[string][]byte
-    tombstones map[string]bool
-}
+- **Deterministic replay** — the same WAL prefix always materializes to the
+  same state; verified by property tests (repeated replay, cross-instance,
+  historical LSNs, same-seed cross-database convergence).
+- **Read-your-writes per handle** — an interceptor advances its in-memory
+  head after each append.
+- **Resolve-then-append is not atomic** — concurrent writers to the same
+  branch are last-writer-wins at document level. The WAL itself stays
+  consistent because every entry is self-contained.
+- **Capture is driver-level** — only writes through the Argon SDK/driver are
+  logged today. Writes made directly to MongoDB bypass the WAL.
 
-func (c *CopyOnWrite) Read(key string) ([]byte, error) {
-    // Check tombstones first
-    if c.tombstones[key] {
-        return nil, ErrDeleted
-    }
-    
-    // Check branch data
-    if data, ok := c.branchData[key]; ok {
-        return data, nil
-    }
-    
-    // Fall back to base data
-    return c.baseData[key], nil
-}
-```
+## Known limitations and roadmap
 
-### Merge Strategies
+Current limitations (deliberate M1 scope):
 
-1. **Fast-forward**: Direct pointer update
-2. **Three-way merge**: Automatic conflict resolution
-3. **Manual merge**: User-guided conflict resolution
+- Reads materialize in memory: no indexes, no aggregation pipeline, Find
+  options (sort/skip/limit/projection) not applied; results in canonical
+  document-ID order.
+- Materialization replays from the branch root every time — cost grows with
+  history length.
+- No merge/diff commands yet (pre-images already carry the data they need).
 
-## Performance Design
+Planned next (in order):
 
-### Optimization Techniques
+1. **M2 — snapshot layer**: periodic collection snapshots at an LSN
+   (image layers), so materialization = nearest snapshot + bounded delta
+   replay; WAL segmentation, object-storage offload and GC with a PITR
+   retention window.
+2. **M3 — mongod as compute**: branches materialize into real MongoDB
+   databases (lazily), reads/writes run on mongod with change-stream
+   capture into the WAL, per-branch connection strings — full query
+   compatibility without reimplementing MongoDB.
+3. **M4 — merge and diff**: three-way document-level merge with reviewable
+   merge plans.
 
-1. **Parallel Processing**
-   ```go
-   func ProcessChanges(changes []Change) {
-       var wg sync.WaitGroup
-       sem := make(chan struct{}, runtime.NumCPU())
-       
-       for _, change := range changes {
-           sem <- struct{}{}
-           wg.Add(1)
-           go func(c Change) {
-               defer wg.Done()
-               defer func() { <-sem }()
-               processChange(c)
-           }(change)
-       }
-       wg.Wait()
-   }
-   ```
+## Storage collections
 
-2. **Batch Operations**
-   - Group small changes
-   - Bulk storage operations
-   - Aggregated statistics updates
+| Collection | Contents |
+|---|---|
+| `wal_log` | The log itself (entries as above) |
+| `wal_branches` | Branch metadata: pointers, ancestry, discarded ranges |
+| `wal_projects` | Project metadata |
+| `wal_counters` | Per-project LSN counters |
 
-3. **Caching Layers**
-   - Memory cache (LRU)
-   - Redis cache (optional)
-   - CDN for read-heavy workloads
-
-### Performance Metrics
-
-| Operation | Target | Achieved |
-|-----------|--------|----------|
-| Branch creation | < 500ms | **1ms** |
-| WAL write throughput | 10k ops/s | **37,905+ ops/s** |
-| Time travel query | < 100ms | **< 50ms** |
-| System startup | < 5s | **< 2s** |
-| Memory usage | < 100MB | **30-50MB** |
-
-## Security Architecture
-
-### Authentication & Authorization
-
-```python
-# API key authentication
-@app.middleware("http")
-async def authenticate(request: Request, call_next):
-    api_key = request.headers.get("X-API-Key")
-    if not verify_api_key(api_key):
-        return JSONResponse(status_code=401, content={"error": "Unauthorized"})
-    return await call_next(request)
-```
-
-### Data Encryption
-
-1. **At Rest**: Object storage encryption (SSE-S3, etc.)
-2. **In Transit**: TLS 1.3 for all connections
-3. **Key Management**: AWS KMS / Azure Key Vault / HashiCorp Vault
-
-### Access Control
-
-```yaml
-# Role-based access control
-roles:
-  viewer:
-    - branches:read
-    - changes:read
-  developer:
-    - branches:*
-    - changes:*
-    - snapshots:create
-  admin:
-    - "*"
-```
-
-## Scaling Strategy
-
-### Horizontal Scaling
-
-1. **API Servers**: Stateless, behind load balancer
-2. **Workers**: Distributed processing with partition assignment
-3. **Storage**: Sharded by branch ID
-
-### Vertical Scaling
-
-1. **MongoDB**: Larger instances for metadata
-2. **Workers**: More CPU cores for compression
-3. **Cache**: Increased memory for hot data
-
-### Multi-Region Deployment
-
-```yaml
-regions:
-  us-east-1:
-    primary: true
-    mongodb: "mongodb+srv://us-east-1.cluster.mongodb.net"
-    storage: "s3://argon-us-east-1"
-  eu-west-1:
-    primary: false
-    mongodb: "mongodb+srv://eu-west-1.cluster.mongodb.net"
-    storage: "s3://argon-eu-west-1"
-    
-replication:
-  mode: "async"
-  lag_threshold: "5m"
-```
-
-### Capacity Planning
-
-| Component | Small | Medium | Large |
-|-----------|-------|--------|-------|
-| API Servers | 2 × 2CPU/4GB | 4 × 4CPU/8GB | 8 × 8CPU/16GB |
-| Workers | 2 × 4CPU/8GB | 4 × 8CPU/16GB | 8 × 16CPU/32GB |
-| MongoDB | M10 | M30 | M60 |
-| Storage | 1TB | 10TB | 100TB |
-| Throughput | 1K ops/s | 10K ops/s | 100K ops/s |
+Indexes on `wal_log`: unique `(project_id, lsn)`;
+`(branch_id, collection, lsn)`; `(branch_id, collection, document_id, lsn)`;
+`timestamp`.

--- a/internal/branch/wal/service.go
+++ b/internal/branch/wal/service.go
@@ -211,6 +211,25 @@ func (s *BranchService) ListBranches(projectID string) ([]*wal.Branch, error) {
 	return branches, nil
 }
 
+// ListBranchesAny lists all branches for a project including deleted ones.
+// Deleted branches can still anchor live descendants' history, so tools
+// that walk every timeline (e.g. WAL migration) must see them.
+func (s *BranchService) ListBranchesAny(projectID string) ([]*wal.Branch, error) {
+	ctx := context.Background()
+	cursor, err := s.collection.Find(ctx, bson.M{"project_id": projectID})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var branches []*wal.Branch
+	if err := cursor.All(ctx, &branches); err != nil {
+		return nil, err
+	}
+
+	return branches, nil
+}
+
 // DeleteBranch deletes a branch (simple version - just removes the pointer)
 func (s *BranchService) DeleteBranch(projectID, name string) error {
 	ctx := context.Background()

--- a/internal/migrate/service.go
+++ b/internal/migrate/service.go
@@ -1,0 +1,403 @@
+// Package migrate rewrites legacy schema-v1 WAL entries into the v2
+// physical-log format in place.
+//
+// v1 logged updates and deletes as their original filter/update expressions;
+// v2 logs the resolved outcome (post/pre-images), which is what makes replay
+// deterministic. Migration therefore has to resolve those expressions one
+// final time: branches are processed parents-first, each branch's data
+// entries are walked in LSN order over a materialized running state, and
+// every legacy entry is rewritten as a put/delete with images — preserving
+// its LSN. Legacy update/delete entries that matched nothing are removed
+// entirely; the resulting LSN gaps are harmless because WAL consumers rely
+// on ordering, never density.
+//
+// Fidelity note: v1 replay resolved "first match" through randomized Go map
+// iteration, so for multi-match filters there is no single historical truth
+// to reproduce. Migration resolves first-match in sorted document-ID order,
+// the same deterministic rule the v2 write path uses.
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/argon-lab/argon/internal/wal"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Service migrates a project's WAL from schema v1 to v2.
+type Service struct {
+	db           *mongo.Database
+	walLog       *mongo.Collection
+	branches     *branchwal.BranchService
+	materializer *materializer.Service
+	compressor   *wal.Compressor
+}
+
+// NewService creates a migration service over the given Argon database.
+func NewService(db *mongo.Database, branches *branchwal.BranchService, mat *materializer.Service) (*Service, error) {
+	compressor, err := wal.NewCompressor(nil)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{
+		db:           db,
+		walLog:       db.Collection("wal_log"),
+		branches:     branches,
+		materializer: mat,
+		compressor:   compressor,
+	}, nil
+}
+
+// Result summarizes one project's migration.
+type Result struct {
+	ProjectID        string
+	BranchesVisited  int
+	EntriesRewritten int
+	EntriesRemoved   int
+}
+
+// legacyEntry is the raw shape of a wal_log document, including the v1
+// payload fields that the v2 Entry model no longer has.
+type legacyEntry struct {
+	ID            interface{}       `bson:"_id"`
+	SchemaVersion int               `bson:"v"`
+	LSN           int64             `bson:"lsn"`
+	BranchID      string            `bson:"branch_id"`
+	Operation     wal.OperationType `bson:"operation"`
+	Collection    string            `bson:"collection"`
+	DocumentID    string            `bson:"document_id"`
+	// v1 payloads
+	CompressedDocument    []byte `bson:"compressed_document"`
+	CompressedOldDocument []byte `bson:"compressed_old_document"`
+	// v2 payloads (present on entries written after the upgrade)
+	CompressedPostImage []byte                 `bson:"post"`
+	Metadata            map[string]interface{} `bson:"metadata"`
+}
+
+func (e *legacyEntry) isLegacyData() bool {
+	if e.SchemaVersion >= wal.EntrySchemaVersion {
+		return false
+	}
+	switch e.Operation {
+	case wal.LegacyOpInsert, wal.LegacyOpUpdate, wal.LegacyOpDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// MigrateProject rewrites all legacy entries of a project in place and
+// returns a summary. It is idempotent: a second run finds no legacy entries
+// and changes nothing.
+func (s *Service) MigrateProject(ctx context.Context, projectID string) (*Result, error) {
+	branches, err := s.branches.ListBranchesAny(projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list branches: %w", err)
+	}
+
+	// Parents were necessarily created before their children, so processing
+	// in creation order guarantees every ancestor is already migrated when
+	// a child materializes its fork-point state through the ancestry chain.
+	sort.Slice(branches, func(i, j int) bool { return branches[i].CreatedLSN < branches[j].CreatedLSN })
+
+	result := &Result{ProjectID: projectID}
+	for _, branch := range branches {
+		rewritten, removed, err := s.migrateBranch(ctx, branch)
+		if err != nil {
+			return nil, fmt.Errorf("branch %s (%s): %w", branch.Name, branch.ID, err)
+		}
+		result.BranchesVisited++
+		result.EntriesRewritten += rewritten
+		result.EntriesRemoved += removed
+	}
+	return result, nil
+}
+
+func (s *Service) migrateBranch(ctx context.Context, branch *wal.Branch) (rewritten, removed int, err error) {
+	// Starting state: everything inherited from (already migrated)
+	// ancestors up to the fork point.
+	state, err := s.materializer.MaterializeBranchAtLSN(branch, branch.BaseLSN)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to materialize fork state: %w", err)
+	}
+
+	// Buffer the branch's entries before rewriting any of them: mutating
+	// documents underneath a live cursor on the same collection risks
+	// re-visits or skips depending on the query plan.
+	cursor, err := s.walLog.Find(ctx,
+		bson.M{"branch_id": branch.ID, "lsn": bson.M{"$gt": branch.BaseLSN}},
+		options.Find().SetSort(bson.M{"lsn": 1}),
+	)
+	if err != nil {
+		return 0, 0, err
+	}
+	var entries []legacyEntry
+	if err := cursor.All(ctx, &entries); err != nil {
+		return 0, 0, fmt.Errorf("failed to load entries: %w", err)
+	}
+
+	for i := range entries {
+		entry := entries[i]
+		if entry.Collection == "" {
+			continue // Control entries need no migration.
+		}
+		collState := stateFor(state, entry.Collection)
+
+		if !entry.isLegacyData() {
+			// Already v2: fold it into the running state and move on.
+			if err := s.applyV2(&entry, collState); err != nil {
+				return rewritten, removed, err
+			}
+			continue
+		}
+
+		didRewrite, didRemove, err := s.migrateEntry(ctx, &entry, collState)
+		if err != nil {
+			return rewritten, removed, fmt.Errorf("entry LSN %d: %w", entry.LSN, err)
+		}
+		if didRewrite {
+			rewritten++
+		}
+		if didRemove {
+			removed++
+		}
+	}
+	return rewritten, removed, nil
+}
+
+// applyV2 folds an already-migrated entry into the running state.
+func (s *Service) applyV2(entry *legacyEntry, collState map[string]bson.M) error {
+	switch entry.Operation {
+	case wal.OpPut:
+		doc, err := s.decompressDoc(entry.CompressedPostImage)
+		if err != nil {
+			return err
+		}
+		collState[entry.DocumentID] = doc
+	case wal.OpDelete:
+		delete(collState, entry.DocumentID)
+	}
+	return nil
+}
+
+// migrateEntry resolves one legacy entry against the running state and
+// rewrites (or removes) it.
+func (s *Service) migrateEntry(ctx context.Context, entry *legacyEntry, collState map[string]bson.M) (rewritten, removed bool, err error) {
+	switch entry.Operation {
+	case wal.LegacyOpInsert:
+		doc, err := s.decompressDoc(entry.CompressedDocument)
+		if err != nil {
+			return false, false, err
+		}
+		docID := entry.DocumentID
+		if docID == "" {
+			id, exists := doc["_id"]
+			if !exists {
+				return false, false, fmt.Errorf("legacy insert has no document ID")
+			}
+			docID = wal.DocumentIDString(id)
+		}
+		if err := s.rewriteAsPut(ctx, entry, docID, doc, collState[docID]); err != nil {
+			return false, false, err
+		}
+		collState[docID] = doc
+		return true, false, nil
+
+	case wal.LegacyOpUpdate:
+		payload, err := s.decompressDoc(entry.CompressedDocument)
+		if err != nil {
+			return false, false, err
+		}
+		filter, update, err := decodeLegacyUpdatePayload(payload)
+		if err != nil {
+			return false, false, err
+		}
+		docID, oldDoc, found, err := firstMatch(collState, filter)
+		if err != nil {
+			return false, false, err
+		}
+		if !found {
+			return false, true, s.removeEntry(ctx, entry)
+		}
+		newDoc, err := driverwal.ApplyUpdate(oldDoc, update, false)
+		if err != nil {
+			return false, false, err
+		}
+		if err := s.rewriteAsPut(ctx, entry, docID, newDoc, oldDoc); err != nil {
+			return false, false, err
+		}
+		collState[docID] = newDoc
+		return true, false, nil
+
+	case wal.LegacyOpDelete:
+		filter, err := s.decompressDoc(entry.CompressedDocument)
+		if err != nil {
+			return false, false, err
+		}
+		docID, oldDoc, found, err := firstMatch(collState, filter)
+		if err != nil {
+			return false, false, err
+		}
+		if !found {
+			return false, true, s.removeEntry(ctx, entry)
+		}
+		if err := s.rewriteAsDelete(ctx, entry, docID, oldDoc); err != nil {
+			return false, false, err
+		}
+		delete(collState, docID)
+		return true, false, nil
+	}
+	return false, false, nil
+}
+
+func (s *Service) rewriteAsPut(ctx context.Context, entry *legacyEntry, docID string, post, pre bson.M) error {
+	postBytes, err := s.compressDoc(post)
+	if err != nil {
+		return err
+	}
+	set := bson.M{
+		"v":           wal.EntrySchemaVersion,
+		"operation":   wal.OpPut,
+		"document_id": docID,
+		"post":        postBytes,
+	}
+	if pre != nil {
+		preBytes, err := s.compressDoc(pre)
+		if err != nil {
+			return err
+		}
+		set["pre"] = preBytes
+	}
+	_, err = s.walLog.UpdateOne(ctx,
+		bson.M{"_id": entry.ID},
+		bson.M{
+			"$set":   set,
+			"$unset": bson.M{"compressed_document": "", "compressed_old_document": ""},
+		},
+	)
+	return err
+}
+
+func (s *Service) rewriteAsDelete(ctx context.Context, entry *legacyEntry, docID string, pre bson.M) error {
+	preBytes, err := s.compressDoc(pre)
+	if err != nil {
+		return err
+	}
+	_, err = s.walLog.UpdateOne(ctx,
+		bson.M{"_id": entry.ID},
+		bson.M{
+			"$set": bson.M{
+				"v":           wal.EntrySchemaVersion,
+				"operation":   wal.OpDelete,
+				"document_id": docID,
+				"pre":         preBytes,
+			},
+			"$unset": bson.M{"compressed_document": "", "compressed_old_document": ""},
+		},
+	)
+	return err
+}
+
+func (s *Service) removeEntry(ctx context.Context, entry *legacyEntry) error {
+	// The operation matched nothing, so it contributed no state; dropping
+	// it leaves an LSN gap, which is legal.
+	_, err := s.walLog.DeleteOne(ctx, bson.M{"_id": entry.ID})
+	return err
+}
+
+func (s *Service) decompressDoc(compressed []byte) (bson.M, error) {
+	if len(compressed) == 0 {
+		return nil, fmt.Errorf("entry has no payload")
+	}
+	raw, err := s.compressor.Decompress(compressed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompress payload: %w", err)
+	}
+	var doc bson.M
+	if err := bson.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("failed to decode payload: %w", err)
+	}
+	return doc, nil
+}
+
+func (s *Service) compressDoc(doc bson.M) ([]byte, error) {
+	raw, err := bson.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	return s.compressor.Compress(raw)
+}
+
+// decodeLegacyUpdatePayload unpacks the v1 {filter, update} envelope.
+func decodeLegacyUpdatePayload(payload bson.M) (filter, update bson.M, err error) {
+	toDoc := func(v interface{}, name string) (bson.M, error) {
+		switch d := v.(type) {
+		case bson.M:
+			return d, nil
+		case bson.Raw:
+			var doc bson.M
+			if err := bson.Unmarshal(d, &doc); err != nil {
+				return nil, fmt.Errorf("failed to decode legacy %s: %w", name, err)
+			}
+			return doc, nil
+		default:
+			// Whatever BSON shape the driver decoded it into: round-trip
+			// it through marshalling to normalize to a map.
+			raw, err := bson.Marshal(bson.M{"v": v})
+			if err != nil {
+				return nil, fmt.Errorf("failed to normalize legacy %s: %w", name, err)
+			}
+			var wrapper struct {
+				V bson.M `bson:"v"`
+			}
+			if err := bson.Unmarshal(raw, &wrapper); err != nil {
+				return nil, fmt.Errorf("failed to normalize legacy %s: %w", name, err)
+			}
+			return wrapper.V, nil
+		}
+	}
+	filter, err = toDoc(payload["filter"], "filter")
+	if err != nil {
+		return nil, nil, err
+	}
+	update, err = toDoc(payload["update"], "update")
+	if err != nil {
+		return nil, nil, err
+	}
+	return filter, update, nil
+}
+
+// firstMatch resolves a filter against a collection state in sorted
+// document-ID order.
+func firstMatch(collState map[string]bson.M, filter bson.M) (string, bson.M, bool, error) {
+	docIDs := make([]string, 0, len(collState))
+	for docID := range collState {
+		docIDs = append(docIDs, docID)
+	}
+	sort.Strings(docIDs)
+
+	for _, docID := range docIDs {
+		matched, err := driverwal.MatchesFilter(collState[docID], filter)
+		if err != nil {
+			return "", nil, false, err
+		}
+		if matched {
+			return docID, collState[docID], true, nil
+		}
+	}
+	return "", nil, false, nil
+}
+
+func stateFor(state map[string]map[string]bson.M, collection string) map[string]bson.M {
+	if _, exists := state[collection]; !exists {
+		state[collection] = make(map[string]bson.M)
+	}
+	return state[collection]
+}

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -9,6 +9,7 @@ import (
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
 	"github.com/argon-lab/argon/internal/importer"
 	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/argon-lab/argon/internal/migrate"
 	projectwal "github.com/argon-lab/argon/internal/project/wal"
 	"github.com/argon-lab/argon/internal/restore"
 	"github.com/argon-lab/argon/internal/timetravel"
@@ -26,6 +27,7 @@ type Services struct {
 	TimeTravel   *timetravel.Service
 	Restore      *restore.Service
 	Importer     *importer.ImportService
+	Migrate      *migrate.Service
 	Monitor      *wal.Monitor
 }
 
@@ -67,6 +69,10 @@ func NewServices() (*Services, error) {
 	timeTravelService := timetravel.NewService(walService, materializerService)
 	restoreService := restore.NewService(walService, branchService, materializerService, timeTravelService)
 	importerService := importer.NewImportService(walService, projectService, branchService)
+	migrateService, err := migrate.NewService(db, branchService, materializerService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create migration service: %w", err)
+	}
 
 	// Create monitor with production-ready configuration
 	monitorConfig := wal.MonitorConfig{
@@ -92,6 +98,7 @@ func NewServices() (*Services, error) {
 		TimeTravel:   timeTravelService,
 		Restore:      restoreService,
 		Importer:     importerService,
+		Migrate:      migrateService,
 		Monitor:      monitor,
 	}, nil
 }

--- a/tests/wal/determinism_property_test.go
+++ b/tests/wal/determinism_property_test.go
@@ -1,0 +1,223 @@
+package wal_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/argon-lab/argon/internal/restore"
+	"github.com/argon-lab/argon/internal/timetravel"
+	"github.com/argon-lab/argon/internal/wal"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// This file holds the M1 acceptance property: replaying the same WAL prefix
+// must always yield the same state — across repeated materializations,
+// across independent service instances (separate processes in production),
+// and at every historical LSN. The workload below deliberately exercises
+// every write path (insert single/batch, update with a mix of operators and
+// filters, replace, upsert, delete single/many), plus branch forks and a
+// reset, because those are exactly the code paths whose v1 versions were
+// nondeterministic.
+
+// applyRandomWorkload drives a seeded pseudo-random operation sequence
+// through an interceptor. Everything is derived from the seed, so two runs
+// with the same seed issue identical operations.
+func applyRandomWorkload(t *testing.T, rng *rand.Rand, interceptor *driverwal.Interceptor, numOps int) {
+	t.Helper()
+	ctx := context.Background()
+	collections := []string{"users", "orders", "items"}
+
+	for i := 0; i < numOps; i++ {
+		coll := collections[rng.Intn(len(collections))]
+		docID := fmt.Sprintf("doc-%d", rng.Intn(30))
+
+		switch rng.Intn(10) {
+		case 0, 1, 2: // insert (may collide with an existing _id; ignore dup errors)
+			_, _ = interceptor.InsertOne(ctx, coll, bson.M{
+				"_id":   docID,
+				"n":     int32(rng.Intn(1000)),
+				"group": rng.Intn(5),
+				"tags":  []interface{}{fmt.Sprintf("t%d", rng.Intn(3))},
+			})
+		case 3, 4: // update by _id with typed operators
+			_, err := interceptor.UpdateOne(ctx, coll,
+				bson.M{"_id": docID},
+				bson.M{
+					"$inc":  bson.M{"n": int32(rng.Intn(7) - 3)},
+					"$set":  bson.M{"touched": int64(i)},
+					"$push": bson.M{"tags": fmt.Sprintf("u%d", i%4)},
+				}, false)
+			require.NoError(t, err)
+		case 5: // update many by non-ID filter
+			_, err := interceptor.UpdateMany(ctx, coll,
+				bson.M{"group": rng.Intn(5)},
+				bson.M{"$inc": bson.M{"n": int32(1)}, "$unset": bson.M{"touched": ""}}, false)
+			require.NoError(t, err)
+		case 6: // upsert
+			_, err := interceptor.UpdateOne(ctx, coll,
+				bson.M{"_id": fmt.Sprintf("upsert-%d", rng.Intn(10))},
+				bson.M{"$set": bson.M{"n": int32(i)}, "$setOnInsert": bson.M{"origin": "upsert"}}, true)
+			require.NoError(t, err)
+		case 7: // replace
+			_, err := interceptor.ReplaceOne(ctx, coll,
+				bson.M{"_id": docID},
+				bson.M{"replaced": true, "n": int32(i)}, false)
+			require.NoError(t, err)
+		case 8: // delete one by comparison filter
+			_, err := interceptor.DeleteOne(ctx, coll, bson.M{"n": bson.M{"$gt": int32(rng.Intn(900))}})
+			require.NoError(t, err)
+		case 9: // delete many in a group
+			_, err := interceptor.DeleteMany(ctx, coll, bson.M{"group": rng.Intn(5), "n": bson.M{"$lt": int32(rng.Intn(200))}})
+			require.NoError(t, err)
+		}
+	}
+}
+
+// requireSameState asserts content-level equality of two branch states.
+func requireSameState(t *testing.T, want, got map[string]map[string]bson.M, label string) {
+	t.Helper()
+	require.Equal(t, len(want), len(got), "%s: collection sets differ", label)
+	for coll, wantDocs := range want {
+		require.Equal(t, wantDocs, got[coll], "%s: collection %s diverged", label, coll)
+	}
+}
+
+func TestProperty_ReplayDeterminism(t *testing.T) {
+	db := setupTestDB(t)
+	walService, err := wal.NewService(db)
+	require.NoError(t, err)
+	branchService, err := branchwal.NewBranchService(db, walService)
+	require.NoError(t, err)
+	mat := materializer.NewService(walService, branchService)
+	tt := timetravel.NewService(walService, mat)
+	restoreService := restore.NewService(walService, branchService, mat, tt)
+
+	const seed = 42
+
+	// Build a history that exercises forks and a reset on top of the
+	// random single-branch workload.
+	main, err := branchService.CreateBranch("prop-test", "main", "")
+	require.NoError(t, err)
+	mainWriter := driverwal.NewInterceptor(walService, main, branchService, mat)
+
+	rng := rand.New(rand.NewSource(seed))
+	applyRandomWorkload(t, rng, mainWriter, 120)
+
+	// Fork a feature branch mid-history and diverge both sides.
+	main, err = branchService.GetBranchByID(main.ID)
+	require.NoError(t, err)
+	feature, err := branchService.CreateBranch("prop-test", "feature", main.ID)
+	require.NoError(t, err)
+	featureWriter := driverwal.NewInterceptor(walService, feature, branchService, mat)
+	applyRandomWorkload(t, rng, featureWriter, 60)
+	applyRandomWorkload(t, rng, mainWriter, 60)
+
+	// Reset main part-way back, then write more on top: materialization
+	// must skip the discarded window while the pre-reset fork keeps it.
+	main, err = branchService.GetBranchByID(main.ID)
+	require.NoError(t, err)
+	resetTarget := main.HeadLSN - 20
+	_, err = restoreService.ResetBranchToLSN(main.ID, resetTarget)
+	require.NoError(t, err)
+	main, err = branchService.GetBranchByID(main.ID)
+	require.NoError(t, err)
+	applyRandomWorkload(t, rng, mainWriter, 30)
+
+	main, err = branchService.GetBranchByID(main.ID)
+	require.NoError(t, err)
+	feature, err = branchService.GetBranchByID(feature.ID)
+	require.NoError(t, err)
+
+	t.Run("Repeated materialization is identical", func(t *testing.T) {
+		refMain, err := mat.MaterializeBranch(main)
+		require.NoError(t, err)
+		refFeature, err := mat.MaterializeBranch(feature)
+		require.NoError(t, err)
+		require.NotEmpty(t, refMain, "workload must have produced state")
+
+		for i := 0; i < 50; i++ {
+			gotMain, err := mat.MaterializeBranch(main)
+			require.NoError(t, err)
+			requireSameState(t, refMain, gotMain, fmt.Sprintf("main run %d", i))
+
+			gotFeature, err := mat.MaterializeBranch(feature)
+			require.NoError(t, err)
+			requireSameState(t, refFeature, gotFeature, fmt.Sprintf("feature run %d", i))
+		}
+	})
+
+	t.Run("Independent service instances agree", func(t *testing.T) {
+		// A second wal.Service + materializer over the same database is the
+		// closest in-process stand-in for a separate reader process.
+		walService2, err := wal.NewService(db)
+		require.NoError(t, err)
+		branchService2, err := branchwal.NewBranchService(db, walService2)
+		require.NoError(t, err)
+		mat2 := materializer.NewService(walService2, branchService2)
+
+		ref, err := mat.MaterializeBranch(main)
+		require.NoError(t, err)
+		got, err := mat2.MaterializeBranch(main)
+		require.NoError(t, err)
+		requireSameState(t, ref, got, "cross-instance")
+	})
+
+	t.Run("Historical states are stable", func(t *testing.T) {
+		// Pick a few LSNs across the branch's history; each must
+		// materialize identically on repeated evaluation.
+		lsns := []int64{main.HeadLSN / 4, main.HeadLSN / 2, resetTarget, main.HeadLSN}
+		for _, lsn := range lsns {
+			if lsn <= 0 {
+				continue
+			}
+			ref, err := tt.GetBranchStateAtLSN(main, lsn)
+			require.NoError(t, err)
+			for i := 0; i < 10; i++ {
+				got, err := tt.GetBranchStateAtLSN(main, lsn)
+				require.NoError(t, err)
+				requireSameState(t, ref, got, fmt.Sprintf("lsn %d run %d", lsn, i))
+			}
+		}
+	})
+
+	t.Run("Same seed on a fresh database converges to the same state", func(t *testing.T) {
+		// Replay the exact same seeded workload (single-branch portion)
+		// against a second database: write-time resolution plus
+		// deterministic replay must land both databases on identical
+		// materialized content.
+		db2 := setupTestDB(t)
+		walServiceB, err := wal.NewService(db2)
+		require.NoError(t, err)
+		branchServiceB, err := branchwal.NewBranchService(db2, walServiceB)
+		require.NoError(t, err)
+		matB := materializer.NewService(walServiceB, branchServiceB)
+
+		mainA, err := branchService.CreateBranch("prop-replay", "main", "")
+		require.NoError(t, err)
+		mainB, err := branchServiceB.CreateBranch("prop-replay", "main", "")
+		require.NoError(t, err)
+
+		writerA := driverwal.NewInterceptor(walService, mainA, branchService, mat)
+		writerB := driverwal.NewInterceptor(walServiceB, mainB, branchServiceB, matB)
+
+		rngA := rand.New(rand.NewSource(7))
+		rngB := rand.New(rand.NewSource(7))
+		applyRandomWorkload(t, rngA, writerA, 100)
+		applyRandomWorkload(t, rngB, writerB, 100)
+
+		mainA, _ = branchService.GetBranchByID(mainA.ID)
+		mainB, _ = branchServiceB.GetBranchByID(mainB.ID)
+
+		stateA, err := mat.MaterializeBranch(mainA)
+		require.NoError(t, err)
+		stateB, err := matB.MaterializeBranch(mainB)
+		require.NoError(t, err)
+		requireSameState(t, stateA, stateB, "cross-database same-seed")
+	})
+}

--- a/tests/wal/migrate_test.go
+++ b/tests/wal/migrate_test.go
@@ -1,0 +1,186 @@
+package wal_test
+
+import (
+	"context"
+	"testing"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/argon-lab/argon/internal/migrate"
+	"github.com/argon-lab/argon/internal/wal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// insertLegacyEntry writes a raw schema-v1 wal_log document the way the old
+// code did: expression payloads in compressed_document, no "v" field. The
+// LSN is reserved through the sequencer so v2 entries can interleave.
+func insertLegacyEntry(t *testing.T, db *mongo.Database, walService *wal.Service, compressor *wal.Compressor,
+	projectID, branchID string, op wal.OperationType, collection, documentID string, payload bson.M) int64 {
+	t.Helper()
+
+	raw, err := bson.Marshal(payload)
+	require.NoError(t, err)
+	compressed, err := compressor.Compress(raw)
+	require.NoError(t, err)
+
+	// Reserve an LSN by appending a throwaway v2 entry? No — reserve
+	// directly through a counter bump: append via the wal_counters
+	// document to stay in sequence with future writes.
+	seq := wal.NewSequencer(db)
+	lsn, err := seq.Reserve(projectID, 1)
+	require.NoError(t, err)
+
+	_, err = db.Collection("wal_log").InsertOne(context.Background(), bson.M{
+		"lsn":                 lsn,
+		"project_id":          projectID,
+		"branch_id":           branchID,
+		"operation":           op,
+		"collection":          collection,
+		"document_id":         documentID,
+		"compressed_document": compressed,
+	})
+	require.NoError(t, err)
+	return lsn
+}
+
+func TestMigrate_LegacyWAL(t *testing.T) {
+	db := setupTestDB(t)
+	walService, err := wal.NewService(db)
+	require.NoError(t, err)
+	branchService, err := branchwal.NewBranchService(db, walService)
+	require.NoError(t, err)
+	mat := materializer.NewService(walService, branchService)
+	migrator, err := migrate.NewService(db, branchService, mat)
+	require.NoError(t, err)
+	compressor, err := wal.NewCompressor(nil)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	branch, err := branchService.CreateBranch("legacy-project", "main", "")
+	require.NoError(t, err)
+
+	// Legacy history: two inserts, an update by filter, a delete by filter,
+	// and an update that matches nothing (must be dropped).
+	insertLegacyEntry(t, db, walService, compressor, "legacy-project", branch.ID,
+		wal.LegacyOpInsert, "users", "u1", bson.M{"_id": "u1", "name": "Alice", "score": int32(10)})
+	insertLegacyEntry(t, db, walService, compressor, "legacy-project", branch.ID,
+		wal.LegacyOpInsert, "users", "u2", bson.M{"_id": "u2", "name": "Bob", "score": int32(20)})
+	insertLegacyEntry(t, db, walService, compressor, "legacy-project", branch.ID,
+		wal.LegacyOpUpdate, "users", "", bson.M{
+			"filter": bson.M{"name": "Alice"},
+			"update": bson.M{"$set": bson.M{"score": int32(15)}},
+		})
+	insertLegacyEntry(t, db, walService, compressor, "legacy-project", branch.ID,
+		wal.LegacyOpDelete, "users", "", bson.M{"name": "Bob"})
+	noopLSN := insertLegacyEntry(t, db, walService, compressor, "legacy-project", branch.ID,
+		wal.LegacyOpUpdate, "users", "", bson.M{
+			"filter": bson.M{"name": "Nobody"},
+			"update": bson.M{"$set": bson.M{"x": 1}},
+		})
+	lastLSN := noopLSN
+	require.NoError(t, branchService.UpdateBranchHead(branch.ID, lastLSN))
+	branch, err = branchService.GetBranchByID(branch.ID)
+	require.NoError(t, err)
+
+	t.Run("Materializer refuses legacy entries before migration", func(t *testing.T) {
+		_, err := mat.MaterializeCollection(branch, "users")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "migration")
+	})
+
+	t.Run("Migration rewrites history in place", func(t *testing.T) {
+		result, err := migrator.MigrateProject(ctx, "legacy-project")
+		require.NoError(t, err)
+		assert.Equal(t, 4, result.EntriesRewritten, "two inserts, one update, one delete")
+		assert.Equal(t, 1, result.EntriesRemoved, "the no-op update is dropped")
+
+		state, err := mat.MaterializeCollection(branch, "users")
+		require.NoError(t, err)
+		require.Len(t, state, 1, "Bob was deleted")
+		assert.Equal(t, "Alice", state["u1"]["name"])
+		assert.Equal(t, int32(15), state["u1"]["score"], "legacy $set resolved into the post-image")
+
+		// The rewritten entries are proper v2 physical records.
+		entries, err := walService.GetBranchEntries(branch.ID, "users", 0, lastLSN)
+		require.NoError(t, err)
+		require.Len(t, entries, 4)
+		for _, entry := range entries {
+			assert.False(t, entry.IsLegacy(), "entry LSN %d still legacy", entry.LSN)
+			assert.NotEmpty(t, entry.DocumentID)
+			if entry.Operation == wal.OpPut {
+				assert.NotEmpty(t, entry.PostImage)
+			}
+		}
+		// The resolved update carries the pre-image of the replaced doc.
+		update := entries[2]
+		assert.Equal(t, wal.OpPut, update.Operation)
+		var pre bson.M
+		require.NoError(t, bson.Unmarshal(update.PreImage, &pre))
+		assert.Equal(t, int32(10), pre["score"])
+	})
+
+	t.Run("Migration is idempotent", func(t *testing.T) {
+		result, err := migrator.MigrateProject(ctx, "legacy-project")
+		require.NoError(t, err)
+		assert.Zero(t, result.EntriesRewritten)
+		assert.Zero(t, result.EntriesRemoved)
+	})
+}
+
+func TestMigrate_MixedHistoryAndBranches(t *testing.T) {
+	db := setupTestDB(t)
+	walService, err := wal.NewService(db)
+	require.NoError(t, err)
+	branchService, err := branchwal.NewBranchService(db, walService)
+	require.NoError(t, err)
+	mat := materializer.NewService(walService, branchService)
+	migrator, err := migrate.NewService(db, branchService, mat)
+	require.NoError(t, err)
+	compressor, err := wal.NewCompressor(nil)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	main, err := branchService.CreateBranch("mixed-project", "main", "")
+	require.NoError(t, err)
+
+	// Legacy prefix on main.
+	insertLegacyEntry(t, db, walService, compressor, "mixed-project", main.ID,
+		wal.LegacyOpInsert, "items", "i1", bson.M{"_id": "i1", "v": int32(1)})
+	lsn := insertLegacyEntry(t, db, walService, compressor, "mixed-project", main.ID,
+		wal.LegacyOpInsert, "items", "i2", bson.M{"_id": "i2", "v": int32(2)})
+	require.NoError(t, branchService.UpdateBranchHead(main.ID, lsn))
+	main, _ = branchService.GetBranchByID(main.ID)
+
+	// Fork a child at the legacy point, then write v2 entries on both.
+	child, err := branchService.CreateBranch("mixed-project", "child", main.ID)
+	require.NoError(t, err)
+
+	postImage, err := bson.Marshal(bson.M{"_id": "i3", "v": int32(3)})
+	require.NoError(t, err)
+	_, err = walService.Append(&wal.Entry{
+		ProjectID:  "mixed-project",
+		BranchID:   child.ID,
+		Operation:  wal.OpPut,
+		Collection: "items",
+		DocumentID: "i3",
+		PostImage:  postImage,
+	})
+	require.NoError(t, err)
+	childHead := walService.GetCurrentLSN("mixed-project")
+	require.NoError(t, branchService.UpdateBranchHead(child.ID, childHead))
+
+	// Migrate: parent's legacy prefix must be rewritten and the child's
+	// ancestry (which crosses the migrated segment) must materialize.
+	_, err = migrator.MigrateProject(ctx, "mixed-project")
+	require.NoError(t, err)
+
+	child, _ = branchService.GetBranchByID(child.ID)
+	state, err := mat.MaterializeCollection(child, "items")
+	require.NoError(t, err)
+	assert.Len(t, state, 3, "child sees migrated parent history plus its own v2 write")
+	assert.EqualValues(t, 1, state["i1"]["v"])
+	assert.EqualValues(t, 3, state["i3"]["v"])
+}

--- a/tests/wal/restore_test.go
+++ b/tests/wal/restore_test.go
@@ -127,10 +127,13 @@ func TestRestore_ResetBranchToTime(t *testing.T) {
 		assert.NoError(t, err)
 
 		time.Sleep(50 * time.Millisecond)
-		midTime := time.Now()
 
 		_, err = interceptor.InsertOne(ctx, "events", bson.M{"_id": "e2", "time": "noon"})
 		assert.NoError(t, err)
+		// Capture the reset target after e2's insert completed, so e2's WAL
+		// timestamp is at or before it no matter how long the insert
+		// round-trips took under load.
+		afterNoon := time.Now()
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -140,8 +143,8 @@ func TestRestore_ResetBranchToTime(t *testing.T) {
 		// Update branch
 		branch, _ = branchService.GetBranchByID(branch.ID)
 
-		// Reset to mid time
-		resetBranch, err := restoreService.ResetBranchToTime(branch.ID, midTime.Add(25*time.Millisecond))
+		// Reset to the moment right after e2
+		resetBranch, err := restoreService.ResetBranchToTime(branch.ID, afterNoon)
 		assert.NoError(t, err)
 
 		// Verify state


### PR DESCRIPTION
Closes out the correctness milestone with its acceptance tests, the promised migration path, and documentation that matches the code.

## Property tests — the guarantee, executable

A seeded pseudo-random workload (inserts, operator-mix updates, upserts, replaces, single/bulk deletes over multiple collections) runs across a forked branch topology and through a mid-history reset. Then:

- **50 repeated materializations** of both branches must be identical.
- **Independent service instances** over the same database (the in-process stand-in for separate reader processes) must agree.
- **Historical states** at several LSNs — including the reset target — must be stable across repeated evaluation.
- **The same seed on a fresh database** must converge to identical materialized content (write-time resolution + deterministic replay, end to end).

## v1 → v2 WAL migration

`argon migrate-wal --project <name>` rewrites legacy schema-v1 entries in place:

- Branches are processed **parents-first** (creation order), so each fork-point state materializes through already-migrated ancestors.
- Legacy inserts become puts; legacy update/delete **expressions are resolved one final time** against the running state into puts/deletes with post/pre-images. First-match uses sorted document-ID order — v1's randomized map iteration means there is no single historical truth to reproduce for multi-match filters, so migration uses the same deterministic rule as the v2 write path (noted in the package docs).
- No-op legacy operations (matched nothing) are **removed**, leaving legal LSN gaps.
- LSNs are preserved, so branch pointers and discarded ranges stay valid. The tool is **idempotent**.

The materializer refuses unmigrated v1 data entries with an error pointing at this command.

## Architecture docs

`docs/ARCHITECTURE.md` now describes the system as implemented — entry format, sequencer, ancestry and discarded-range semantics, the write path, and an honest consistency-model section with the real M1 limitations. Descriptions of components that don't exist in this codebase (collection-prefix branching, S3 storage engine, change-stream workers) are gone; snapshots, mongod-as-compute and merge/diff live in the roadmap section where they belong.

## Tests

Full suite green locally against MongoDB 7 (replica set), `golangci-lint` clean. New: `TestProperty_ReplayDeterminism` (4 sub-properties), `TestMigrate_LegacyWAL` (rewrite, pre/post-image contents, idempotency, refusal-before-migration), `TestMigrate_MixedHistoryAndBranches` (legacy prefix + v2 suffix + fork across the migrated segment).
