### PR TITLE
Automatic snapshots, reclamation on branch delete, snapshot CLI

### DIFF
--- a/cli/cmd/snapshot.go
+++ b/cli/cmd/snapshot.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+var snapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Manage collection snapshots",
+	Long: `Snapshots capture the materialized state of a branch at an LSN so
+that reads replay only the delta above the snapshot instead of the
+branch's entire history. Argon also takes snapshots automatically as
+branches grow; these commands trigger and inspect them explicitly.`,
+}
+
+var snapshotCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Snapshot a branch at its current head",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+		if branchName == "" {
+			branchName = "main"
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+		branch, err := services.Branches.GetBranch(project.ID, branchName)
+		if err != nil {
+			return fmt.Errorf("branch %q not found: %w", branchName, err)
+		}
+
+		snaps, err := services.Snapshots.CreateSnapshot(context.Background(), branch.ID, branch.HeadLSN)
+		if err != nil {
+			return fmt.Errorf("snapshot failed: %w", err)
+		}
+
+		fmt.Printf("Created %d collection snapshot(s) at LSN %d:\n", len(snaps), branch.HeadLSN)
+		for _, s := range snaps {
+			fmt.Printf("  %-24s %6d docs  %8d bytes  %d chunk(s)\n",
+				s.Collection, s.DocCount, s.SizeBytes, len(s.ChunkIDs))
+		}
+		return nil
+	},
+}
+
+var snapshotListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List snapshots of a branch",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+		if branchName == "" {
+			branchName = "main"
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+		branch, err := services.Branches.GetBranch(project.ID, branchName)
+		if err != nil {
+			return fmt.Errorf("branch %q not found: %w", branchName, err)
+		}
+
+		snaps, err := services.Snapshots.ListSnapshots(context.Background(), branch.ID)
+		if err != nil {
+			return fmt.Errorf("failed to list snapshots: %w", err)
+		}
+		if len(snaps) == 0 {
+			fmt.Println("No snapshots yet.")
+			return nil
+		}
+
+		fmt.Printf("%-8s %-24s %8s %10s %s\n", "LSN", "COLLECTION", "DOCS", "BYTES", "CREATED")
+		for _, s := range snaps {
+			fmt.Printf("%-8d %-24s %8d %10d %s\n",
+				s.LSN, s.Collection, s.DocCount, s.SizeBytes, s.CreatedAt.Format("2006-01-02 15:04:05"))
+		}
+		return nil
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{snapshotCreateCmd, snapshotListCmd} {
+		c.Flags().StringP("project", "p", "", "Project name (required)")
+		c.Flags().StringP("branch", "b", "", "Branch name (default: main)")
+	}
+	snapshotCmd.AddCommand(snapshotCreateCmd)
+	snapshotCmd.AddCommand(snapshotListCmd)
+	rootCmd.AddCommand(snapshotCmd)
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,7 @@ is planned but not built, it says so explicitly.
 │  ├─ timetravel           historical state queries          │
 │  ├─ restore              reset / branch-from-history       │
 │  ├─ driver (interceptor) write-time filter resolution      │
+│  ├─ snapshot             image layer: bounded replay depth │
 │  ├─ importer             bulk import into put entries      │
 │  └─ migrate              v1 → v2 WAL migration             │
 └──────────────────────────────┬─────────────────────────────┘
@@ -115,6 +116,41 @@ discarded window, while a branch forked *before* the reset has its fork
 point at or below it. Pre-reset forks therefore keep the history they
 legitimately captured, and post-reset readers never resurrect it.
 
