### PR TITLE
Add BulkWrite to the driver surface

### DIFF
--- a/internal/driver/wal/bulkwrite.go
+++ b/internal/driver/wal/bulkwrite.go
@@ -1,0 +1,131 @@
+package wal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// BulkWriteResult mirrors mongo.BulkWriteResult: aggregate counts plus the
+// upserted IDs keyed by the index of the model that produced them.
+type BulkWriteResult struct {
+	InsertedCount int64
+	MatchedCount  int64
+	ModifiedCount int64
+	DeletedCount  int64
+	UpsertedCount int64
+	UpsertedIDs   map[int64]interface{}
+}
+
+// BulkWriteError reports which model of a bulk operation failed. Callers
+// still receive the partial result accumulated before (and, for unordered
+// bulks, around) the failure, matching driver behavior.
+type BulkWriteError struct {
+	Index int
+	Err   error
+}
+
+func (e *BulkWriteError) Error() string {
+	return fmt.Sprintf("bulk write model %d: %v", e.Index, e.Err)
+}
+
+func (e *BulkWriteError) Unwrap() error { return e.Err }
+
+// BulkWrite executes a sequence of write models against one collection.
+//
+// Models always execute sequentially — each model must resolve against the
+// state produced by the ones before it (an update may target a document
+// inserted two models earlier). `ordered` only controls error handling, as
+// in MongoDB: ordered bulks stop at the first failing model, unordered
+// bulks attempt every model and report the failures afterwards.
+func (i *Interceptor) BulkWrite(ctx context.Context, collection string, models []mongo.WriteModel, ordered bool) (*BulkWriteResult, error) {
+	if len(models) == 0 {
+		return nil, fmt.Errorf("bulk write requires at least one model")
+	}
+
+	result := &BulkWriteResult{UpsertedIDs: make(map[int64]interface{})}
+	var failures []error
+
+	for idx, model := range models {
+		err := i.applyBulkModel(ctx, collection, int64(idx), model, result)
+		if err != nil {
+			failure := &BulkWriteError{Index: idx, Err: err}
+			if ordered {
+				return result, failure
+			}
+			failures = append(failures, failure)
+		}
+	}
+
+	if len(failures) > 0 {
+		return result, errors.Join(failures...)
+	}
+	return result, nil
+}
+
+func (i *Interceptor) applyBulkModel(ctx context.Context, collection string, idx int64, model mongo.WriteModel, result *BulkWriteResult) error {
+	switch m := model.(type) {
+	case *mongo.InsertOneModel:
+		if _, err := i.InsertOne(ctx, collection, m.Document); err != nil {
+			return err
+		}
+		result.InsertedCount++
+
+	case *mongo.UpdateOneModel:
+		r, err := i.UpdateOne(ctx, collection, m.Filter, m.Update, boolValue(m.Upsert))
+		if err != nil {
+			return err
+		}
+		accumulateUpdate(result, r, idx)
+
+	case *mongo.UpdateManyModel:
+		r, err := i.UpdateMany(ctx, collection, m.Filter, m.Update, boolValue(m.Upsert))
+		if err != nil {
+			return err
+		}
+		accumulateUpdate(result, r, idx)
+
+	case *mongo.ReplaceOneModel:
+		r, err := i.ReplaceOne(ctx, collection, m.Filter, m.Replacement, boolValue(m.Upsert))
+		if err != nil {
+			return err
+		}
+		accumulateUpdate(result, r, idx)
+
+	case *mongo.DeleteOneModel:
+		r, err := i.DeleteOne(ctx, collection, m.Filter)
+		if err != nil {
+			return err
+		}
+		result.DeletedCount += r.DeletedCount
+
+	case *mongo.DeleteManyModel:
+		r, err := i.DeleteMany(ctx, collection, m.Filter)
+		if err != nil {
+			return err
+		}
+		result.DeletedCount += r.DeletedCount
+
+	case nil:
+		return fmt.Errorf("write model is nil")
+
+	default:
+		return fmt.Errorf("unsupported write model type %T", model)
+	}
+	return nil
+}
+
+func accumulateUpdate(result *BulkWriteResult, r *UpdateResult, idx int64) {
+	result.MatchedCount += r.MatchedCount
+	result.ModifiedCount += r.ModifiedCount
+	result.UpsertedCount += r.UpsertedCount
+	if r.UpsertedID != nil {
+		result.UpsertedIDs[idx] = r.UpsertedID
+	}
+}
+
+func boolValue(b *bool) bool {
+	return b != nil && *b
+}

