### PR TITLE
Docs: reflect M2 engine completion, benchmarks remain

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Argon's engine is being rebuilt milestone by milestone, correctness first ([full
 | Milestone | Scope | Status |
 |---|---|---|
 | **M1 · Correctness** | Deterministic replay (property-tested), distributed LSN sequencer, branch ancestry isolation, truthful write results, WAL v2 migration | ✅ Shipped |
-| **M2 · Bounded time travel** | Snapshots that bound replay depth, WAL segmentation + GC, **public reproducible benchmarks** | 🚧 In progress |
+| **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · **public reproducible benchmarks** 🚧 | Engine shipped · benchmarks in progress |
 | **M3 · True drop-in** | One physical MongoDB database per branch, change-stream capture, per-branch connection strings, `argon undo --session` | Planned |
 | **M4 · Merge & diff** | Document-level diff, three-way merge, reviewable data PRs | Planned |
 | **M5 · Agent ecosystem** | MCP server, LangGraph checkpointer, TTL sandboxes, eval pinning | Planned |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -244,17 +244,23 @@ Current limitations (deliberate scope):
   options (sort/skip/limit/projection) not applied; results in canonical
   document-ID order.
 - No merge/diff commands yet (pre-images already carry the data they need).
-- WAL entries and snapshot chunks live in MongoDB; offload to object
-  storage (S3/GCS) is an optional cost optimization behind the ChunkStore
-  interface, not yet implemented.
+- WAL entries live in MongoDB and are reclaimed by retention-window GC once
+  snapshots cover them; snapshot chunks can additionally live in an
+  S3-compatible or filesystem chunk store (see "Chunk store backends"
+  above). GCS is not yet a backend.
+- No published performance numbers yet: the public, reproducible benchmark
+  suite is the remaining M2 deliverable, and numbers return only with it.
 
 Planned next (in order):
 
-1. **M3 — mongod as compute**: branches materialize into real MongoDB
+1. **M2 (remaining) — public benchmarks**: a reproducible benchmark repo
+   (`docker compose up`); every published performance number links to a
+   run you can reproduce.
+2. **M3 — mongod as compute**: branches materialize into real MongoDB
    databases (lazily), reads/writes run on mongod with change-stream
    capture into the WAL, per-branch connection strings — full query
    compatibility without reimplementing MongoDB.
-2. **M4 — merge and diff**: three-way document-level merge with reviewable
+3. **M4 — merge and diff**: three-way document-level merge with reviewable
    merge plans.
 
 ## Storage collections

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -101,15 +101,18 @@ reproduce. What we can say structurally today:
   structurally by running reads on real mongod.
 - No merge/diff commands yet (M4) — pre-images already record the data they
   will need.
-- All WAL entries live in MongoDB; cold-history offload to object storage is
-  the remainder of M2.
+- WAL entries live in MongoDB and are reclaimed by retention-window GC once
+  snapshots cover them; snapshot chunks can additionally live in an
+  S3-compatible or filesystem chunk store.
+- No published performance numbers yet: the public benchmark suite is the
+  remaining M2 deliverable, and numbers return only with it.
 
 ## 🔮 Roadmap
 
 | Milestone | Scope | Status |
 |---|---|---|
 | **M1 · Correctness** | Deterministic replay (property-tested), distributed LSN sequencer, branch ancestry isolation, truthful write results, WAL v2 migration | ✅ Shipped |
-| **M2 · Bounded time travel** | Snapshots that bound replay depth (✅ merged), WAL segmentation + GC, **public reproducible benchmarks** | 🚧 In progress |
+| **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · **public reproducible benchmarks** 🚧 | Engine shipped · benchmarks in progress |
 | **M3 · True drop-in** | One physical MongoDB database per branch, change-stream capture, per-branch connection strings, `argon undo --session` | Planned |
 | **M4 · Merge & diff** | Document-level diff, three-way merge, reviewable data PRs | Planned |
 | **M5 · Agent ecosystem** | MCP server, LangGraph checkpointer, TTL sandboxes, eval pinning | Planned |


### PR DESCRIPTION
Follow-up to #10/#12, which completed the M2 engine work (snapshots, retention-window WAL GC, S3/filesystem chunk stores).

- Fixes the stale Known-limitations bullet in ARCHITECTURE.md that still said object-storage offload was "not yet implemented" — contradicting the chunk-store backends section added by #12 on the same page.
- States the honest current storage model: WAL entries in MongoDB, reclaimed by retention-window GC once snapshots cover them; snapshot chunks optionally in S3-compatible or filesystem stores (GCS not yet a backend).
- Updates the milestone tables in README and FEATURES.md: M2 is now "Engine shipped · benchmarks in progress" with per-item status. The public reproducible benchmark suite is the one remaining M2 deliverable, and it stays the gate for publishing any performance numbers.