### PR TITLE
Check branches out into real MongoDB databases (mongod as compute)

### DIFF
--- a/cli/cmd/checkout.go
+++ b/cli/cmd/checkout.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+// resolveBranch loads the project and branch named by the shared flags.
+func resolveBranch(services *walcli.Services, projectName, branchName string) (string, error) {
+	project, err := services.Projects.GetProjectByName(projectName)
+	if err != nil {
+		return "", fmt.Errorf("project %q not found: %w", projectName, err)
+	}
+	if branchName == "" {
+		branchName = "main"
+	}
+	branch, err := services.Branches.GetBranch(project.ID, branchName)
+	if err != nil {
+		return "", fmt.Errorf("branch %q not found: %w", branchName, err)
+	}
+	return branch.ID, nil
+}
+
+var checkoutCmd = &cobra.Command{
+	Use:   "checkout",
+	Short: "Materialize a branch into a real MongoDB database",
+	Long: `Checkout builds the branch's state into a physical MongoDB database
+that any unmodified MongoDB driver can connect to: queries, indexes,
+aggregation and transactions all run on mongod itself. While checked
+out, feed the WAL by running "argon watch" so direct writes keep
+versioned history; SDK writes to a checked-out branch are rejected.
+
+Re-running checkout refreshes the database to the branch's current WAL
+state.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		branchID, err := resolveBranch(services, projectName, branchName)
+		if err != nil {
+			return err
+		}
+
+		info, err := services.Checkout.Checkout(context.Background(), branchID)
+		if err != nil {
+			return fmt.Errorf("checkout failed: %w", err)
+		}
+
+		fmt.Printf("Checked out at LSN %d: %d collection(s), %d document(s)\n",
+			info.LSN, info.Collections, info.Documents)
+		fmt.Printf("Connection string:\n  %s\n", services.BranchConnectionString(info.PhysicalDB))
+		fmt.Println("Run \"argon watch\" for this branch to capture direct writes into the WAL.")
+		return nil
+	},
+}
+
+var connectCmd = &cobra.Command{
+	Use:   "connect",
+	Short: "Print the connection string of a checked-out branch",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		branchID, err := resolveBranch(services, projectName, branchName)
+		if err != nil {
+			return err
+		}
+		branch, err := services.Branches.GetBranchByID(branchID)
+		if err != nil {
+			return err
+		}
+		if !branch.IsLive() {
+			return fmt.Errorf("branch is not checked out; run \"argon checkout\" first")
+		}
+		fmt.Println(services.BranchConnectionString(branch.PhysicalDB))
+		return nil
+	},
+}
+
+var releaseCmd = &cobra.Command{
+	Use:   "release",
+	Short: "Drop a branch's physical database (the WAL keeps the history)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		branchID, err := resolveBranch(services, projectName, branchName)
+		if err != nil {
+			return err
+		}
+		if err := services.Checkout.Release(context.Background(), branchID); err != nil {
+			return fmt.Errorf("release failed: %w", err)
+		}
+		fmt.Println("Released. Check the branch out again anytime to rebuild it from the WAL.")
+		return nil
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{checkoutCmd, connectCmd, releaseCmd} {
+		c.Flags().StringP("project", "p", "", "Project name (required)")
+		c.Flags().StringP("branch", "b", "", "Branch name (default: main)")
+	}
+	rootCmd.AddCommand(checkoutCmd)
+	rootCmd.AddCommand(connectCmd)
+	rootCmd.AddCommand(releaseCmd)
+}

--- a/internal/branch/wal/service.go
+++ b/internal/branch/wal/service.go
@@ -188,6 +188,24 @@ func (s *BranchService) GetBranchByIDAny(branchID string) (*wal.Branch, error) {
 	return &branch, nil
 }
 
+// SetCheckoutState records (or clears, with empty values) a branch's
+// physical-database checkout.
+func (s *BranchService) SetCheckoutState(branchID, physicalDB, state string, checkedOutLSN int64) error {
+	ctx := context.Background()
+	update := bson.M{}
+	if physicalDB == "" && state == "" {
+		update["$unset"] = bson.M{"physical_db": "", "state": "", "checked_out_lsn": ""}
+	} else {
+		update["$set"] = bson.M{
+			"physical_db":     physicalDB,
+			"state":           state,
+			"checked_out_lsn": checkedOutLSN,
+		}
+	}
+	_, err := s.collection.UpdateOne(ctx, bson.M{"_id": branchID}, update)
+	return err
+}
+
 // AddDiscardedRange records an LSN window abandoned by a reset so that
 // materialization skips it. The entries themselves stay in the WAL for
 // audit and for time travel to points before the reset.

--- a/internal/checkout/service.go
+++ b/internal/checkout/service.go
@@ -1,0 +1,225 @@
+// Package checkout materializes branches into real MongoDB databases —
+// "mongod as compute". A checked-out branch gets a physical database that
+// applications connect to with any unmodified MongoDB driver: queries,
+// indexes, aggregation and transactions are executed by mongod itself
+// instead of an in-process reimplementation. The WAL remains the versioned
+// source of truth; while a branch is live, its WAL is fed from the
+// database's change stream (see the ingest package) rather than the SDK
+// write path.
+package checkout
+
+import (
+	"context"
+	"fmt"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/argon-lab/argon/internal/wal"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// insertBatchSize bounds bulk-insert batches during materialization.
+const insertBatchSize = 1000
+
+// Service checks branches out into physical databases and back.
+type Service struct {
+	client       *mongo.Client
+	branches     *branchwal.BranchService
+	materializer *materializer.Service
+}
+
+// NewService creates a checkout service. The client must be the same
+// deployment that holds the Argon metadata: physical branch databases live
+// alongside it.
+func NewService(client *mongo.Client, branches *branchwal.BranchService, mat *materializer.Service) *Service {
+	return &Service{client: client, branches: branches, materializer: mat}
+}
+
+// PhysicalDBName is the database a branch materializes into. Branch IDs
+// are globally unique, so the project doesn't need to appear; the fixed
+// prefix keeps Argon-owned databases recognizable and clear of user names.
+func PhysicalDBName(branchID string) string {
+	return "argon_br_" + branchID
+}
+
+// Info describes a completed checkout.
+type Info struct {
+	BranchID    string
+	PhysicalDB  string
+	LSN         int64
+	Collections int
+	Documents   int64
+}
+
+// Checkout materializes the branch's state at its current head into its
+// physical database and marks the branch live. Re-running refreshes the
+// database to the branch's current WAL state (any direct writes since the
+// previous checkout that have already been ingested are preserved by
+// definition; un-ingested ones would be lost, so refresh while the
+// ingester is stopped or drained).
+func (s *Service) Checkout(ctx context.Context, branchID string) (*Info, error) {
+	branch, err := s.branches.GetBranchByID(branchID)
+	if err != nil {
+		return nil, fmt.Errorf("branch %s not found: %w", branchID, err)
+	}
+
+	state, err := s.materializer.MaterializeBranch(branch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to materialize branch: %w", err)
+	}
+
+	dbName := PhysicalDBName(branch.ID)
+	physical := s.client.Database(dbName)
+
+	// Idempotent refresh: rebuild from the WAL state.
+	if err := physical.Drop(ctx); err != nil {
+		return nil, fmt.Errorf("failed to reset physical database: %w", err)
+	}
+
+	info := &Info{BranchID: branch.ID, PhysicalDB: dbName, LSN: branch.HeadLSN}
+	for collection, docs := range state {
+		count, err := s.loadCollection(ctx, physical, collection, docs)
+		if err != nil {
+			return nil, fmt.Errorf("collection %s: %w", collection, err)
+		}
+		info.Collections++
+		info.Documents += count
+	}
+
+	if err := s.branches.SetCheckoutState(branch.ID, dbName, wal.BranchStateLive, branch.HeadLSN); err != nil {
+		return nil, fmt.Errorf("failed to mark branch live: %w", err)
+	}
+	return info, nil
+}
+
+// loadCollection bulk-inserts one collection's state and prepares it for
+// change-stream capture.
+func (s *Service) loadCollection(ctx context.Context, physical *mongo.Database, collection string, docs map[string]bson.M) (int64, error) {
+	// Pre/post images give the ingester exact document images on update
+	// and delete events. Best effort: unsupported deployments still work
+	// through updateLookup, with pre-images absent.
+	if err := EnablePrePostImages(ctx, physical, collection); err != nil {
+		return 0, err
+	}
+	if len(docs) == 0 {
+		return 0, nil
+	}
+
+	coll := physical.Collection(collection)
+	batch := make([]interface{}, 0, insertBatchSize)
+	var total int64
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		if _, err := coll.InsertMany(ctx, batch, options.InsertMany().SetOrdered(false)); err != nil {
+			return fmt.Errorf("failed to load documents: %w", err)
+		}
+		total += int64(len(batch))
+		batch = batch[:0]
+		return nil
+	}
+
+	for _, doc := range docs {
+		batch = append(batch, doc)
+		if len(batch) >= insertBatchSize {
+			if err := flush(); err != nil {
+				return total, err
+			}
+		}
+	}
+	if err := flush(); err != nil {
+		return total, err
+	}
+	return total, nil
+}
+
+// EnablePrePostImages turns on change-stream pre/post images for a
+// collection, creating it if needed. Failures on deployments that don't
+// support the option (pre-6.0) are ignored — capture degrades to
+// updateLookup post-images.
+func EnablePrePostImages(ctx context.Context, physical *mongo.Database, collection string) error {
+	err := physical.RunCommand(ctx, bson.D{
+		{Key: "create", Value: collection},
+		{Key: "changeStreamPreAndPostImages", Value: bson.M{"enabled": true}},
+	}).Err()
+	if err == nil {
+		return nil
+	}
+	// Collection may already exist: collMod instead.
+	modErr := physical.RunCommand(ctx, bson.D{
+		{Key: "collMod", Value: collection},
+		{Key: "changeStreamPreAndPostImages", Value: bson.M{"enabled": true}},
+	}).Err()
+	if modErr == nil {
+		return nil
+	}
+	// Unsupported server or option: proceed without pre-images.
+	return nil
+}
+
+// Release drops the physical database and returns the branch to
+// metadata-only state. The WAL keeps everything; a later checkout rebuilds
+// the database. Un-ingested direct writes are lost — drain the ingester
+// first.
+func (s *Service) Release(ctx context.Context, branchID string) error {
+	branch, err := s.branches.GetBranchByID(branchID)
+	if err != nil {
+		return fmt.Errorf("branch %s not found: %w", branchID, err)
+	}
+	if branch.PhysicalDB != "" {
+		if err := s.client.Database(branch.PhysicalDB).Drop(ctx); err != nil {
+			return fmt.Errorf("failed to drop physical database: %w", err)
+		}
+	}
+	return s.branches.SetCheckoutState(branch.ID, "", "", 0)
+}
+
+// ConnectionString renders the URI applications use to reach a checked-out
+// branch, based on the deployment URI Argon itself uses.
+func ConnectionString(baseURI, physicalDB string) string {
+	if baseURI == "" {
+		baseURI = "mongodb://localhost:27017"
+	}
+	// Insert the database into the URI: mongodb://host[:port][/db][?opts]
+	// Keep it simple and robust for the common forms.
+	base := baseURI
+	var query string
+	if i := indexByte(base, '?'); i >= 0 {
+		query = base[i:]
+		base = base[:i]
+	}
+	// Strip a trailing default database path if present.
+	if i := indexByteAfterScheme(base, '/'); i >= 0 {
+		base = base[:i]
+	}
+	return base + "/" + physicalDB + query
+}
+
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// indexByteAfterScheme finds the first occurrence of c after "://".
+func indexByteAfterScheme(s string, c byte) int {
+	start := 0
+	for i := 0; i+2 < len(s); i++ {
+		if s[i] == ':' && s[i+1] == '/' && s[i+2] == '/' {
+			start = i + 3
+			break
+		}
+	}
+	for i := start; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/driver/wal/interceptor.go
+++ b/internal/driver/wal/interceptor.go
@@ -91,8 +91,22 @@ type match struct {
 	doc   bson.M
 }
 
+// guardNotLive rejects SDK writes to checked-out branches: their WAL is
+// fed from the physical database's change stream, and writing through both
+// paths would double-log. Handles created before a checkout can be stale;
+// recreate handles after checking a branch out.
+func (i *Interceptor) guardNotLive() error {
+	if i.branch.IsLive() {
+		return fmt.Errorf("branch %s is checked out as %s: connect with a MongoDB driver instead of the SDK write path", i.branch.Name, i.branch.PhysicalDB)
+	}
+	return nil
+}
+
 // InsertOne intercepts an insert operation and writes a put entry.
 func (i *Interceptor) InsertOne(ctx context.Context, collection string, document interface{}) (*InsertResult, error) {
+	if err := i.guardNotLive(); err != nil {
+		return nil, err
+	}
 	docID, doc, err := i.ensureDocumentID(document)
 	if err != nil {
 		return nil, err
@@ -120,6 +134,9 @@ func (i *Interceptor) InsertOne(ctx context.Context, collection string, document
 
 // InsertMany intercepts a bulk insert and writes one batched set of puts.
 func (i *Interceptor) InsertMany(ctx context.Context, collection string, documents []interface{}) ([]interface{}, error) {
+	if err := i.guardNotLive(); err != nil {
+		return nil, err
+	}
 	if len(documents) == 0 {
 		return nil, fmt.Errorf("insertMany requires at least one document")
 	}
@@ -185,6 +202,9 @@ func (i *Interceptor) ReplaceOne(ctx context.Context, collection string, filter,
 }
 
 func (i *Interceptor) applyUpdate(collection string, filter, update interface{}, upsert, limitOne bool) (*UpdateResult, error) {
+	if err := i.guardNotLive(); err != nil {
+		return nil, err
+	}
 	filterDoc, err := normalizeFilter(filter)
 	if err != nil {
 		return nil, err
@@ -256,6 +276,9 @@ func (i *Interceptor) DeleteMany(ctx context.Context, collection string, filter 
 }
 
 func (i *Interceptor) applyDelete(collection string, filter interface{}, limitOne bool) (*DeleteResult, error) {
+	if err := i.guardNotLive(); err != nil {
+		return nil, err
+	}
 	filterDoc, err := normalizeFilter(filter)
 	if err != nil {
 		return nil, err

--- a/internal/wal/models.go
+++ b/internal/wal/models.go
@@ -153,6 +153,24 @@ type Branch struct {
 	// necessarily higher than the discarded entries') would advance the head
 	// past the discarded window and resurrect it.
 	DiscardedRanges []LSNRange `bson:"discarded_ranges,omitempty" json:"discarded_ranges,omitempty"`
+
+	// Checkout state (mongod-as-compute). A checked-out ("live") branch is
+	// materialized into a real MongoDB database that applications connect
+	// to directly; the WAL is fed from its change stream instead of the
+	// SDK write path.
+	PhysicalDB     string `bson:"physical_db,omitempty" json:"physical_db,omitempty"`
+	State          string `bson:"state,omitempty" json:"state,omitempty"` // "" | BranchStateLive
+	CheckedOutLSN  int64  `bson:"checked_out_lsn,omitempty" json:"checked_out_lsn,omitempty"`
+}
+
+// BranchStateLive marks a branch as checked out into a physical database.
+const BranchStateLive = "live"
+
+// IsLive reports whether the branch is checked out into a physical
+// database (writes flow through mongod and the change-stream ingester, not
+// the SDK interceptor).
+func (b *Branch) IsLive() bool {
+	return b.State == BranchStateLive
 }
 
 // IsDiscardedForRead reports whether an LSN must be skipped when reading

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/checkout"
 	"github.com/argon-lab/argon/internal/gc"
 	"github.com/argon-lab/argon/internal/importer"
 	"github.com/argon-lab/argon/internal/materializer"
@@ -32,7 +33,9 @@ type Services struct {
 	Migrate      *migrate.Service
 	Snapshots    *snapshot.Service
 	GC           *gc.Service
+	Checkout     *checkout.Service
 	Monitor      *wal.Monitor
+	MongoURI     string
 }
 
 // NewServices creates and returns all WAL services
@@ -91,6 +94,7 @@ func NewServices() (*Services, error) {
 	}
 	snapshotService.EnableAuto(snapshot.DefaultAutoConfig())
 	gcService := gc.NewService(walService, branchService, snapshotService)
+	checkoutService := checkout.NewService(client, branchService, materializerService)
 	// Reclaim a deleted branch's WAL entries and snapshots. Safe because
 	// regular deletion refuses branches with children.
 	branchService.SetDeleteHook(func(branchID string) {
@@ -126,8 +130,16 @@ func NewServices() (*Services, error) {
 		Migrate:      migrateService,
 		Snapshots:    snapshotService,
 		GC:           gcService,
+		Checkout:     checkoutService,
 		Monitor:      monitor,
+		MongoURI:     mongoURI,
 	}, nil
+}
+
+// BranchConnectionString renders the URI applications use to reach a
+// checked-out branch's physical database.
+func (s *Services) BranchConnectionString(physicalDB string) string {
+	return checkout.ConnectionString(s.MongoURI, physicalDB)
 }
 
 // RunGC wraps garbage collection for CLI use: the cli module cannot import

--- a/tests/wal/checkout_test.go
+++ b/tests/wal/checkout_test.go
@@ -1,0 +1,188 @@
+package wal_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/argon-lab/argon/internal/checkout"
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// newCheckoutFixture extends the snapshot fixture with a checkout service
+// and a client handle for physical databases.
+func newCheckoutFixture(t *testing.T) (*snapshotFixture, *checkout.Service, *mongo.Client) {
+	t.Helper()
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	client := db.Client()
+	svc := checkout.NewService(client, f.branches, f.mat)
+	return f, svc, client
+}
+
+func dropPhysical(t *testing.T, client *mongo.Client, branchID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = client.Database(checkout.PhysicalDBName(branchID)).Drop(context.Background())
+	})
+}
+
+func TestCheckout_MaterializesIntoRealMongo(t *testing.T) {
+	f, svc, client := newCheckoutFixture(t)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("co-test", "main", "")
+	require.NoError(t, err)
+	dropPhysical(t, client, main.ID)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+
+	for i := 0; i < 50; i++ {
+		_, err := writer.InsertOne(ctx, "users", bson.M{
+			"_id":   fmt.Sprintf("u%02d", i),
+			"score": int32(i),
+			"team":  []string{"red", "blue"}[i%2],
+		})
+		require.NoError(t, err)
+	}
+	_, err = writer.InsertOne(ctx, "orders", bson.M{"_id": "o1", "total": int32(99)})
+	require.NoError(t, err)
+
+	info, err := svc.Checkout(ctx, main.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, info.Collections)
+	assert.EqualValues(t, 51, info.Documents)
+
+	physical := client.Database(info.PhysicalDB)
+
+	t.Run("State matches the WAL materialization", func(t *testing.T) {
+		count, err := physical.Collection("users").CountDocuments(ctx, bson.M{})
+		require.NoError(t, err)
+		assert.EqualValues(t, 50, count)
+
+		var doc bson.M
+		require.NoError(t, physical.Collection("users").FindOne(ctx, bson.M{"_id": "u07"}).Decode(&doc))
+		assert.EqualValues(t, 7, doc["score"])
+	})
+
+	t.Run("Real mongod capabilities work", func(t *testing.T) {
+		users := physical.Collection("users")
+
+		// Secondary index.
+		_, err := users.Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{Key: "score", Value: -1}}})
+		require.NoError(t, err)
+
+		// Sort + limit + skip — Find options the SDK path never supported.
+		cursor, err := users.Find(ctx, bson.M{},
+			options.Find().SetSort(bson.D{{Key: "score", Value: -1}}).SetLimit(3).SetSkip(1))
+		require.NoError(t, err)
+		var top []bson.M
+		require.NoError(t, cursor.All(ctx, &top))
+		require.Len(t, top, 3)
+		assert.EqualValues(t, 48, top[0]["score"], "sorted descending, skipping the max")
+
+		// Aggregation pipeline — flat-out unsupported before.
+		aggCursor, err := users.Aggregate(ctx, mongo.Pipeline{
+			{{Key: "$group", Value: bson.M{"_id": "$team", "total": bson.M{"$sum": "$score"}}}},
+			{{Key: "$sort", Value: bson.M{"_id": 1}}},
+		})
+		require.NoError(t, err)
+		var groups []bson.M
+		require.NoError(t, aggCursor.All(ctx, &groups))
+		require.Len(t, groups, 2)
+		assert.Equal(t, "blue", groups[0]["_id"])
+	})
+}
+
+func TestCheckout_RefreshAndRelease(t *testing.T) {
+	f, svc, client := newCheckoutFixture(t)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("co-refresh", "main", "")
+	require.NoError(t, err)
+	dropPhysical(t, client, main.ID)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+
+	_, err = writer.InsertOne(ctx, "docs", bson.M{"_id": "a", "v": int32(1)})
+	require.NoError(t, err)
+
+	info, err := svc.Checkout(ctx, main.ID)
+	require.NoError(t, err)
+	physical := client.Database(info.PhysicalDB)
+
+	// Release, write more through the SDK, check out again: the refresh
+	// reflects the newer WAL state.
+	require.NoError(t, svc.Release(ctx, main.ID))
+	branch, _ := f.branches.GetBranchByID(main.ID)
+	assert.False(t, branch.IsLive())
+
+	writer2 := driverwal.NewInterceptor(f.wal, branch, f.branches, f.mat)
+	_, err = writer2.InsertOne(ctx, "docs", bson.M{"_id": "b", "v": int32(2)})
+	require.NoError(t, err)
+
+	_, err = svc.Checkout(ctx, main.ID)
+	require.NoError(t, err)
+	count, err := physical.Collection("docs").CountDocuments(ctx, bson.M{})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, count, "refresh materializes the post-release writes")
+}
+
+func TestCheckout_LiveBranchRejectsSDKWrites(t *testing.T) {
+	f, svc, client := newCheckoutFixture(t)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("co-guard", "main", "")
+	require.NoError(t, err)
+	dropPhysical(t, client, main.ID)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	_, err = writer.InsertOne(ctx, "docs", bson.M{"_id": "a"})
+	require.NoError(t, err)
+
+	_, err = svc.Checkout(ctx, main.ID)
+	require.NoError(t, err)
+
+	// A fresh handle sees the live state and refuses every write form.
+	live, err := f.branches.GetBranchByID(main.ID)
+	require.NoError(t, err)
+	require.True(t, live.IsLive())
+	liveWriter := driverwal.NewInterceptor(f.wal, live, f.branches, f.mat)
+
+	_, err = liveWriter.InsertOne(ctx, "docs", bson.M{"_id": "b"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checked out")
+
+	_, err = liveWriter.UpdateOne(ctx, "docs", bson.M{"_id": "a"}, bson.M{"$set": bson.M{"x": 1}}, false)
+	require.Error(t, err)
+
+	_, err = liveWriter.DeleteMany(ctx, "docs", bson.M{})
+	require.Error(t, err)
+
+	// Reads still work (the WAL state remains queryable).
+	docs, err := liveWriter.FindMatches("docs", bson.M{}, false)
+	require.NoError(t, err)
+	assert.Len(t, docs, 1)
+
+	// After release, SDK writes flow again.
+	require.NoError(t, svc.Release(ctx, main.ID))
+	released, _ := f.branches.GetBranchByID(main.ID)
+	releasedWriter := driverwal.NewInterceptor(f.wal, released, f.branches, f.mat)
+	_, err = releasedWriter.InsertOne(ctx, "docs", bson.M{"_id": "c"})
+	require.NoError(t, err)
+}
+
+func TestCheckout_ConnectionString(t *testing.T) {
+	cases := []struct{ base, db, want string }{
+		{"mongodb://localhost:27017", "argon_br_x", "mongodb://localhost:27017/argon_br_x"},
+		{"mongodb://localhost:27017/", "argon_br_x", "mongodb://localhost:27017/argon_br_x"},
+		{"mongodb://user:pw@host:27017/admin?authSource=admin", "argon_br_x", "mongodb://user:pw@host:27017/argon_br_x?authSource=admin"},
+		{"mongodb+srv://cluster.example.net/?retryWrites=true", "argon_br_x", "mongodb+srv://cluster.example.net/argon_br_x?retryWrites=true"},
+		{"", "argon_br_x", "mongodb://localhost:27017/argon_br_x"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, checkout.ConnectionString(c.base, c.db), "base %q", c.base)
+	}
+}


### PR DESCRIPTION
First slice of M3: a branch can now materialize into a **physical MongoDB database** that any unmodified driver connects to.

## What this changes

`argon checkout -p <project> -b <branch>` rebuilds the branch's state (snapshot-accelerated) into `argon_br_<branchID>` and prints a connection string. From there, **mongod is the query engine**: secondary indexes, `sort/skip/limit`, aggregation pipelines, transactions — everything the in-process SDK engine could never offer. `argon connect` re-prints the URI; `argon release` drops the database (the WAL keeps all history; checkout again anytime).

Checkout is an **idempotent rebuild from the WAL** — re-running refreshes the database to the branch's current state.

## Write routing

While a branch is live, the SDK write path is rejected with a pointer to the connection string: the branch's WAL will be fed from the database's **change stream** (next PR), and logging through both paths would double-write history. SDK reads still work. Collections are created with `changeStreamPreAndPostImages` enabled (best effort; degrades to updateLookup on older servers) so the ingester gets exact images.

## Tests

- Checked-out state ≡ WAL materialization.
- Real-mongod capabilities on the physical DB: index creation, sorted/paginated finds, `$group` aggregation — asserted working.
- Release → SDK writes → re-checkout reflects them.
- Live guard across insert/update/delete forms; reads unaffected; release restores SDK writes.
- Connection-string rendering across URI shapes (auth, srv, query options).

Next: the change-stream ingester (`argon watch`) that turns direct writes into WAL entries with resume-token recovery.