+## Snapshots (the image layer)
+
+A snapshot captures the fully materialized state of one collection on one
+branch at one LSN — including everything inherited through the ancestry
+chain. Materialization then starts from the nearest usable snapshot and
+replays only the delta above it, which bounds read cost regardless of how
+long the branch's history grows. Reads below a snapshot, and branches
+without one, fall back to full replay unchanged.
+
+- **Storage**: content-addressed chunks (hex SHA-256 of the compressed
+  bytes, ~4MB pre-compression, zstd) in `wal_snapshot_chunks`; manifests in
+  `wal_snapshots`. Identical content stores once, so snapshots of
+  slowly-changing collections share almost all their chunks. Documents
+  serialize in canonical sorted-key form to keep the bytes deterministic.
+  The `ChunkStore` interface is where object-storage backends (S3/GCS)
+  plug in.
+- **Lookup**: materialization searches the leaf-most ancestry hop first — a
+  leaf snapshot covers the entire inherited chain beneath it. Within a hop,
+  the newest usable snapshot inside the segment's LSN window wins.
+- **Reset interaction**: reset never touches snapshots. Each manifest
+  records how many discarded ranges existed when it was built
+  (`RangesApplied`); ranges are append-only, so a reader detects
+  invalidation by checking only ranges recorded afterwards, with the same
+  visibility rule replay applies to entries. Post-reset snapshots are
+  automatically valid again.
+- **Incremental**: `CreateSnapshot` materializes through the snapshot-aware
+  path itself, so each snapshot builds from the previous one plus the delta.
+- **Automatic**: the driver notifies the snapshot service after writes;
+  once a branch head advances a threshold past its newest snapshot (default
+  1000 LSNs, checked at most every 64 writes per branch), a snapshot is
+  taken off the write path. `argon snapshot create/list` does it manually.
+- **Reclamation**: deleting a branch (which requires it to have no
+  children) drops its manifests and any chunks no other manifest
+  references.
+
 ## Write path (SDK / interceptor)
 
 Applications write through the Argon driver wrapper, which resolves each
@@ -162,21 +198,19 @@ entries removed). Migration is idempotent.
 
 ## Known limitations and roadmap
 
-Current limitations (deliberate M1 scope):
+Current limitations (deliberate scope):
 
 - Reads materialize in memory: no indexes, no aggregation pipeline, Find
   options (sort/skip/limit/projection) not applied; results in canonical
   document-ID order.
-- Materialization replays from the branch root every time — cost grows with
-  history length.
 - No merge/diff commands yet (pre-images already carry the data they need).
+- WAL entries all live in MongoDB; cold history is not yet offloaded.
 
 Planned next (in order):
 
-1. **M2 — snapshot layer**: periodic collection snapshots at an LSN
-   (image layers), so materialization = nearest snapshot + bounded delta
-   replay; WAL segmentation, object-storage offload and GC with a PITR
-   retention window.
+1. **M2 (remaining) — WAL segmentation**: cold segments offloaded to object
+   storage, entry GC under a PITR retention window once snapshots cover
+   them.
 2. **M3 — mongod as compute**: branches materialize into real MongoDB
    databases (lazily), reads/writes run on mongod with change-stream
    capture into the WAL, per-branch connection strings — full query
@@ -192,6 +226,8 @@ Planned next (in order):
 | `wal_branches` | Branch metadata: pointers, ancestry, discarded ranges |
 | `wal_projects` | Project metadata |
 | `wal_counters` | Per-project LSN counters |
+| `wal_snapshots` | Snapshot manifests |
+| `wal_snapshot_chunks` | Content-addressed snapshot data |
 
 Indexes on `wal_log`: unique `(project_id, lsn)`;
 `(branch_id, collection, lsn)`; `(branch_id, collection, document_id, lsn)`;

--- a/internal/branch/wal/service.go
+++ b/internal/branch/wal/service.go
@@ -18,6 +18,18 @@ type BranchService struct {
 	db         *mongo.Database
 	collection *mongo.Collection
 	wal        *wal.Service
+
+	// onDelete runs after a branch is successfully soft-deleted through
+	// DeleteBranch (never after ForceDeleteBranch: force-deleted branches
+	// may still anchor descendants' history). Used to reclaim snapshots
+	// without this package depending on the snapshot package.
+	onDelete func(branchID string)
+}
+
+// SetDeleteHook registers a callback invoked after a successful
+// DeleteBranch.
+func (s *BranchService) SetDeleteHook(hook func(branchID string)) {
+	s.onDelete = hook
 }
 
 // NewBranchService creates a new WAL branch service
@@ -279,8 +291,17 @@ func (s *BranchService) DeleteBranch(projectID, name string) error {
 		bson.M{"_id": branch.ID},
 		bson.M{"$set": bson.M{"is_deleted": true}},
 	)
