### PR TITLE
Collection snapshots: bounded replay depth for materialization

### DIFF
--- a/internal/driver/wal/canonical.go
+++ b/internal/driver/wal/canonical.go
@@ -28,6 +28,14 @@ func CanonicalBytes(v interface{}) ([]byte, error) {
 	return bson.Marshal(bson.D{{Key: "v", Value: canonical}})
 }
 
+// Canonicalize converts a BSON value into its canonical form: documents
+// become bson.D with recursively sorted keys, so marshalling the result is
+// deterministic. Snapshot serialization depends on this for content-level
+// chunk deduplication.
+func Canonicalize(v interface{}) (interface{}, error) {
+	return canonicalizeValue(v)
+}
+
 // CanonicalEqual reports whether two BSON values are equal under the
 // canonical (sorted-key) representation.
 func CanonicalEqual(a, b interface{}) (bool, error) {

--- a/internal/materializer/service.go
+++ b/internal/materializer/service.go
@@ -19,10 +19,25 @@ type BranchLookup interface {
 	GetBranchByIDAny(branchID string) (*wal.Branch, error)
 }
 
+// SnapshotSource serves materialized snapshots so replay can start from the
+// nearest one instead of the branch root. Implemented by the snapshot
+// service; nil means "always replay in full".
+type SnapshotSource interface {
+	// FindUsable returns the loaded state of the newest usable snapshot of
+	// (branch, collection) whose LSN lies in [minLSN, maxLSN], honoring
+	// discarded-range visibility for a read whose segment upper bound is
+	// readUpperBound. ok is false when no usable snapshot exists.
+	FindUsable(branch *wal.Branch, collection string, minLSN, maxLSN, readUpperBound int64) (state map[string]bson.M, lsn int64, ok bool, err error)
+	// CollectionsUpTo lists collections with snapshots for the branch in
+	// the LSN window.
+	CollectionsUpTo(branchID string, minLSN, maxLSN int64) ([]string, error)
+}
+
 // Service materializes state from WAL entries
 type Service struct {
-	wal      *wal.Service
-	branches BranchLookup
+	wal       *wal.Service
+	branches  BranchLookup
+	snapshots SnapshotSource
 }
 
 // NewService creates a new materializer service
@@ -31,6 +46,13 @@ func NewService(walService *wal.Service, branches BranchLookup) *Service {
 		wal:      walService,
 		branches: branches,
 	}
+}
+
+// SetSnapshotSource wires in a snapshot provider. A setter rather than a
+// constructor argument because the snapshot service itself needs the
+// materializer to build snapshots — the two reference each other.
+func (s *Service) SetSnapshotSource(src SnapshotSource) {
+	s.snapshots = src
 }
 
 // segment is one ancestor's contribution to a branch's history: the
@@ -90,7 +112,10 @@ func (s *Service) ancestrySegments(branch *wal.Branch, targetLSN int64) ([]segme
 }
 
 // MaterializeCollectionAtLSN builds the state of one collection as of