--- a/internal/driver/wal/collection.go
+++ b/internal/driver/wal/collection.go
@@ -108,6 +108,30 @@ func (c *Collection) DeleteMany(ctx context.Context, filter interface{}, opts ..
 	return &mongo.DeleteResult{DeletedCount: result.DeletedCount}, nil
 }
 
+// BulkWrite executes a sequence of write models. Models run sequentially so
+// each resolves against the state its predecessors produced; the ordered
+// option (default true) controls whether the bulk stops at the first error.
+func (c *Collection) BulkWrite(ctx context.Context, models []mongo.WriteModel, opts ...*options.BulkWriteOptions) (*mongo.BulkWriteResult, error) {
+	ordered := true
+	for _, o := range opts {
+		if o != nil && o.Ordered != nil {
+			ordered = *o.Ordered
+		}
+	}
+	result, err := c.interceptor.BulkWrite(ctx, c.name, models, ordered)
+	if result == nil {
+		return nil, err
+	}
+	return &mongo.BulkWriteResult{
+		InsertedCount: result.InsertedCount,
+		MatchedCount:  result.MatchedCount,
+		ModifiedCount: result.ModifiedCount,
+		DeletedCount:  result.DeletedCount,
+		UpsertedCount: result.UpsertedCount,
+		UpsertedIDs:   result.UpsertedIDs,
+	}, err
+}
+
 // Find executes a query and returns a real cursor over the matching
 // documents in canonical document-ID order.
 func (c *Collection) Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (*mongo.Cursor, error) {

--- a/tests/wal/bulkwrite_test.go
+++ b/tests/wal/bulkwrite_test.go
@@ -1,0 +1,133 @@
+package wal_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestInterceptor_BulkWrite(t *testing.T) {
+	db := setupTestDB(t)
+	_, _, _, interceptor := newInterceptorFixture(t, db, "bulk-project", "main")
+	ctx := context.Background()
+
+	t.Run("Mixed models accumulate real counts", func(t *testing.T) {
+		upsert := true
+		models := []mongo.WriteModel{
+			&mongo.InsertOneModel{Document: bson.M{"_id": "b1", "n": int32(1), "team": "red"}},
+			&mongo.InsertOneModel{Document: bson.M{"_id": "b2", "n": int32(2), "team": "red"}},
+			&mongo.InsertOneModel{Document: bson.M{"_id": "b3", "n": int32(3), "team": "blue"}},
+			&mongo.UpdateOneModel{
+				Filter: bson.M{"_id": "b1"},
+				Update: bson.M{"$inc": bson.M{"n": int32(10)}},
+			},
+			&mongo.UpdateManyModel{
+				Filter: bson.M{"team": "red"},
+				Update: bson.M{"$set": bson.M{"seen": true}},
+			},
+			&mongo.ReplaceOneModel{
+				Filter:      bson.M{"_id": "b3"},
+				Replacement: bson.M{"replaced": true},
+			},
+			&mongo.UpdateOneModel{
+				Filter: bson.M{"_id": "b4"},
+				Update: bson.M{"$set": bson.M{"n": int32(4)}},
+				Upsert: &upsert,
+			},
+			&mongo.DeleteOneModel{Filter: bson.M{"_id": "b2"}},
+		}
+
+		result, err := interceptor.BulkWrite(ctx, "bulk", models, true)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(3), result.InsertedCount)
+		assert.Equal(t, int64(4), result.MatchedCount, "b1 + two reds + b3 replace")
+		assert.Equal(t, int64(4), result.ModifiedCount)
+		assert.Equal(t, int64(1), result.DeletedCount)
+		assert.Equal(t, int64(1), result.UpsertedCount)
+		assert.Equal(t, "b4", result.UpsertedIDs[6], "upserted ID keyed by model index")
+
+		// A later model must see the state produced by an earlier one.
+		state, err := interceptor.FindMatches("bulk", bson.M{}, false)
+		require.NoError(t, err)
+		assert.Len(t, state, 3, "b1, b3(replaced), b4 remain")
+
+		matches, err := interceptor.FindMatches("bulk", bson.M{"_id": "b1"}, true)
+		require.NoError(t, err)
+		require.Len(t, matches, 1)
+		assert.EqualValues(t, 11, matches[0]["n"], "update saw the insert from the same bulk")
+		assert.Equal(t, true, matches[0]["seen"])
+	})
+
+	t.Run("Ordered bulk stops at the first failure", func(t *testing.T) {
+		models := []mongo.WriteModel{
+			&mongo.InsertOneModel{Document: bson.M{"_id": "o1"}},
+			&mongo.InsertOneModel{Document: bson.M{"_id": "o1"}}, // duplicate
+			&mongo.InsertOneModel{Document: bson.M{"_id": "o2"}}, // must not run
+		}
+
+		result, err := interceptor.BulkWrite(ctx, "ordered", models, true)
+		require.Error(t, err)
+
+		var bulkErr *driverwal.BulkWriteError
+		require.True(t, errors.As(err, &bulkErr))
+		assert.Equal(t, 1, bulkErr.Index, "failure reported at the duplicate's index")
+		assert.Equal(t, int64(1), result.InsertedCount, "partial result before the failure")
+
+		state, err := interceptor.FindMatches("ordered", bson.M{}, false)
+		require.NoError(t, err)
+		assert.Len(t, state, 1, "o2 was never attempted")
+	})
+
+	t.Run("Unordered bulk continues past failures", func(t *testing.T) {
+		models := []mongo.WriteModel{
+			&mongo.InsertOneModel{Document: bson.M{"_id": "u1"}},
+			&mongo.InsertOneModel{Document: bson.M{"_id": "u1"}}, // duplicate
+			&mongo.InsertOneModel{Document: bson.M{"_id": "u2"}}, // still runs
+		}
+
+		result, err := interceptor.BulkWrite(ctx, "unordered", models, false)
+		require.Error(t, err)
+		assert.Equal(t, int64(2), result.InsertedCount, "both non-failing inserts applied")
+
+		state, err := interceptor.FindMatches("unordered", bson.M{}, false)
+		require.NoError(t, err)
+		assert.Len(t, state, 2)
+	})
+
+	t.Run("Nil and unknown models are rejected", func(t *testing.T) {
+		_, err := interceptor.BulkWrite(ctx, "bad", []mongo.WriteModel{nil}, true)
+		require.Error(t, err)
+
+		_, err = interceptor.BulkWrite(ctx, "bad", nil, true)
+		require.Error(t, err, "empty bulks are rejected like the driver does")
+	})
+}
+
+func TestCollection_BulkWrite(t *testing.T) {
+	db := setupTestDB(t)
+	walService, branchService, branch, _ := newInterceptorFixture(t, db, "bulk-coll-project", "main")
+	mat := materializer.NewService(walService, branchService)
+	collection := driverwal.NewCollection("events", branch, walService, branchService, mat)
+	ctx := context.Background()
+
+	result, err := collection.BulkWrite(ctx, []mongo.WriteModel{
+		&mongo.InsertOneModel{Document: bson.M{"_id": "e1", "kind": "a"}},
+		&mongo.InsertOneModel{Document: bson.M{"_id": "e2", "kind": "b"}},
+		&mongo.DeleteManyModel{Filter: bson.M{"kind": "a"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.InsertedCount)
+	assert.Equal(t, int64(1), result.DeletedCount)
+
+	count, err := collection.CountDocuments(ctx, bson.M{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}


### PR DESCRIPTION
Completes the M1.5 write surface: `Collection.BulkWrite` / `Interceptor.BulkWrite` dispatching `mongo.WriteModel` sequences (insert / update one+many / replace / delete one+many, with upsert).

Models always execute **sequentially** — each must resolve against the state its predecessors produced (an update may target a document inserted two models earlier in the same bulk; there's a test asserting exactly that). The `ordered` option only controls error handling, as in MongoDB: ordered bulks stop at the first failing model, unordered bulks attempt every model and report the failures together (`errors.Join`). Real aggregate counts, `UpsertedIDs` keyed by model index, and partial results returned alongside errors, matching driver behavior.

Tests: mixed-model counts, in-bulk read-your-writes, ordered stop with indexed `BulkWriteError`, unordered continue, nil/unknown/empty model rejection, collection-level wrapper.