+	if err != nil {
+		return err
+	}
 
-	return err
+	// Safe because DeleteBranch refuses branches with children: nothing
+	// can reach this branch's snapshots through an ancestry chain anymore.
+	if s.onDelete != nil {
+		s.onDelete(branch.ID)
+	}
+
+	return nil
 }
 
 // UpdateBranchHead advances the head LSN of a branch. $max keeps the head

--- a/internal/driver/wal/interceptor.go
+++ b/internal/driver/wal/interceptor.go
@@ -18,6 +18,13 @@ type Materializer interface {
 	MaterializeBranch(branch *wal.Branch) (map[string]map[string]bson.M, error)
 }
 
+// AutoSnapshotter is notified after writes so it can decide whether the
+// branch has outgrown its newest snapshot. Implementations must be cheap
+// and non-blocking; the snapshot service throttles internally.
+type AutoSnapshotter interface {
+	MaybeSnapshot(branch *wal.Branch)
+}
+
 // Interceptor turns MongoDB write operations into deterministic WAL entries.
 //
 // Filters and update operators are resolved here, exactly once, at write
@@ -35,6 +42,7 @@ type Interceptor struct {
 	branches     *branchwal.BranchService
 	materializer Materializer
 	actor        string
+	autoSnapshot AutoSnapshotter
 }
 
 // NewInterceptor creates a new WAL interceptor
@@ -51,6 +59,12 @@ func NewInterceptor(walService *wal.Service, branch *wal.Branch, branchService *
 // "agent:session-42") for audit and per-session undo.
 func (i *Interceptor) SetActor(actor string) {
 	i.actor = actor
+}
+
+// SetAutoSnapshotter enables threshold-based automatic snapshotting for
+// this handle's branch.
+func (i *Interceptor) SetAutoSnapshotter(a AutoSnapshotter) {
+	i.autoSnapshot = a
 }
 
 // InsertResult represents the result of an insert operation
@@ -399,6 +413,9 @@ func (i *Interceptor) advanceHead(lsn int64) error {
 	}
 	if lsn > i.branch.HeadLSN {
 		i.branch.HeadLSN = lsn
+	}
+	if i.autoSnapshot != nil {
+		i.autoSnapshot.MaybeSnapshot(i.branch)
 	}
 	return nil
 }

