### PR TITLE
Retention-window WAL GC and full reclamation of deleted branches

### DIFF
--- a/cli/cmd/gc.go
+++ b/cli/cmd/gc.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+var gcCmd = &cobra.Command{
+	Use:   "gc",
+	Short: "Reclaim WAL entries covered by snapshots and outside retention",
+	Long: `Deletes WAL entries that no reader can need anymore: entries at or
+below the newest snapshot that covers them, older than the retention
+window, and not pinned by a live child branch's fork point. History
+without snapshot coverage is never deleted, no matter how old.
+
+Reclaiming entries ends time-travel, audit and undo below the cutoff —
+that is what a retention window means. Use --dry-run to preview.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+		retention, _ := cmd.Flags().GetDuration("retention")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+
+		report, err := services.RunGC(context.Background(), project.ID, retention, dryRun)
+		if err != nil {
+			return fmt.Errorf("gc failed: %w", err)
+		}
+
+		verb := "Removed"
+		if report.DryRun {
+			verb = "Would remove"
+		}
+		for _, br := range report.Branches {
+			if len(br.Cutoffs) == 0 {
+				continue
+			}
+			fmt.Printf("Branch %s:\n", br.BranchName)
+			for coll, cutoff := range br.Cutoffs {
+				fmt.Printf("  %-24s reclaim up to LSN %d\n", coll, cutoff)
+			}
+		}
+		if report.DryRun {
+			fmt.Printf("%s entries below the cutoffs above (dry run).\n", verb)
+		} else {
+			fmt.Printf("%s %d entries.\n", verb, report.EntriesRemoved)
+		}
+		return nil
+	},
+}
+
+func init() {
+	gcCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	gcCmd.Flags().Duration("retention", 7*24*time.Hour, "Retention window for historical reads")
+	gcCmd.Flags().Bool("dry-run", false, "Report what would be deleted without deleting")
+	rootCmd.AddCommand(gcCmd)
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,8 +148,34 @@ without one, fall back to full replay unchanged.
   1000 LSNs, checked at most every 64 writes per branch), a snapshot is
   taken off the write path. `argon snapshot create/list` does it manually.
 - **Reclamation**: deleting a branch (which requires it to have no
-  children) drops its manifests and any chunks no other manifest
-  references.
+  children) drops its WAL entries, its manifests and any chunks no other
+  manifest references.
+
+## Garbage collection (retention window)
+
+`argon gc` (and `Services.RunGC`) deletes WAL entries that no reader can
+ever need again. Per (branch, collection), the reclaim cutoff is
+
+```
+min( S,  R,  min over live children of S_i )
+```
+
+where `S` is the newest snapshot valid for every possible future reader
+(no later discarded range overlaps it), `R` is the newest LSN older than
+the retention window (default 7 days), and `S_i` is the newest snapshot at
+or below each live child's fork point — children and all their descendants
+read the parent's segment with an upper bound pinned to the fork, so they
+can only be served by snapshots at or below it. Entries at or below the
+cutoff are deleted; control entries stay.
+
+Two consequences worth stating plainly: history without snapshot coverage
+is **never** deleted, no matter how old — and reclaiming entries ends
+time-travel, audit and undo below the cutoff, which is exactly what a
+retention window means.
+
+Together with snapshots this gives storage an upper bound: state size plus
+the retention window of history, instead of the full write history
+forever.
 
 ## Write path (SDK / interceptor)
 
@@ -204,18 +230,17 @@ Current limitations (deliberate scope):
   options (sort/skip/limit/projection) not applied; results in canonical
   document-ID order.
 - No merge/diff commands yet (pre-images already carry the data they need).
-- WAL entries all live in MongoDB; cold history is not yet offloaded.
+- WAL entries and snapshot chunks live in MongoDB; offload to object
+  storage (S3/GCS) is an optional cost optimization behind the ChunkStore
+  interface, not yet implemented.
 
 Planned next (in order):
 
-1. **M2 (remaining) — WAL segmentation**: cold segments offloaded to object
-   storage, entry GC under a PITR retention window once snapshots cover
-   them.
-2. **M3 — mongod as compute**: branches materialize into real MongoDB
+1. **M3 — mongod as compute**: branches materialize into real MongoDB
    databases (lazily), reads/writes run on mongod with change-stream
    capture into the WAL, per-branch connection strings — full query
    compatibility without reimplementing MongoDB.
-3. **M4 — merge and diff**: three-way document-level merge with reviewable
+2. **M4 — merge and diff**: three-way document-level merge with reviewable
    merge plans.
 
 ## Storage collections

--- a/internal/gc/service.go
+++ b/internal/gc/service.go
@@ -1,0 +1,206 @@
+// Package gc reclaims WAL entries that no reader can ever need again.
+//
+// The coverage argument, per (branch, collection):
+//
+//   - Readers of the branch itself (at any current or future head) start
+//     from the newest snapshot that is valid for them. A snapshot at LSN S
+//     that is usable for *every* future reader (no later discarded range
+//     overlaps it) covers all entries with LSN <= S.
+//   - A live child forked at F reads this branch's segment with upper
+//     bound exactly F — and so does every deeper descendant through that
+//     child, because ancestry traversal clamps the limit to the fork
+//     point at each hop. Those readers can only use snapshots with
+//     LSN <= F, so each live child needs entries above its own coverage
+//     snapshot S_i (the newest usable snapshot at or below F_i).
+//   - The retention window is the time-travel guarantee: entries younger
+//     than the window must stay so any in-window historical LSN can be
+//     materialized; older ones may go once covered.
+//
+// The reclaim cutoff is therefore
+//
+//	min( S, R, min over live children of S_i )
+//
+// where R is the newest LSN older than the retention window. Entries at or
+// below the cutoff are deleted; everything else stays. With no snapshot
+// (S = 0) nothing is deleted, no matter how old — history that is anyone's
+// only source of truth is never dropped.
+//
+// Deleting entries below the cutoff also deletes discarded-range entries
+// and pre-images in that region, which ends their audit/undo availability.
+// That is exactly what a retention window means; pick it accordingly.
+package gc
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/snapshot"
+	"github.com/argon-lab/argon/internal/wal"
+)
+
+// Config tunes garbage collection.
+type Config struct {
+	// RetentionWindow is how far back in time historical reads (time
+	// travel, audit, undo) remain guaranteed. Entries younger than this
+	// are never reclaimed.
+	RetentionWindow time.Duration
+	// DryRun reports what would be deleted without deleting it.
+	DryRun bool
+}
+
+// DefaultConfig keeps one week of history.
+func DefaultConfig() Config {
+	return Config{RetentionWindow: 7 * 24 * time.Hour}
+}
+
+// Service reclaims WAL entries covered by snapshots and outside retention.
+type Service struct {
+	wal       *wal.Service
+	branches  *branchwal.BranchService
+	snapshots *snapshot.Service
+}
+
+// NewService creates a GC service.
+func NewService(walService *wal.Service, branches *branchwal.BranchService, snapshots *snapshot.Service) *Service {
+	return &Service{wal: walService, branches: branches, snapshots: snapshots}
+}
+
+// BranchReport describes what GC did (or would do) for one branch.
+type BranchReport struct {
+	BranchID       string
+	BranchName     string
+	EntriesRemoved int64
+	Cutoffs        map[string]int64 // collection -> reclaim cutoff LSN
+}
+
+// Report summarizes a project GC run.
+type Report struct {
+	ProjectID      string
+	Branches       []BranchReport
+	EntriesRemoved int64
+	DryRun         bool
+}
+
+// RunProject reclaims covered, out-of-retention entries across every live
+// branch of a project.
+func (s *Service) RunProject(ctx context.Context, projectID string, cfg Config) (*Report, error) {
+	if cfg.RetentionWindow < 0 {
+		return nil, fmt.Errorf("retention window must not be negative")
+	}
+
+	branches, err := s.branches.ListBranchesAny(projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list branches: %w", err)
+	}
+
+	// Live children per parent: their fork points constrain the parent.
+	childrenOf := make(map[string][]*wal.Branch)
+	for _, b := range branches {
+		if !b.IsDeleted && b.ParentID != "" {
+			childrenOf[b.ParentID] = append(childrenOf[b.ParentID], b)
+		}
+	}
+
+	report := &Report{ProjectID: projectID, DryRun: cfg.DryRun}
+	retentionCutoffTime := time.Now().Add(-cfg.RetentionWindow)
+
+	for _, branch := range branches {
+		if branch.IsDeleted {
+			continue // Reclaimed at deletion time via the delete hook.
+		}
+		br, err := s.gcBranch(ctx, branch, childrenOf[branch.ID], retentionCutoffTime, cfg.DryRun)
+		if err != nil {
+			return nil, fmt.Errorf("branch %s (%s): %w", branch.Name, branch.ID, err)
+		}
+		report.Branches = append(report.Branches, *br)
+		report.EntriesRemoved += br.EntriesRemoved
+	}
+	return report, nil
+}
+
+func (s *Service) gcBranch(ctx context.Context, branch *wal.Branch, liveChildren []*wal.Branch, retentionCutoffTime time.Time, dryRun bool) (*BranchReport, error) {
+	report := &BranchReport{
+		BranchID:   branch.ID,
+		BranchName: branch.Name,
+		Cutoffs:    make(map[string]int64),
+	}
+
+	// R: the retention window translated into this branch's LSNs.
+	retentionLSN, err := s.wal.LatestLSNBefore(branch.ID, retentionCutoffTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute retention cutoff: %w", err)
+	}
+	if retentionLSN == 0 {
+		return report, nil // Everything is inside the window.
+	}
+
+	collections, err := s.wal.DistinctCollections(branch.ID, 0, branch.HeadLSN)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collections: %w", err)
+	}
+
+	for _, collection := range collections {
+		// S: coverage for the branch's own (and post-fork) readers — must
+		// be valid for every possible future read bound.
+		coverage, err := s.snapshots.NewestUsableLSN(branch, collection, branch.HeadLSN, math.MaxInt64)
+		if err != nil {
+			return nil, err
+		}
+		if coverage == 0 {
+			continue // No snapshot: this history is the only source of truth.
+		}
+
+		cutoff := min64(coverage, retentionLSN)
+
+		// S_i: every live child's readers are pinned to its fork point and
+		// can only use snapshots at or below it.
+		for _, child := range liveChildren {
+			childCoverage, err := s.snapshots.NewestUsableLSN(branch, collection, child.BaseLSN, child.BaseLSN)
+			if err != nil {
+				return nil, err
+			}
+			cutoff = min64(cutoff, childCoverage)
+		}
+
+		if cutoff <= 0 {
+			continue
+		}
+		report.Cutoffs[collection] = cutoff
+
+		if dryRun {
+			continue
+		}
+		removed, err := s.wal.DeleteDataEntriesUpTo(branch.ID, collection, cutoff)
+		if err != nil {
+			return nil, fmt.Errorf("failed to delete entries for %s: %w", collection, err)
+		}
+		report.EntriesRemoved += removed
+	}
+	return report, nil
+}
+
+// ReclaimDeletedBranch removes everything a deleted branch owned: WAL
+// entries and snapshots (manifests plus unshared chunks). Only safe for
+// regular deletion, which refuses branches with children — nothing can
+// traverse the branch's history afterwards.
+func (s *Service) ReclaimDeletedBranch(ctx context.Context, branchID string) (entriesRemoved, manifestsRemoved, chunksRemoved int64, err error) {
+	entriesRemoved, err = s.wal.DeleteBranchEntries(branchID)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to delete branch entries: %w", err)
+	}
+	manifestsRemoved, chunksRemoved, err = s.snapshots.CleanupBranch(ctx, branchID)
+	if err != nil {
+		return entriesRemoved, 0, 0, err
+	}
+	return entriesRemoved, manifestsRemoved, chunksRemoved, nil
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/snapshot/service.go
+++ b/internal/snapshot/service.go
@@ -201,6 +201,38 @@ func (s *Service) load(ctx context.Context, snap *Snapshot) (map[string]bson.M, 
 	return state, nil
 }
 
+// NewestUsableLSN returns the LSN of the newest snapshot of (branch,
+// collection) at or below maxLSN that is usable for a read whose segment
+// upper bound is readUpperBound, or 0 if none. GC uses this to compute how
+// far a collection's entries are covered: pass math.MaxInt64 as
+// readUpperBound to require validity for every possible future reader.
+func (s *Service) NewestUsableLSN(branch *wal.Branch, collection string, maxLSN, readUpperBound int64) (int64, error) {
+	ctx := context.Background()
+	cursor, err := s.manifests.Find(ctx,
+		bson.M{
+			"branch_id":  branch.ID,
+			"collection": collection,
+			"lsn":        bson.M{"$lte": maxLSN},
+		},
+		options.Find().SetSort(bson.M{"lsn": -1}),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query snapshots: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	for cursor.Next(ctx) {
+		var snap Snapshot
+		if err := cursor.Decode(&snap); err != nil {
+			return 0, fmt.Errorf("failed to decode snapshot manifest: %w", err)
+		}
+		if s.usable(&snap, branch, readUpperBound) {
+			return snap.LSN, nil
+		}
+	}
+	return 0, cursor.Err()
+}
+
 // CollectionsUpTo implements materializer.SnapshotSource: collections that
 // have a snapshot for this branch within the LSN window.
 func (s *Service) CollectionsUpTo(branchID string, minLSN, maxLSN int64) ([]string, error) {

--- a/internal/wal/service.go
+++ b/internal/wal/service.go
@@ -309,6 +309,56 @@ func (s *Service) GetProjectEntries(projectID, collection string, startLSN, endL
 	return s.GetEntries(filter, opts)
 }
 
+// LatestLSNBefore returns the highest LSN of the branch's entries whose
+// timestamp is at or before the given time, or 0 if none. GC uses this to
+// translate the retention window into an LSN cutoff.
+func (s *Service) LatestLSNBefore(branchID string, cutoff time.Time) (int64, error) {
+	ctx := context.Background()
+	var entry struct {
+		LSN int64 `bson:"lsn"`
+	}
+	err := s.collection.FindOne(ctx,
+		bson.M{"branch_id": branchID, "timestamp": bson.M{"$lte": cutoff}},
+		options.FindOne().SetSort(bson.M{"lsn": -1}).SetProjection(bson.M{"lsn": 1}),
+	).Decode(&entry)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return entry.LSN, nil
+}
+
+// DeleteDataEntriesUpTo removes a collection's data entries (puts and
+// deletes) on one branch with LSN at or below cutoff. Control entries are
+// kept — they are tiny and carry branch/project lineage. Callers are
+// responsible for the coverage argument (see the gc package).
+func (s *Service) DeleteDataEntriesUpTo(branchID, collection string, cutoff int64) (int64, error) {
+	ctx := context.Background()
+	res, err := s.collection.DeleteMany(ctx, bson.M{
+		"branch_id":  branchID,
+		"collection": collection,
+		"operation":  bson.M{"$in": []OperationType{OpPut, OpDelete}},
+		"lsn":        bson.M{"$lte": cutoff},
+	})
+	if err != nil {
+		return 0, err
+	}
+	return res.DeletedCount, nil
+}
+
+// DeleteBranchEntries removes every entry belonging to a branch. Only safe
+// once the branch is deleted and no live descendant can traverse it.
+func (s *Service) DeleteBranchEntries(branchID string) (int64, error) {
+	ctx := context.Background()
+	res, err := s.collection.DeleteMany(ctx, bson.M{"branch_id": branchID})
+	if err != nil {
+		return 0, err
+	}
+	return res.DeletedCount, nil
+}
+
 // GetMetrics returns a snapshot of current metrics
 func (s *Service) GetMetrics() MetricsSnapshot {
 	return s.metrics.GetSnapshot()

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/gc"
 	"github.com/argon-lab/argon/internal/importer"
 	"github.com/argon-lab/argon/internal/materializer"
 	"github.com/argon-lab/argon/internal/migrate"
@@ -30,6 +31,7 @@ type Services struct {
 	Importer     *importer.ImportService
 	Migrate      *migrate.Service
 	Snapshots    *snapshot.Service
+	GC           *gc.Service
 	Monitor      *wal.Monitor
 }
 
@@ -81,10 +83,12 @@ func NewServices() (*Services, error) {
 		return nil, fmt.Errorf("failed to create snapshot service: %w", err)
 	}
 	snapshotService.EnableAuto(snapshot.DefaultAutoConfig())
-	// Reclaim a branch's snapshots when it is deleted.
+	gcService := gc.NewService(walService, branchService, snapshotService)
+	// Reclaim a deleted branch's WAL entries and snapshots. Safe because
+	// regular deletion refuses branches with children.
 	branchService.SetDeleteHook(func(branchID string) {
-		if _, _, err := snapshotService.CleanupBranch(context.Background(), branchID); err != nil {
-			fmt.Printf("Warning: failed to clean up snapshots for branch %s: %v\n", branchID, err)
+		if _, _, _, err := gcService.ReclaimDeletedBranch(context.Background(), branchID); err != nil {
+			fmt.Printf("Warning: failed to reclaim storage for branch %s: %v\n", branchID, err)
 		}
 	})
 
@@ -114,8 +118,15 @@ func NewServices() (*Services, error) {
 		Importer:     importerService,
 		Migrate:      migrateService,
 		Snapshots:    snapshotService,
+		GC:           gcService,
 		Monitor:      monitor,
 	}, nil
+}
+
+// RunGC wraps garbage collection for CLI use: the cli module cannot import
+// internal packages, so the config type stays behind this boundary.
+func (s *Services) RunGC(ctx context.Context, projectID string, retention time.Duration, dryRun bool) (*gc.Report, error) {
+	return s.GC.RunProject(ctx, projectID, gc.Config{RetentionWindow: retention, DryRun: dryRun})
 }
 
 // ImportPreview wraps the importer preview functionality for CLI use

--- a/tests/wal/gc_test.go
+++ b/tests/wal/gc_test.go
@@ -1,0 +1,218 @@
+package wal_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/gc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// zeroRetention makes every existing entry immediately out-of-window, so
+// tests exercise pure coverage logic.
+var zeroRetention = gc.Config{RetentionWindow: 0}
+
+func countBranchEntries(t *testing.T, f *snapshotFixture, branchID string) int {
+	t.Helper()
+	entries, err := f.wal.GetBranchEntries(branchID, "", 0, int64(1)<<62)
+	require.NoError(t, err)
+	return len(entries)
+}
+
+func TestGC_RequiresSnapshotCoverage(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	gcService := gc.NewService(f.wal, f.branches, f.snapshots)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("gc-cover", "main", "")
+	require.NoError(t, err)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	for i := 0; i < 10; i++ {
+		_, err := writer.InsertOne(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%d", i)})
+		require.NoError(t, err)
+	}
+
+	// No snapshot: nothing may be reclaimed, however old the entries are.
+	before := countBranchEntries(t, f, main.ID)
+	report, err := gcService.RunProject(ctx, "gc-cover", zeroRetention)
+	require.NoError(t, err)
+	assert.Zero(t, report.EntriesRemoved, "uncovered history is never deleted")
+	assert.Equal(t, before, countBranchEntries(t, f, main.ID))
+
+	// Snapshot, then GC: covered entries go, state is unchanged.
+	main, _ = f.branches.GetBranchByID(main.ID)
+	stateBefore, err := f.matFull.MaterializeBranch(main)
+	require.NoError(t, err)
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+
+	report, err = gcService.RunProject(ctx, "gc-cover", zeroRetention)
+	require.NoError(t, err)
+	assert.EqualValues(t, 10, report.EntriesRemoved, "all covered data entries reclaimed")
+
+	stateAfter, err := f.mat.MaterializeBranch(main)
+	require.NoError(t, err)
+	requireSameState(t, stateBefore, stateAfter, "state after GC")
+
+	// Idempotent.
+	report, err = gcService.RunProject(ctx, "gc-cover", zeroRetention)
+	require.NoError(t, err)
+	assert.Zero(t, report.EntriesRemoved)
+}
+
+func TestGC_RetentionWindowKeepsRecentHistory(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	gcService := gc.NewService(f.wal, f.branches, f.snapshots)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("gc-window", "main", "")
+	require.NoError(t, err)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	for i := 0; i < 5; i++ {
+		_, err := writer.InsertOne(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%d", i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+
+	// Everything is younger than an hour: a one-hour window reclaims nothing.
+	report, err := gcService.RunProject(ctx, "gc-window", gc.Config{RetentionWindow: time.Hour})
+	require.NoError(t, err)
+	assert.Zero(t, report.EntriesRemoved, "in-window history must survive even when covered")
+}
+
+func TestGC_LiveChildForkPinsHistory(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	gcService := gc.NewService(f.wal, f.branches, f.snapshots)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("gc-fork", "main", "")
+	require.NoError(t, err)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	for i := 0; i < 8; i++ {
+		_, err := writer.InsertOne(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%d", i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	// Fork first, snapshot afterwards: the snapshot is newer than the fork
+	// point, so the child cannot use it — its history must stay pinned.
+	child, err := f.branches.CreateBranch("gc-fork", "child", main.ID)
+	require.NoError(t, err)
+	for i := 8; i < 12; i++ {
+		_, err := writer.InsertOne(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%d", i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+
+	report, err := gcService.RunProject(ctx, "gc-fork", zeroRetention)
+	require.NoError(t, err)
+	assert.Zero(t, report.EntriesRemoved,
+		"a live child without a usable snapshot at or below its fork pins the parent's history")
+
+	childState, err := f.mat.MaterializeCollection(child, "docs")
+	require.NoError(t, err)
+	assert.Len(t, childState, 8, "child still materializes its fork state")
+
+	// The child gains coverage only from a snapshot at or below its fork
+	// point. Delete the child instead: the pin disappears and the parent
+	// reclaims. (No delete hook is wired in this fixture, so deletion only
+	// flips the flag — exactly what this test needs.)
+	require.NoError(t, f.branches.DeleteBranch("gc-fork", "child"))
+
+	report, err = gcService.RunProject(ctx, "gc-fork", zeroRetention)
+	require.NoError(t, err)
+	assert.EqualValues(t, 12, report.EntriesRemoved, "unpinned covered history reclaimed")
+
+	mainState, err := f.mat.MaterializeCollection(main, "docs")
+	require.NoError(t, err)
+	assert.Len(t, mainState, 12)
+}
+
+func TestGC_SnapshotBeforeForkAllowsReclaim(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	gcService := gc.NewService(f.wal, f.branches, f.snapshots)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("gc-fork2", "main", "")
+	require.NoError(t, err)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	for i := 0; i < 6; i++ {
+		_, err := writer.InsertOne(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%d", i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	// Snapshot first, fork afterwards: the child's fork point is at (or
+	// above) the snapshot, so the child reads through the snapshot and the
+	// raw entries below it are reclaimable.
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+	child, err := f.branches.CreateBranch("gc-fork2", "child", main.ID)
+	require.NoError(t, err)
+
+	report, err := gcService.RunProject(ctx, "gc-fork2", zeroRetention)
+	require.NoError(t, err)
+	assert.EqualValues(t, 6, report.EntriesRemoved,
+		"child forked at the snapshot reads through it; raw entries reclaimed")
+
+	childState, err := f.mat.MaterializeCollection(child, "docs")
+	require.NoError(t, err)
+	assert.Len(t, childState, 6, "child materializes from the parent snapshot after GC")
+}
+
+func TestGC_DeletedBranchReclaimsEverything(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	gcService := gc.NewService(f.wal, f.branches, f.snapshots)
+	ctx := context.Background()
+
+	// Wire the hook the way walcli does.
+	f.branches.SetDeleteHook(func(branchID string) {
+		_, _, _, err := gcService.ReclaimDeletedBranch(ctx, branchID)
+		require.NoError(t, err)
+	})
+
+	main, err := f.branches.CreateBranch("gc-del", "main", "")
+	require.NoError(t, err)
+	mainWriter := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	_, err = mainWriter.InsertOne(ctx, "docs", bson.M{"_id": "keep"})
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	doomed, err := f.branches.CreateBranch("gc-del", "doomed", main.ID)
+	require.NoError(t, err)
+	doomedWriter := driverwal.NewInterceptor(f.wal, doomed, f.branches, f.mat)
+	for i := 0; i < 20; i++ {
+		_, err := doomedWriter.InsertOne(ctx, "scratch", bson.M{"_id": fmt.Sprintf("s%d", i)})
+		require.NoError(t, err)
+	}
+	doomed, _ = f.branches.GetBranchByID(doomed.ID)
+	_, err = f.snapshots.CreateSnapshot(ctx, doomed.ID, doomed.HeadLSN)
+	require.NoError(t, err)
+
+	require.NoError(t, f.branches.DeleteBranch("gc-del", "doomed"))
+
+	assert.Zero(t, countBranchEntries(t, f, doomed.ID), "deleted branch keeps no WAL entries")
+	snaps, err := f.snapshots.ListSnapshots(ctx, doomed.ID)
+	require.NoError(t, err)
+	assert.Empty(t, snaps, "deleted branch keeps no snapshots")
+
+	// The parent is untouched.
+	state, err := f.mat.MaterializeCollection(main, "docs")
+	require.NoError(t, err)
+	assert.Len(t, state, 1)
+}


### PR DESCRIPTION
Final M2 slice (except optional object-storage offload): WAL entries get reclaimed once nothing can ever read them, giving storage an upper bound of *state size + retention window of history* instead of the full write history forever.

## The coverage rule

Per (branch, collection), entries at or below `min(S, R, min over live children of S_i)` are deleted:

- **S** — newest snapshot valid for *every* possible future reader (no later discarded range overlaps it).
- **R** — newest LSN older than the retention window (default 7 days). The window is the time-travel/audit/undo guarantee; younger entries never go.
- **S_i** — newest snapshot at or below each live child's **fork point**. Children and all their descendants read the parent's segment with an upper bound pinned to the fork (ancestry traversal clamps the limit at each hop), so only snapshots at or below the fork can serve them. A child forked above the newest snapshot pins nothing; a child forked below it pins everything the child might replay.

History without snapshot coverage is **never** deleted, no matter how old.

## Also

- Deleting a branch now reclaims its WAL entries along with its snapshots (delete hook now goes through a GC service wrapping both). Safe because regular deletion refuses branches with children.
- `argon gc -p <project> [--retention 168h] [--dry-run]`, with a `walcli` wrapper since the cli module can't import internal packages.
- ARCHITECTURE.md gains the GC chapter; object-storage offload stays explicitly optional behind the `ChunkStore` interface.

## Tests

Each branch of the coverage argument has a dedicated test: no snapshot → nothing reclaimed; covered + zero window → reclaimed with state identical before/after (checked against a snapshot-free materializer); in-window history survives; fork-before-snapshot pins the parent until the child is deleted; snapshot-before-fork lets the parent reclaim while the child reads through the snapshot; deleted branches drop entries + manifests + unshared chunks. Full suite green locally, lint clean.