### PR TITLE
Give test databases nanosecond-unique names

### DIFF
--- a/tests/wal/wal_core_test.go
+++ b/tests/wal/wal_core_test.go
@@ -2,6 +2,7 @@ package wal_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -30,8 +31,11 @@ func setupTestDB(t *testing.T) *mongo.Database {
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
 
-	// Use a unique database name for each test
-	dbName := "argon_wal_test_" + time.Now().Format("20060102150405")
+	// Use a unique database name for each test. Nanosecond resolution
+	// matters: tests that open two databases (e.g. the cross-database
+	// determinism property) collide on a second-granularity name when the
+	// machine is fast enough.
+	dbName := fmt.Sprintf("argon_wal_test_%d", time.Now().UnixNano())
 	db := client.Database(dbName)
 
 	// Clean up after test

--- a/tests/wal/write_performance_test.go
+++ b/tests/wal/write_performance_test.go
@@ -191,7 +191,7 @@ func setupBenchDB(b *testing.B) *mongo.Database {
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(b, err)
 
-	dbName := "argon_wal_bench_" + time.Now().Format("20060102150405")
+	dbName := fmt.Sprintf("argon_wal_bench_%d", time.Now().UnixNano())
 	db := client.Database(dbName)
 
 	b.Cleanup(func() {


### PR DESCRIPTION
The shared fixture named test databases with a second-resolution timestamp. Any test opening two databases — like the cross-database determinism property added in #4 — collides with itself on a fast machine: both handles resolve to the same database and the second project creation fails (`TestProperty_ReplayDeterminism/Same_seed_on_a_fresh_database_converges` failed exactly this way in the #4 CI run). Local Docker round-trips masked it; CI runners are quick enough to hit it.

Nanosecond names remove the whole collision class, for both the test and bench fixtures.