--- a/internal/snapshot/auto.go
+++ b/internal/snapshot/auto.go
@@ -1,0 +1,138 @@
+package snapshot
+
+import (
+	"context"
+	"log"
+
+	"github.com/argon-lab/argon/internal/wal"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// AutoConfig tunes threshold-based automatic snapshotting.
+type AutoConfig struct {
+	// Threshold is how many LSNs a branch head may advance past its newest
+	// snapshot before a new snapshot is taken.
+	Threshold int64
+	// CheckEvery throttles how often MaybeSnapshot actually consults the
+	// database: only every Nth call per branch performs the check.
+	CheckEvery int
+	// Synchronous runs snapshot creation inline instead of in a goroutine.
+	// Meant for tests; production keeps snapshotting off the write path.
+	Synchronous bool
+}
+
+// DefaultAutoConfig snapshots roughly every 1000 entries per branch,
+// checking the database at most every 64 writes.
+func DefaultAutoConfig() AutoConfig {
+	return AutoConfig{Threshold: 1000, CheckEvery: 64}
+}
+
+// autoState is the per-branch throttle/in-flight bookkeeping.
+type autoState struct {
+	callsSinceCheck int
+	inFlight        bool
+}
+
+// EnableAuto turns on threshold-based auto-snapshotting; MaybeSnapshot is a
+// no-op until this is called.
+func (s *Service) EnableAuto(cfg AutoConfig) {
+	if cfg.Threshold <= 0 {
+		cfg.Threshold = DefaultAutoConfig().Threshold
+	}
+	if cfg.CheckEvery <= 0 {
+		cfg.CheckEvery = DefaultAutoConfig().CheckEvery
+	}
+	s.autoMu.Lock()
+	defer s.autoMu.Unlock()
+	s.autoCfg = &cfg
+	if s.autoBranches == nil {
+		s.autoBranches = make(map[string]*autoState)
+	}
+}
+
+// MaybeSnapshot implements the driver's auto-snapshot hook: called after
+// writes with the (freshly advanced) branch. It is cheap by design — most
+// calls only bump an in-memory counter; every CheckEvery-th call per branch
+// consults the newest snapshot LSN and, when the head has advanced past the
+// threshold, kicks off snapshot creation (asynchronously unless configured
+// otherwise). Failures are logged, never surfaced to the write path: a
+// missed snapshot only means bounded-replay starts further back.
+func (s *Service) MaybeSnapshot(branch *wal.Branch) {
+	s.autoMu.Lock()
+	cfg := s.autoCfg
+	if cfg == nil {
+		s.autoMu.Unlock()
+		return
+	}
+	st := s.autoBranches[branch.ID]
+	if st == nil {
+		st = &autoState{}
+		s.autoBranches[branch.ID] = st
+	}
+	st.callsSinceCheck++
+	if st.callsSinceCheck < cfg.CheckEvery || st.inFlight {
+		s.autoMu.Unlock()
+		return
+	}
+	st.callsSinceCheck = 0
+	st.inFlight = true
+	s.autoMu.Unlock()
+
+	release := func() {
+		s.autoMu.Lock()
+		st.inFlight = false
+		s.autoMu.Unlock()
+	}
+
+	run := func() {
+		defer release()
+		if err := s.snapshotIfStale(branch, cfg.Threshold); err != nil {
+			log.Printf("auto-snapshot for branch %s failed: %v", branch.ID, err)
+		}
+	}
+
+	if cfg.Synchronous {
+		run()
+	} else {
+		go run()
+	}
+}
+
+// snapshotIfStale creates a snapshot when the branch head has advanced more
+// than threshold LSNs past the newest existing snapshot (or past the fork
+// point when the branch has none).
+func (s *Service) snapshotIfStale(branch *wal.Branch, threshold int64) error {
+	ctx := context.Background()
+
+	// Re-read the branch: the caller's copy may lag, and snapshotting at a
+	// stale head is wasted work.
+	fresh, err := s.branches.GetBranchByIDAny(branch.ID)
+	if err != nil {
+		return err
+	}
+
+	baseline := fresh.BaseLSN
+	var newest Snapshot
+	err = s.manifests.FindOne(ctx,
+		bson.M{"branch_id": fresh.ID},
+		options.FindOne().SetSort(bson.M{"lsn": -1}),
+	).Decode(&newest)
+	switch err {
+	case nil:
+		if newest.LSN > baseline {
+			baseline = newest.LSN
+		}
+	case mongo.ErrNoDocuments:
+		// No snapshot yet; baseline stays at the fork point.
+	default:
+		return err
+	}
+
+	if fresh.HeadLSN-baseline < threshold {
+		return nil
+	}
+	_, err = s.CreateSnapshot(ctx, fresh.ID, fresh.HeadLSN)
+	return err
+}

--- a/internal/snapshot/gc.go
+++ b/internal/snapshot/gc.go
@@ -1,0 +1,78 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// CleanupBranch removes a deleted branch's snapshot manifests and any
+// chunks no other manifest references.
+//
+// This is safe for regularly deleted branches because deletion refuses
+// branches with children — nobody's ancestry chain can reach the removed
+// snapshots. Force-deleted branches (which may still anchor descendants)
+// must not be cleaned up; descendants keep reading the ancestor's
+// snapshots through the chain.
+//
+// Chunk reclamation is a two-step check (drop manifests, then delete
+// chunks that no remaining manifest references). A snapshot being created
+// concurrently could in principle re-reference a chunk between the check
+// and the delete; the next snapshot of that branch simply re-uploads the
+// chunk (content addressing makes that harmless but wasteful), and proper
+// epoch-based GC arrives with WAL segment retention.
+func (s *Service) CleanupBranch(ctx context.Context, branchID string) (manifestsRemoved, chunksRemoved int64, err error) {
+	// Collect the chunk IDs this branch's manifests reference.
+	cursor, err := s.manifests.Find(ctx, bson.M{"branch_id": branchID})
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to list snapshots for branch %s: %w", branchID, err)
+	}
+	candidates := make(map[string]bool)
+	var manifests []Snapshot
+	if err := cursor.All(ctx, &manifests); err != nil {
+		return 0, 0, fmt.Errorf("failed to load snapshots for branch %s: %w", branchID, err)
+	}
+	for _, m := range manifests {
+		for _, id := range m.ChunkIDs {
+			candidates[id] = true
+		}
+	}
+	if len(manifests) == 0 {
+		return 0, 0, nil
+	}
+
+	res, err := s.manifests.DeleteMany(ctx, bson.M{"branch_id": branchID})
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to delete snapshot manifests: %w", err)
+	}
+	manifestsRemoved = res.DeletedCount
+
+	// Keep chunks still referenced by any surviving manifest.
+	candidateIDs := make([]string, 0, len(candidates))
+	for id := range candidates {
+		candidateIDs = append(candidateIDs, id)
+	}
+	stillUsed, err := s.manifests.Distinct(ctx, "chunk_ids", bson.M{"chunk_ids": bson.M{"$in": candidateIDs}})
+	if err != nil {
+		return manifestsRemoved, 0, fmt.Errorf("failed to check chunk references: %w", err)
+	}
+	for _, v := range stillUsed {
+		if id, ok := v.(string); ok {
+			delete(candidates, id)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return manifestsRemoved, 0, nil
+	}
+	orphaned := make([]string, 0, len(candidates))
+	for id := range candidates {
+		orphaned = append(orphaned, id)
+	}
+	chunkRes, err := s.chunks.DeleteMany(ctx, bson.M{"_id": bson.M{"$in": orphaned}})
+	if err != nil {
+		return manifestsRemoved, 0, fmt.Errorf("failed to delete orphaned chunks: %w", err)
+	}
+	return manifestsRemoved, chunkRes.DeletedCount, nil
+}