-// targetLSN, following the branch's ancestry chain.
+// targetLSN, following the branch's ancestry chain. When a snapshot source
+// is wired in, replay starts from the nearest usable snapshot (searching
+// leaf-most hop first, since a leaf snapshot covers the entire inherited
+// chain beneath it) and only the delta above it is replayed.
 func (s *Service) MaterializeCollectionAtLSN(branch *wal.Branch, collection string, targetLSN int64) (map[string]bson.M, error) {
 	segments, err := s.ancestrySegments(branch, targetLSN)
 	if err != nil {
@@ -98,7 +123,30 @@ func (s *Service) MaterializeCollectionAtLSN(branch *wal.Branch, collection stri
 	}
 
 	state := make(map[string]bson.M)
-	for _, seg := range segments {
+	startIdx := 0
+	if s.snapshots != nil {
+		for i := len(segments) - 1; i >= 0; i-- {
+			seg := segments[i]
+			snapState, snapLSN, ok, err := s.snapshots.FindUsable(seg.branch, collection, seg.fromLSN, seg.toLSN, seg.toLSN)
+			if err != nil {
+				return nil, fmt.Errorf("failed to look up snapshot for branch %s: %w", seg.branch.ID, err)
+			}
+			if ok {
+				// A snapshot's state already covers everything at or below
+				// its LSN, including the inherited chain — replay resumes
+				// right above it within this hop.
+				state = snapState
+				startIdx = i
+				segments[i].fromLSN = snapLSN + 1
+				break
+			}
+		}
+	}
+
+	for _, seg := range segments[startIdx:] {
+		if seg.fromLSN > seg.toLSN {
+			continue // Snapshot sits exactly at the segment's end.
+		}
 		entries, err := s.wal.GetBranchEntries(seg.branch.ID, collection, seg.fromLSN, seg.toLSN)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get entries for branch %s: %w", seg.branch.ID, err)
@@ -122,33 +170,42 @@ func (s *Service) MaterializeCollection(branch *wal.Branch, collection string) (
 }
 
 // MaterializeBranchAtLSN builds the state of every collection in a branch as
-// of targetLSN, keyed by collection name.
+// of targetLSN, keyed by collection name. Collections are discovered across
+// the ancestry chain (entries and snapshots) and each is materialized
+// through the snapshot-aware single-collection path.
 func (s *Service) MaterializeBranchAtLSN(branch *wal.Branch, targetLSN int64) (map[string]map[string]bson.M, error) {
 	segments, err := s.ancestrySegments(branch, targetLSN)
 	if err != nil {
 		return nil, err
 	}
 
-	state := make(map[string]map[string]bson.M)
+	collections := make(map[string]bool)
 	for _, seg := range segments {
-		entries, err := s.wal.GetBranchEntries(seg.branch.ID, "", seg.fromLSN, seg.toLSN)
+		names, err := s.wal.DistinctCollections(seg.branch.ID, seg.fromLSN, seg.toLSN)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get entries for branch %s: %w", seg.branch.ID, err)
+			return nil, fmt.Errorf("failed to list collections for branch %s: %w", seg.branch.ID, err)
 		}
-		for _, entry := range entries {
-			if entry.Collection == "" {
-				continue // Control operations carry no collection state.
+		for _, name := range names {
+			collections[name] = true
+		}
+		if s.snapshots != nil {
+			snapNames, err := s.snapshots.CollectionsUpTo(seg.branch.ID, seg.fromLSN, seg.toLSN)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list snapshot collections for branch %s: %w", seg.branch.ID, err)
 			}
-			if seg.branch.IsDiscardedForRead(entry.LSN, seg.toLSN) {
-				continue
-			}
-			if _, exists := state[entry.Collection]; !exists {
-				state[entry.Collection] = make(map[string]bson.M)
-			}
-			if err := s.ApplyEntry(state[entry.Collection], entry); err != nil {
-				return nil, fmt.Errorf("failed to apply entry LSN %d: %w", entry.LSN, err)
+			for _, name := range snapNames {
+				collections[name] = true
 			}
 		}
+	}
+
+	state := make(map[string]map[string]bson.M, len(collections))
+	for name := range collections {
+		collState, err := s.MaterializeCollectionAtLSN(branch, name, targetLSN)
+		if err != nil {
+			return nil, err
+		}
+		state[name] = collState
 	}
 
 	return state, nil

--- a/internal/snapshot/chunkstore.go
+++ b/internal/snapshot/chunkstore.go
@@ -1,0 +1,71 @@
+package snapshot
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// ChunkStore stores immutable, content-addressed blobs. The ID of a chunk
+// is the hex SHA-256 of its (compressed) bytes, so writing the same content
+// twice is free — snapshots of slowly-changing collections share most of
+// their chunks.
+//
+// The MongoDB implementation keeps chunks in a collection, which works on
+// any deployment with zero extra infrastructure; object-storage backends
+// (S3/GCS) can implement the same interface when WAL segments move there.
+type ChunkStore interface {
+	// Put stores data and returns its content address.
+	Put(ctx context.Context, data []byte) (string, error)
+	// Get retrieves a chunk by content address.
+	Get(ctx context.Context, id string) ([]byte, error)
+}
+
+// mongoChunkStore stores chunks in the wal_snapshot_chunks collection.
+type mongoChunkStore struct {
+	chunks *mongo.Collection
+}
+
+// NewMongoChunkStore creates a chunk store backed by a MongoDB collection.
+func NewMongoChunkStore(db *mongo.Database) ChunkStore {
+	return &mongoChunkStore{chunks: db.Collection("wal_snapshot_chunks")}
+}
+
+func chunkID(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *mongoChunkStore) Put(ctx context.Context, data []byte) (string, error) {
+	id := chunkID(data)
+	_, err := s.chunks.InsertOne(ctx, bson.M{
+		"_id":        id,
+		"data":       primitive.Binary{Data: data},
+		"size":       len(data),
+		"created_at": time.Now(),
+	})
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return id, nil // Content already stored: deduplicated.
+		}
+		return "", fmt.Errorf("failed to store chunk %s: %w", id, err)
+	}
+	return id, nil
+}
+
+func (s *mongoChunkStore) Get(ctx context.Context, id string) ([]byte, error) {
+	var doc struct {
+		Data primitive.Binary `bson:"data"`
+	}
+	err := s.chunks.FindOne(ctx, bson.M{"_id": id}).Decode(&doc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load chunk %s: %w", id, err)
+	}
+	return doc.Data.Data, nil
+}

--- a/internal/snapshot/codec.go
+++ b/internal/snapshot/codec.go
@@ -1,0 +1,110 @@
+package snapshot
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/wal"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// The snapshot payload format is a sequence of standard BSON documents,
+// each {k: <document ID>, d: <document>}, emitted in sorted-key order so
+// identical states always serialize to identical bytes (which is what makes
+// chunk-level deduplication effective). The stream is cut into chunks at a
+// size threshold and each chunk is compressed independently, so loading
+// never needs more than one chunk in memory at a time.
+
+// targetChunkSize is the pre-compression cut-off for a chunk. Kept well
+// under MongoDB's 16MB document limit even for incompressible data.
+const targetChunkSize = 4 * 1024 * 1024
+
+type frame struct {
+	Key string   `bson:"k"`
+	Doc bson.Raw `bson:"d"`
+}
+
+// encodeState serializes a collection state into compressed chunks.
+func encodeState(state map[string]bson.M, compressor *wal.Compressor) (chunks [][]byte, docCount int64, err error) {
+	keys := make([]string, 0, len(state))
+	for k := range state {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf []byte
+	flush := func() error {
+		if len(buf) == 0 {
+			return nil
+		}
+		compressed, err := compressor.Compress(buf)
+		if err != nil {
+			return fmt.Errorf("failed to compress snapshot chunk: %w", err)
+		}
+		chunks = append(chunks, compressed)
+		buf = nil
+		return nil
+	}
+
+	for _, k := range keys {
+		// Canonicalize before marshalling: documents are Go maps, and
+		// marshalling a map serializes keys in randomized order, which
+		// would give identical states different bytes — and different
+		// chunk hashes — on every run, defeating deduplication.
+		canonical, err := driverwal.Canonicalize(state[k])
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to canonicalize document %s: %w", k, err)
+		}
+		docRaw, err := bson.Marshal(canonical)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to marshal document %s: %w", k, err)
+		}
+		frameRaw, err := bson.Marshal(frame{Key: k, Doc: docRaw})
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to marshal frame for %s: %w", k, err)
+		}
+		buf = append(buf, frameRaw...)
+		docCount++
+		if len(buf) >= targetChunkSize {
+			if err := flush(); err != nil {
+				return nil, 0, err
+			}
+		}
+	}
+	if err := flush(); err != nil {
+		return nil, 0, err
+	}
+	return chunks, docCount, nil
+}
+
+// decodeChunk appends one decompressed chunk's frames into state.
+func decodeChunk(compressed []byte, compressor *wal.Compressor, state map[string]bson.M) error {
+	raw, err := compressor.Decompress(compressed)
+	if err != nil {
+		return fmt.Errorf("failed to decompress snapshot chunk: %w", err)
+	}
+
+	// A BSON stream: each document starts with its int32 total length.
+	for offset := 0; offset < len(raw); {
+		if offset+4 > len(raw) {
+			return fmt.Errorf("truncated snapshot chunk at offset %d", offset)
+		}
+		docLen := int(binary.LittleEndian.Uint32(raw[offset : offset+4]))
+		if docLen < 5 || offset+docLen > len(raw) {
+			return fmt.Errorf("corrupt snapshot frame at offset %d (len %d)", offset, docLen)
+		}
+		var f frame
+		if err := bson.Unmarshal(raw[offset:offset+docLen], &f); err != nil {
+			return fmt.Errorf("failed to decode snapshot frame at offset %d: %w", offset, err)
+		}
+		var doc bson.M
+		if err := bson.Unmarshal(f.Doc, &doc); err != nil {
+			return fmt.Errorf("failed to decode document %s: %w", f.Key, err)
+		}
+		state[f.Key] = doc
+		offset += docLen
+	}
+	return nil
+}

--- a/internal/snapshot/models.go
+++ b/internal/snapshot/models.go
@@ -1,0 +1,39 @@
+// Package snapshot implements collection snapshots — the "image layer" that
+// bounds replay depth. A snapshot captures the fully materialized state of
+// one collection on one branch at one LSN; materialization then becomes
+// "load nearest snapshot at or below the target, replay only the delta"
+// instead of replaying from the branch root.
+package snapshot
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// Snapshot is the manifest of one collection snapshot. The document data
+// itself lives in content-addressed chunks (see ChunkStore); the manifest
+// references them by hash, so identical chunks are shared across snapshots.
+type Snapshot struct {
+	ID         primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+	ProjectID  string             `bson:"project_id" json:"project_id"`
+	BranchID   string             `bson:"branch_id" json:"branch_id"`
+	Collection string             `bson:"collection" json:"collection"`
+
+	// LSN is the position this snapshot reflects: the state equals a full
+	// ancestry replay of the collection up to and including this LSN.
+	LSN int64 `bson:"lsn" json:"lsn"`
+
+	// RangesApplied is how many of the branch's discarded ranges existed
+	// (and were therefore honored) when this snapshot was built. Discarded
+	// ranges are append-only, so a reader can tell whether a later reset
+	// invalidated this snapshot by looking only at ranges with index >=
+	// RangesApplied. This keeps reset itself completely unaware of
+	// snapshots.
+	RangesApplied int `bson:"ranges_applied" json:"ranges_applied"`
+
+	ChunkIDs  []string  `bson:"chunk_ids" json:"chunk_ids"`
+	DocCount  int64     `bson:"doc_count" json:"doc_count"`
+	SizeBytes int64     `bson:"size_bytes" json:"size_bytes"`
+	CreatedAt time.Time `bson:"created_at" json:"created_at"`
+}

--- a/internal/snapshot/service.go
+++ b/internal/snapshot/service.go
@@ -1,0 +1,232 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/argon-lab/argon/internal/wal"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Service creates and serves collection snapshots.
+type Service struct {
+	manifests    *mongo.Collection
+	chunks       ChunkStore
+	branches     *branchwal.BranchService
+	materializer *materializer.Service
+	compressor   *wal.Compressor
+}
+
+// NewService creates a snapshot service. It registers itself as the
+// materializer's snapshot source, so materialization transparently starts
+// from the nearest usable snapshot instead of replaying from the branch
+// root.
+func NewService(db *mongo.Database, branches *branchwal.BranchService, mat *materializer.Service) (*Service, error) {
+	compressor, err := wal.NewCompressor(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Service{
+		manifests:    db.Collection("wal_snapshots"),
+		chunks:       NewMongoChunkStore(db),
+		branches:     branches,
+		materializer: mat,
+		compressor:   compressor,
+	}
+
+	ctx := context.Background()
+	_, err = s.manifests.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "branch_id", Value: 1},
+				{Key: "collection", Value: 1},
+				{Key: "lsn", Value: -1},
+			},
+		},
+		{
+			Keys: bson.M{"project_id": 1},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create snapshot indexes: %w", err)
+	}
+
+	mat.SetSnapshotSource(s)
+	return s, nil
+}
+
+// CreateSnapshot materializes every collection of the branch at the given
+// LSN and stores one snapshot per collection. Because materialization
+// itself starts from the previous snapshot when one exists, successive
+// snapshots are built incrementally, and unchanged collections re-serialize
+// to identical chunks that deduplicate away in the chunk store.
+func (s *Service) CreateSnapshot(ctx context.Context, branchID string, lsn int64) ([]*Snapshot, error) {
+	branch, err := s.branches.GetBranchByIDAny(branchID)
+	if err != nil {
+		return nil, fmt.Errorf("branch %s not found: %w", branchID, err)
+	}
+	if lsn <= branch.BaseLSN || lsn > branch.HeadLSN {
+		return nil, fmt.Errorf("snapshot LSN %d outside branch range (%d, %d]", lsn, branch.BaseLSN, branch.HeadLSN)
+	}
+
+	state, err := s.materializer.MaterializeBranchAtLSN(branch, lsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to materialize branch at LSN %d: %w", lsn, err)
+	}
+
+	snapshots := make([]*Snapshot, 0, len(state))
+	for collection, docs := range state {
+		snap, err := s.storeCollectionSnapshot(ctx, branch, collection, lsn, docs)
+		if err != nil {
+			return nil, fmt.Errorf("collection %s: %w", collection, err)
+		}
+		snapshots = append(snapshots, snap)
+	}
+	return snapshots, nil
+}
+
+func (s *Service) storeCollectionSnapshot(ctx context.Context, branch *wal.Branch, collection string, lsn int64, docs map[string]bson.M) (*Snapshot, error) {
+	chunks, docCount, err := encodeState(docs, s.compressor)
+	if err != nil {
+		return nil, err
+	}
+
+	chunkIDs := make([]string, 0, len(chunks))
+	var sizeBytes int64
+	for _, chunk := range chunks {
+		id, err := s.chunks.Put(ctx, chunk)
+		if err != nil {
+			return nil, err
+		}
+		chunkIDs = append(chunkIDs, id)
+		sizeBytes += int64(len(chunk))
+	}
+
+	snap := &Snapshot{
+		ProjectID:     branch.ProjectID,
+		BranchID:      branch.ID,
+		Collection:    collection,
+		LSN:           lsn,
+		RangesApplied: len(branch.DiscardedRanges),
+		ChunkIDs:      chunkIDs,
+		DocCount:      docCount,
+		SizeBytes:     sizeBytes,
+		CreatedAt:     time.Now(),
+	}
+
+	if _, err := s.manifests.InsertOne(ctx, snap); err != nil {
+		return nil, fmt.Errorf("failed to store snapshot manifest: %w", err)
+	}
+	return snap, nil
+}
+
+// FindUsable implements materializer.SnapshotSource: it returns the loaded
+// state of the newest usable snapshot of (branch, collection) whose LSN
+// lies in [minLSN, maxLSN], for a read whose segment upper bound is
+// readUpperBound.
+//
+// Usability honors discarded ranges: ranges recorded before the snapshot
+// was built (index < RangesApplied) were already excluded from its state;
+// a range recorded afterwards invalidates the snapshot iff it overlaps the
+// snapshot's history (From <= LSN) and the reader must skip it
+// (readUpperBound > To) — the same visibility rule replay uses for
+// individual entries.
+func (s *Service) FindUsable(branch *wal.Branch, collection string, minLSN, maxLSN, readUpperBound int64) (map[string]bson.M, int64, bool, error) {
+	ctx := context.Background()
+	cursor, err := s.manifests.Find(ctx,
+		bson.M{
+			"branch_id":  branch.ID,
+			"collection": collection,
+			"lsn":        bson.M{"$gte": minLSN, "$lte": maxLSN},
+		},
+		options.Find().SetSort(bson.M{"lsn": -1}),
+	)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("failed to query snapshots: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	for cursor.Next(ctx) {
+		var snap Snapshot
+		if err := cursor.Decode(&snap); err != nil {
+			return nil, 0, false, fmt.Errorf("failed to decode snapshot manifest: %w", err)
+		}
+		if !s.usable(&snap, branch, readUpperBound) {
+			continue
+		}
+		state, err := s.load(ctx, &snap)
+		if err != nil {
+			return nil, 0, false, err
+		}
+		return state, snap.LSN, true, nil
+	}
+	return nil, 0, false, cursor.Err()
+}
+
+func (s *Service) usable(snap *Snapshot, branch *wal.Branch, readUpperBound int64) bool {
+	for idx := snap.RangesApplied; idx < len(branch.DiscardedRanges); idx++ {
+		r := branch.DiscardedRanges[idx]
+		if r.From <= snap.LSN && readUpperBound > r.To {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Service) load(ctx context.Context, snap *Snapshot) (map[string]bson.M, error) {
+	state := make(map[string]bson.M, snap.DocCount)
+	for _, chunkID := range snap.ChunkIDs {
+		data, err := s.chunks.Get(ctx, chunkID)
+		if err != nil {
+			return nil, err
+		}
+		if err := decodeChunk(data, s.compressor, state); err != nil {
+			return nil, fmt.Errorf("chunk %s: %w", chunkID, err)
+		}
+	}
+	return state, nil
+}
+
+// CollectionsUpTo implements materializer.SnapshotSource: collections that
+// have a snapshot for this branch within the LSN window.
+func (s *Service) CollectionsUpTo(branchID string, minLSN, maxLSN int64) ([]string, error) {
+	ctx := context.Background()
+	values, err := s.manifests.Distinct(ctx, "collection", bson.M{
+		"branch_id": branchID,
+		"lsn":       bson.M{"$gte": minLSN, "$lte": maxLSN},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list snapshot collections: %w", err)
+	}
+	collections := make([]string, 0, len(values))
+	for _, v := range values {
+		if name, ok := v.(string); ok {
+			collections = append(collections, name)
+		}
+	}
+	return collections, nil
+}
+
+// ListSnapshots returns the manifests for a branch, newest first.
+func (s *Service) ListSnapshots(ctx context.Context, branchID string) ([]*Snapshot, error) {
+	cursor, err := s.manifests.Find(ctx,
+		bson.M{"branch_id": branchID},
+		options.Find().SetSort(bson.M{"lsn": -1}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var snaps []*Snapshot
+	if err := cursor.All(ctx, &snaps); err != nil {
+		return nil, err
+	}
+	return snaps, nil
+}

--- a/internal/wal/service.go
+++ b/internal/wal/service.go
@@ -267,6 +267,30 @@ func (s *Service) GetDocumentHistory(branchID, collection, documentID string, st
 	return s.GetEntries(filter, opts)
 }
 
+// DistinctCollections returns the collections touched by a branch's own
+// entries within an LSN range.
+func (s *Service) DistinctCollections(branchID string, startLSN, endLSN int64) ([]string, error) {
+	ctx := context.Background()
+	values, err := s.collection.Distinct(ctx, "collection", bson.M{
+		"branch_id":  branchID,
+		"collection": bson.M{"$ne": ""},
+		"lsn": bson.M{
+			"$gte": startLSN,
+			"$lte": endLSN,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	collections := make([]string, 0, len(values))
+	for _, v := range values {
+		if name, ok := v.(string); ok {
+			collections = append(collections, name)
+		}
+	}
+	return collections, nil
+}
+
 // GetProjectEntries retrieves all entries for a project within an LSN range
 func (s *Service) GetProjectEntries(projectID, collection string, startLSN, endLSN int64) ([]*Entry, error) {
 	filter := bson.M{

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -12,6 +12,7 @@ import (
 	"github.com/argon-lab/argon/internal/migrate"
 	projectwal "github.com/argon-lab/argon/internal/project/wal"
 	"github.com/argon-lab/argon/internal/restore"
+	"github.com/argon-lab/argon/internal/snapshot"
 	"github.com/argon-lab/argon/internal/timetravel"
 	"github.com/argon-lab/argon/internal/wal"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -28,6 +29,7 @@ type Services struct {
 	Restore      *restore.Service
 	Importer     *importer.ImportService
 	Migrate      *migrate.Service
+	Snapshots    *snapshot.Service
 	Monitor      *wal.Monitor
 }
 
@@ -73,6 +75,11 @@ func NewServices() (*Services, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create migration service: %w", err)
 	}
+	// Registers itself as the materializer's snapshot source.
+	snapshotService, err := snapshot.NewService(db, branchService, materializerService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create snapshot service: %w", err)
+	}
 
 	// Create monitor with production-ready configuration
 	monitorConfig := wal.MonitorConfig{
@@ -99,6 +106,7 @@ func NewServices() (*Services, error) {
 		Restore:      restoreService,
 		Importer:     importerService,
 		Migrate:      migrateService,
+		Snapshots:    snapshotService,
 		Monitor:      monitor,
 	}, nil
 }

--- a/tests/wal/snapshot_test.go
+++ b/tests/wal/snapshot_test.go
@@ -1,0 +1,291 @@
+package wal_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/argon-lab/argon/internal/restore"
+	"github.com/argon-lab/argon/internal/snapshot"
+	"github.com/argon-lab/argon/internal/timetravel"
+	"github.com/argon-lab/argon/internal/wal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// snapshotFixture wires the full service stack twice over the same
+// database: one materializer with snapshots enabled and one without, so
+// tests can assert that the accelerated path produces exactly the state a
+// full replay produces.
+type snapshotFixture struct {
+	wal        *wal.Service
+	branches   *branchwal.BranchService
+	mat        *materializer.Service // snapshot-accelerated
+	matFull    *materializer.Service // full replay, no snapshots
+	snapshots  *snapshot.Service
+	timeTravel *timetravel.Service
+	restore    *restore.Service
+}
+
+func newSnapshotFixture(t *testing.T, db *mongo.Database) *snapshotFixture {
+	t.Helper()
+	walService, err := wal.NewService(db)
+	require.NoError(t, err)
+	branchService, err := branchwal.NewBranchService(db, walService)
+	require.NoError(t, err)
+
+	mat := materializer.NewService(walService, branchService)
+	snapService, err := snapshot.NewService(db, branchService, mat)
+	require.NoError(t, err)
+
+	matFull := materializer.NewService(walService, branchService)
+	tt := timetravel.NewService(walService, mat)
+
+	return &snapshotFixture{
+		wal:        walService,
+		branches:   branchService,
+		mat:        mat,
+		matFull:    matFull,
+		snapshots:  snapService,
+		timeTravel: tt,
+		restore:    restore.NewService(walService, branchService, mat, tt),
+	}
+}
+
+func (f *snapshotFixture) requireSnapshotMatchesFullReplay(t *testing.T, branch *wal.Branch, label string) {
+	t.Helper()
+	accelerated, err := f.mat.MaterializeBranch(branch)
+	require.NoError(t, err, "%s: accelerated path", label)
+	full, err := f.matFull.MaterializeBranch(branch)
+	require.NoError(t, err, "%s: full replay path", label)
+	requireSameState(t, full, accelerated, label)
+}
+
+func TestSnapshot_MatchesFullReplay(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("snap-test", "main", "")
+	require.NoError(t, err)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+
+	rng := rand.New(rand.NewSource(99))
+	applyRandomWorkload(t, rng, writer, 100)
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	t.Run("Snapshot at head, then diverge", func(t *testing.T) {
+		snaps, err := f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+		require.NoError(t, err)
+		require.NotEmpty(t, snaps)
+
+		// State right at the snapshot point.
+		f.requireSnapshotMatchesFullReplay(t, main, "at snapshot LSN")
+
+		// More writes on top: snapshot + delta.
+		applyRandomWorkload(t, rng, writer, 60)
+		main, _ = f.branches.GetBranchByID(main.ID)
+		f.requireSnapshotMatchesFullReplay(t, main, "snapshot plus delta")
+	})
+
+	t.Run("Historical reads below the snapshot still work", func(t *testing.T) {
+		target := main.HeadLSN / 3
+		accelerated, err := f.mat.MaterializeCollectionAtLSN(main, "users", target)
+		require.NoError(t, err)
+		full, err := f.matFull.MaterializeCollectionAtLSN(main, "users", target)
+		require.NoError(t, err)
+		assert.Equal(t, full, accelerated, "reads below the snapshot fall back to replay")
+	})
+
+	t.Run("Child branch uses parent snapshot through ancestry", func(t *testing.T) {
+		main, _ = f.branches.GetBranchByID(main.ID)
+		child, err := f.branches.CreateBranch("snap-test", "child", main.ID)
+		require.NoError(t, err)
+		childWriter := driverwal.NewInterceptor(f.wal, child, f.branches, f.mat)
+		applyRandomWorkload(t, rng, childWriter, 40)
+		child, _ = f.branches.GetBranchByID(child.ID)
+
+		f.requireSnapshotMatchesFullReplay(t, child, "child over parent snapshot")
+	})
+
+	t.Run("Snapshot on the child accelerates the whole chain", func(t *testing.T) {
+		child, err := f.branches.GetBranch("snap-test", "child")
+		require.NoError(t, err)
+		_, err = f.snapshots.CreateSnapshot(ctx, child.ID, child.HeadLSN)
+		require.NoError(t, err)
+
+		childWriter := driverwal.NewInterceptor(f.wal, child, f.branches, f.mat)
+		applyRandomWorkload(t, rng, childWriter, 30)
+		child, _ = f.branches.GetBranchByID(child.ID)
+
+		f.requireSnapshotMatchesFullReplay(t, child, "child snapshot plus delta")
+	})
+}
+
+func TestSnapshot_ResetInvalidation(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("snap-reset", "main", "")
+	require.NoError(t, err)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+
+	// Build history and remember a mid point.
+	for i := 0; i < 20; i++ {
+		_, err := writer.InsertOne(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%02d", i), "n": int32(i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+	midLSN := main.HeadLSN - 10
+
+	// Snapshot at head, then reset to the mid point: the snapshot now
+	// contains discarded history and must not serve post-reset reads.
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+	_, err = f.restore.ResetBranchToLSN(main.ID, midLSN)
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	// New writes after the reset.
+	_, err = writer.InsertOne(ctx, "docs", bson.M{"_id": "post-reset", "n": int32(100)})
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	f.requireSnapshotMatchesFullReplay(t, main, "after reset")
+
+	state, err := f.mat.MaterializeCollection(main, "docs")
+	require.NoError(t, err)
+	assert.NotContains(t, state, "d15", "discarded history must not resurface via the snapshot")
+	assert.Contains(t, state, "post-reset")
+
+	// A snapshot taken after the reset is valid again and serves reads.
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+	_, err = writer.InsertOne(ctx, "docs", bson.M{"_id": "later", "n": int32(101)})
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+	f.requireSnapshotMatchesFullReplay(t, main, "post-reset snapshot plus delta")
+}
+
+func TestSnapshot_IncrementalAndDeduplicated(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("snap-incr", "main", "")
+	require.NoError(t, err)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+
+	// A stable collection that never changes again, and a hot one.
+	stable := make([]interface{}, 200)
+	for i := range stable {
+		stable[i] = bson.M{"_id": fmt.Sprintf("s%03d", i), "payload": fmt.Sprintf("stable-%d", i)}
+	}
+	_, err = writer.InsertMany(ctx, "stable", stable)
+	require.NoError(t, err)
+	_, err = writer.InsertOne(ctx, "hot", bson.M{"_id": "h1", "n": int32(0)})
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	first, err := f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+
+	// Touch only the hot collection, snapshot again.
+	_, err = writer.UpdateOne(ctx, "hot", bson.M{"_id": "h1"}, bson.M{"$inc": bson.M{"n": int32(1)}}, false)
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	second, err := f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+
+	chunkOf := func(snaps []*snapshot.Snapshot, coll string) []string {
+		for _, s := range snaps {
+			if s.Collection == coll {
+				return s.ChunkIDs
+			}
+		}
+		return nil
+	}
+	assert.Equal(t, chunkOf(first, "stable"), chunkOf(second, "stable"),
+		"unchanged collection re-serializes to identical content-addressed chunks")
+	assert.NotEqual(t, chunkOf(first, "hot"), chunkOf(second, "hot"),
+		"changed collection produces new chunks")
+
+	// Chunk store holds the stable chunks only once.
+	count, err := db.Collection("wal_snapshot_chunks").CountDocuments(ctx, bson.M{})
+	require.NoError(t, err)
+	assert.EqualValues(t, len(chunkOf(first, "stable"))+2, count,
+		"stable chunks deduplicated; two distinct hot chunks")
+}
+
+func TestSnapshot_BoundsReplayDepth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping snapshot performance canary in short mode")
+	}
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("snap-perf", "main", "")
+	require.NoError(t, err)
+
+	// Build a deep history with direct batched appends (fast): 20k puts.
+	const total = 20000
+	const batch = 1000
+	for b := 0; b < total/batch; b++ {
+		entries := make([]*wal.Entry, batch)
+		for i := range entries {
+			docID := fmt.Sprintf("doc-%d", (b*batch+i)%5000)
+			post, err := bson.Marshal(bson.M{"_id": docID, "iter": int32(b*batch + i)})
+			require.NoError(t, err)
+			entries[i] = &wal.Entry{
+				ProjectID:  "snap-perf",
+				BranchID:   main.ID,
+				Operation:  wal.OpPut,
+				Collection: "big",
+				DocumentID: docID,
+				PostImage:  post,
+			}
+		}
+		lsns, err := f.wal.AppendBatch(entries)
+		require.NoError(t, err)
+		require.NoError(t, f.branches.UpdateBranchHead(main.ID, lsns[len(lsns)-1]))
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	fullStart := time.Now()
+	full, err := f.matFull.MaterializeCollection(main, "big")
+	require.NoError(t, err)
+	fullElapsed := time.Since(fullStart)
+
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+
+	// A small delta on top of the snapshot.
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	for i := 0; i < 50; i++ {
+		_, err := writer.InsertOne(ctx, "big", bson.M{"_id": fmt.Sprintf("delta-%d", i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	snapStart := time.Now()
+	accelerated, err := f.mat.MaterializeCollection(main, "big")
+	require.NoError(t, err)
+	snapElapsed := time.Since(snapStart)
+
+	assert.Len(t, accelerated, len(full)+50)
+	t.Logf("full replay of %d entries: %v; snapshot+50-delta: %v", total, fullElapsed, snapElapsed)
+	// Canary, not a benchmark: the snapshot path must clearly beat full
+	// replay on a 20k-entry history.
+	assert.Less(t, snapElapsed, fullElapsed,
+		"snapshot-backed materialization should be faster than full replay")
+}


### PR DESCRIPTION
First slice of the M2 snapshot layer: collection snapshots (the "image layer") that bound replay depth, integrated into materialization.

## Design

**Snapshots are per (branch, collection, LSN).** A snapshot captures the fully materialized state — including everything inherited through the ancestry chain — as of one LSN. Data lives in **content-addressed chunks** (hex SHA-256 of the compressed bytes, ~4MB pre-compression, zstd): identical content stores once, so snapshots of slowly-changing collections share almost all their chunks. Documents serialize in canonical form (recursively sorted keys) — decoded documents are Go maps, and map marshalling randomizes key order, which would defeat deduplication.

**Materialization searches leaf-most hop first.** For each ancestry segment, the newest usable snapshot within the segment's LSN window wins; a leaf snapshot covers the entire inherited chain beneath it, so replay resumes right above the snapshot instead of at the branch root. Reads below the snapshot, or on branches without one, fall back to full replay unchanged.

**Reset never touches snapshots.** Each manifest records how many of the branch's discarded ranges existed when it was built (`RangesApplied`); ranges are append-only, so a reader can tell whether a *later* reset invalidated the snapshot by checking only the newer ranges — same visibility rule replay uses for individual entries (`From <= snapshot LSN && readUpperBound > To`). Snapshots taken after a reset are valid again automatically.

**Incremental by construction.** `CreateSnapshot` materializes through the (snapshot-aware) materializer, so successive snapshots build from the previous one plus the delta.

The chunk store is MongoDB-backed (`wal_snapshot_chunks`) — zero extra infrastructure; the `ChunkStore` interface is where S3/GCS backends plug in when WAL segments move to object storage.

## Tests

- **Snapshot path ≡ full replay** under a seeded random workload (same generator as the determinism property): at the snapshot LSN, snapshot+delta, historical reads below the snapshot, child branches reading a parent snapshot through ancestry, and a chain accelerated by a child snapshot. Every case is checked against a second materializer with snapshots disabled.
- **Reset interaction**: a snapshot containing later-discarded history must not serve post-reset reads (and doesn't resurrect discarded documents); a post-reset snapshot serves reads again.
- **Deduplication**: an unchanged collection re-serializes to identical chunk IDs across snapshots; the chunk store holds shared chunks once.
- **Replay-depth canary**: on a 20k-entry history, snapshot+50-entry-delta materialization must beat full replay (locally ~9ms vs ~84ms).

## Not in this PR (next slices)

Auto-snapshot triggering on a threshold, snapshot GC for deleted branches, CLI (`argon snapshot create/list`), WAL segmentation + object-storage offload + retention-window GC.