--- a/internal/snapshot/service.go
+++ b/internal/snapshot/service.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
@@ -16,10 +17,16 @@ import (
 // Service creates and serves collection snapshots.
 type Service struct {
 	manifests    *mongo.Collection
-	chunks       ChunkStore
+	chunks       *mongo.Collection // raw handle for GC reference checks
+	store        ChunkStore
 	branches     *branchwal.BranchService
 	materializer *materializer.Service
 	compressor   *wal.Compressor
+
+	// Auto-snapshot state (see auto.go).
+	autoMu       sync.Mutex
+	autoCfg      *AutoConfig
+	autoBranches map[string]*autoState
 }
 
 // NewService creates a snapshot service. It registers itself as the
@@ -34,7 +41,8 @@ func NewService(db *mongo.Database, branches *branchwal.BranchService, mat *mate
 
 	s := &Service{
 		manifests:    db.Collection("wal_snapshots"),
-		chunks:       NewMongoChunkStore(db),
+		chunks:       db.Collection("wal_snapshot_chunks"),
+		store:        NewMongoChunkStore(db),
 		branches:     branches,
 		materializer: mat,
 		compressor:   compressor,
@@ -100,7 +108,7 @@ func (s *Service) storeCollectionSnapshot(ctx context.Context, branch *wal.Branc
 	chunkIDs := make([]string, 0, len(chunks))
 	var sizeBytes int64
 	for _, chunk := range chunks {
-		id, err := s.chunks.Put(ctx, chunk)
+		id, err := s.store.Put(ctx, chunk)
 		if err != nil {
 			return nil, err
 		}
@@ -182,7 +190,7 @@ func (s *Service) usable(snap *Snapshot, branch *wal.Branch, readUpperBound int6
 func (s *Service) load(ctx context.Context, snap *Snapshot) (map[string]bson.M, error) {
 	state := make(map[string]bson.M, snap.DocCount)
 	for _, chunkID := range snap.ChunkIDs {
-		data, err := s.chunks.Get(ctx, chunkID)
+		data, err := s.store.Get(ctx, chunkID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -80,6 +80,13 @@ func NewServices() (*Services, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create snapshot service: %w", err)
 	}
+	snapshotService.EnableAuto(snapshot.DefaultAutoConfig())
+	// Reclaim a branch's snapshots when it is deleted.
+	branchService.SetDeleteHook(func(branchID string) {
+		if _, _, err := snapshotService.CleanupBranch(context.Background(), branchID); err != nil {
+			fmt.Printf("Warning: failed to clean up snapshots for branch %s: %v\n", branchID, err)
+		}
+	})
 
 	// Create monitor with production-ready configuration
 	monitorConfig := wal.MonitorConfig{

--- a/tests/wal/snapshot_auto_test.go
+++ b/tests/wal/snapshot_auto_test.go
@@ -1,0 +1,124 @@
+package wal_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/snapshot"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestSnapshot_AutoTrigger(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	ctx := context.Background()
+
+	// Synchronous mode with a tiny threshold so the test is deterministic:
+	// check on every write, snapshot once the head is 10 LSNs past the
+	// newest snapshot (or the fork point).
+	f.snapshots.EnableAuto(snapshot.AutoConfig{
+		Threshold:   10,
+		CheckEvery:  1,
+		Synchronous: true,
+	})
+
+	main, err := f.branches.CreateBranch("auto-snap", "main", "")
+	require.NoError(t, err)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	writer.SetAutoSnapshotter(f.snapshots)
+
+	// Below the threshold: no snapshot yet.
+	for i := 0; i < 5; i++ {
+		_, err := writer.InsertOne(ctx, "docs", bson.M{"_id": fmt.Sprintf("a%d", i)})
+		require.NoError(t, err)
+	}
+	snaps, err := f.snapshots.ListSnapshots(ctx, main.ID)
+	require.NoError(t, err)
+	assert.Empty(t, snaps, "below threshold: no automatic snapshot")
+
+	// Cross the threshold.
+	for i := 5; i < 15; i++ {
+		_, err := writer.InsertOne(ctx, "docs", bson.M{"_id": fmt.Sprintf("a%d", i)})
+		require.NoError(t, err)
+	}
+	snaps, err = f.snapshots.ListSnapshots(ctx, main.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, snaps, "threshold crossed: automatic snapshot taken")
+	firstCount := len(snaps)
+
+	// Immediately after, the head is close to the snapshot again — more
+	// writes below the threshold must not snapshot again.
+	_, err = writer.InsertOne(ctx, "docs", bson.M{"_id": "extra"})
+	require.NoError(t, err)
+	snaps, err = f.snapshots.ListSnapshots(ctx, main.ID)
+	require.NoError(t, err)
+	assert.Len(t, snaps, firstCount, "no re-snapshot while within threshold of the last one")
+
+	// State served through the auto-snapshot equals full replay.
+	main, _ = f.branches.GetBranchByID(main.ID)
+	f.requireSnapshotMatchesFullReplay(t, main, "auto-snapshot state")
+}
+
+func TestSnapshot_CleanupOnBranchDelete(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	ctx := context.Background()
+
+	// Wire the delete hook the way walcli does.
+	f.branches.SetDeleteHook(func(branchID string) {
+		_, _, err := f.snapshots.CleanupBranch(ctx, branchID)
+		require.NoError(t, err)
+	})
+
+	main, err := f.branches.CreateBranch("gc-test", "main", "")
+	require.NoError(t, err)
+	mainWriter := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+
+	// Shared content: main and the doomed branch snapshot identical
+	// "shared" collections, so their chunks are deduplicated across both.
+	docs := make([]interface{}, 50)
+	for i := range docs {
+		docs[i] = bson.M{"_id": fmt.Sprintf("s%02d", i), "payload": "shared"}
+	}
+	_, err = mainWriter.InsertMany(ctx, "shared", docs)
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+
+	// The doomed branch: inherits "shared" (same chunks) plus its own data.
+	doomed, err := f.branches.CreateBranch("gc-test", "doomed", main.ID)
+	require.NoError(t, err)
+	doomedWriter := driverwal.NewInterceptor(f.wal, doomed, f.branches, f.mat)
+	_, err = doomedWriter.InsertOne(ctx, "own", bson.M{"_id": "only-here", "payload": "doomed"})
+	require.NoError(t, err)
+	doomed, _ = f.branches.GetBranchByID(doomed.ID)
+	_, err = f.snapshots.CreateSnapshot(ctx, doomed.ID, doomed.HeadLSN)
+	require.NoError(t, err)
+
+	chunksBefore, err := db.Collection("wal_snapshot_chunks").CountDocuments(ctx, bson.M{})
+	require.NoError(t, err)
+
+	require.NoError(t, f.branches.DeleteBranch("gc-test", "doomed"))
+
+	// Doomed manifests gone; shared chunks survive because main's
+	// snapshot still references them; the branch-only chunk is gone.
+	snaps, err := f.snapshots.ListSnapshots(ctx, doomed.ID)
+	require.NoError(t, err)
+	assert.Empty(t, snaps, "deleted branch keeps no manifests")
+
+	chunksAfter, err := db.Collection("wal_snapshot_chunks").CountDocuments(ctx, bson.M{})
+	require.NoError(t, err)
+	assert.Less(t, chunksAfter, chunksBefore, "orphaned chunks reclaimed")
+
+	// Main still materializes through its snapshot untouched.
+	main, _ = f.branches.GetBranchByID(main.ID)
+	f.requireSnapshotMatchesFullReplay(t, main, "survivor after sibling GC")
+	state, err := f.mat.MaterializeCollection(main, "shared")
+	require.NoError(t, err)
+	assert.Len(t, state, 50)
+}

--- a/tests/wal/week3_integration_test.go
+++ b/tests/wal/week3_integration_test.go
@@ -86,6 +86,10 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 			assert.NoError(t, err)
 		}
 		checkpoints["noon"] = walService.GetCurrentLSN(project.ID)
+		// Captured after the noon writes completed, so their WAL
+		// timestamps are guaranteed at or before it regardless of how
+		// long the write round-trips took under load.
+		timestamps["noonDone"] = time.Now()
 
 		// Evening: Something went wrong
 		time.Sleep(10 * time.Millisecond)
@@ -118,7 +122,7 @@ func TestWeek3_IntegrationTests(t *testing.T) {
 			assert.Len(t, noonUsers, 6) // admin + 5 test users
 
 			// Query by time
-			noonState, err := timeTravelService.MaterializeAtTime(mainBranch, "config", timestamps["noon"].Add(5*time.Millisecond))
+			noonState, err := timeTravelService.MaterializeAtTime(mainBranch, "config", timestamps["noonDone"])
 			assert.NoError(t, err)
 			assert.Equal(t, "1.1.0", noonState["app"]["version"])
 		})


### PR DESCRIPTION
Second slice of the M2 snapshot layer.

**Automatic snapshotting.** The driver notifies the snapshot service after writes (`SetAutoSnapshotter`); once a branch head advances a threshold past its newest snapshot (default 1000 LSNs, checked at most every 64 writes per branch, per-branch in-flight dedup), a snapshot is taken **off the write path**. Failures only log — a missed snapshot just means bounded replay starts further back. Synchronous mode exists for deterministic tests.

**Reclamation.** Deleting a branch drops its manifests and any chunks **no surviving manifest references** — content shared with other branches' snapshots stays (there's a test where a sibling's identical collection keeps the shared chunks alive). Wired through a delete hook on the branch service, which fires only for regular deletion: it refuses branches with children, so nothing can reach the removed snapshots through an ancestry chain. Force-delete intentionally keeps snapshots (descendants may still read them).

**CLI.** `argon snapshot create -p <project> [-b <branch>]` and `argon snapshot list`.

**Docs.** ARCHITECTURE.md gains the snapshot chapter; the bounded-replay-depth limitation moves out of the limitations list; WAL segmentation/offload stays on the roadmap.

Also hardens a load-sensitive time-travel assertion in the week3 integration test (same latency-race class as the reset-to-time fix in #4's follow-up).

Tests: threshold-based auto-trigger (below/above/re-arm), auto-snapshot state ≡ full replay, shared-chunk-preserving GC on branch delete; full suite green locally, lint clean.