### PR TITLE
Ingest direct writes into the WAL from branch change streams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,24 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    
-    services:
-      mongodb:
-        image: mongo:latest
-        ports:
-          - 27017:27017
-        options: >-
-          --health-cmd "mongosh --eval 'db.adminCommand({ping: 1})'"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    
+
     steps:
     - uses: actions/checkout@v4
+
+    # Change streams (the ingest path) require a replica set, which service
+    # containers can't be configured as — hence docker run.
+    - name: Start MongoDB (single-node replica set)
+      run: |
+        docker run -d --name ci-mongo -p 27017:27017 mongo:7 --replSet rs0 --bind_ip_all
+        for i in $(seq 1 30); do
+          docker exec ci-mongo mongosh --quiet --eval 'db.runCommand({ping: 1})' && break
+          sleep 1
+        done
+        docker exec ci-mongo mongosh --quiet --eval 'rs.initiate({_id: "rs0", members: [{_id: 0, host: "localhost:27017"}]})'
+        for i in $(seq 1 30); do
+          [ "$(docker exec ci-mongo mongosh --quiet --eval 'db.hello().isWritablePrimary')" = "true" ] && break
+          sleep 1
+        done
     
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/cli/cmd/watch.go
+++ b/cli/cmd/watch.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Capture a checked-out branch's direct writes into the WAL",
+	Long: `Watch tails the change stream of a checked-out branch's physical
+database and converts every write into WAL entries, so branching, time
+travel, diff and undo keep working on data written directly through
+MongoDB drivers.
+
+Runs until interrupted. The stream position is persisted, so restarting
+resumes where the previous run stopped; delivery is at-least-once and
+replay is idempotent, so a crash can never lose or corrupt history.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		branchID, err := resolveBranch(services, projectName, branchName)
+		if err != nil {
+			return err
+		}
+
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
+		fmt.Println("Watching for changes (Ctrl-C to stop)...")
+		if err := services.Ingest.Run(ctx, branchID); err != nil {
+			return fmt.Errorf("watch failed: %w", err)
+		}
+		fmt.Println("Stopped; stream position saved.")
+		return nil
+	},
+}
+
+func init() {
+	watchCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	watchCmd.Flags().StringP("branch", "b", "", "Branch name (default: main)")
+	rootCmd.AddCommand(watchCmd)
+}

--- a/internal/checkout/service.go
+++ b/internal/checkout/service.go
@@ -26,6 +26,7 @@ const insertBatchSize = 1000
 // Service checks branches out into physical databases and back.
 type Service struct {
 	client       *mongo.Client
+	ingestState  *mongo.Collection
 	branches     *branchwal.BranchService
 	materializer *materializer.Service
 }
@@ -33,8 +34,15 @@ type Service struct {
 // NewService creates a checkout service. The client must be the same
 // deployment that holds the Argon metadata: physical branch databases live
 // alongside it.
-func NewService(client *mongo.Client, branches *branchwal.BranchService, mat *materializer.Service) *Service {
-	return &Service{client: client, branches: branches, materializer: mat}
+func NewService(client *mongo.Client, metaDB *mongo.Database, branches *branchwal.BranchService, mat *materializer.Service) *Service {
+	return &Service{
+		client: client,
+		// Same collection the ingest package owns; written here only to
+		// clear stale stream positions (importing ingest would cycle).
+		ingestState:  metaDB.Collection("wal_ingest_state"),
+		branches:     branches,
+		materializer: mat,
+	}
 }
 
 // PhysicalDBName is the database a branch materializes into. Branch IDs
@@ -73,9 +81,13 @@ func (s *Service) Checkout(ctx context.Context, branchID string) (*Info, error) 
 	dbName := PhysicalDBName(branch.ID)
 	physical := s.client.Database(dbName)
 
-	// Idempotent refresh: rebuild from the WAL state.
+	// Idempotent refresh: rebuild from the WAL state. The old change-stream
+	// position points into the dropped database and must not be resumed.
 	if err := physical.Drop(ctx); err != nil {
 		return nil, fmt.Errorf("failed to reset physical database: %w", err)
+	}
+	if _, err := s.ingestState.DeleteOne(ctx, bson.M{"_id": branch.ID}); err != nil {
+		return nil, fmt.Errorf("failed to clear ingest state: %w", err)
 	}
 
 	info := &Info{BranchID: branch.ID, PhysicalDB: dbName, LSN: branch.HeadLSN}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1,0 +1,279 @@
+// Package ingest feeds a checked-out branch's WAL from its physical
+// database's change stream. Applications write to the database with any
+// MongoDB driver; the ingester converts each change event into a physical
+// WAL entry (put with post-image / delete with pre-image), so branching,
+// time travel, diff and undo keep working on directly-written data.
+//
+// Delivery is at-least-once: the resume token is persisted after entries
+// are appended, so a crash between the two can re-deliver events. That is
+// safe by construction — puts and deletes replay idempotently — at the cost
+// of occasional duplicate entries in the log.
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/checkout"
+	"github.com/argon-lab/argon/internal/wal"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// maxBatch bounds how many change events are appended in one WAL batch.
+const maxBatch = 200
+
+// Service turns change streams into WAL entries.
+type Service struct {
+	client   *mongo.Client
+	wal      *wal.Service
+	branches *branchwal.BranchService
+	state    *mongo.Collection // wal_ingest_state: resume tokens per branch
+
+	// Collections observed with pre/post images enabled, per run.
+	seenMu sync.Mutex
+	seen   map[string]bool
+}
+
+// NewService creates an ingester over the deployment holding both the
+// Argon metadata and the physical branch databases.
+func NewService(client *mongo.Client, metaDB *mongo.Database, walService *wal.Service, branches *branchwal.BranchService) *Service {
+	return &Service{
+		client:   client,
+		wal:      walService,
+		branches: branches,
+		state:    metaDB.Collection("wal_ingest_state"),
+		seen:     make(map[string]bool),
+	}
+}
+
+// RunOption configures a Run invocation.
+type RunOption func(*runConfig)
+
+type runConfig struct {
+	ready chan<- struct{}
+}
+
+// WithReady signals on the channel once the change stream is open — i.e.
+// once writes are guaranteed to be captured. Without a persisted resume
+// token the stream starts "now": writes made between checkout and stream
+// open are not captured, so callers that need a hard guarantee should wait
+// for readiness before writing.
+func WithReady(ch chan<- struct{}) RunOption {
+	return func(c *runConfig) { c.ready = ch }
+}
+
+// Run watches the branch's physical database until the context is
+// canceled, converting every data change into WAL entries and advancing
+// the branch head. It resumes from the persisted token when one exists, so
+// restarts don't lose events.
+func (s *Service) Run(ctx context.Context, branchID string, opts ...RunOption) error {
+	var cfg runConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	branch, err := s.branches.GetBranchByID(branchID)
+	if err != nil {
+		return fmt.Errorf("branch %s not found: %w", branchID, err)
+	}
+	if !branch.IsLive() {
+		return fmt.Errorf("branch %s is not checked out; run checkout first", branch.Name)
+	}
+
+	physical := s.client.Database(branch.PhysicalDB)
+
+	csOpts := options.ChangeStream().
+		SetFullDocument(options.UpdateLookup).
+		SetFullDocumentBeforeChange(options.WhenAvailable).
+		SetMaxAwaitTime(500 * time.Millisecond)
+
+	if token, err := s.loadResumeToken(ctx, branchID); err != nil {
+		return err
+	} else if token != nil {
+		csOpts.SetResumeAfter(token)
+	}
+
+	stream, err := physical.Watch(ctx, mongo.Pipeline{}, csOpts)
+	if err != nil {
+		return fmt.Errorf("failed to open change stream on %s: %w", branch.PhysicalDB, err)
+	}
+	defer func() { _ = stream.Close(context.Background()) }()
+
+	if cfg.ready != nil {
+		close(cfg.ready)
+	}
+
+	batch := make([]*wal.Entry, 0, maxBatch)
+	for {
+		if ctx.Err() != nil {
+			// Drain what we have, then stop.
+			return s.flush(branch, batch, stream.ResumeToken())
+		}
+
+		if stream.TryNext(ctx) {
+			entry, err := s.convertEvent(ctx, physical, branch, stream.Current)
+			if err != nil {
+				return err
+			}
+			if entry != nil {
+				batch = append(batch, entry)
+			}
+			if len(batch) < maxBatch {
+				continue
+			}
+		}
+
+		if err := stream.Err(); err != nil {
+			if ctx.Err() != nil {
+				return s.flush(branch, batch, stream.ResumeToken())
+			}
+			return fmt.Errorf("change stream error: %w", err)
+		}
+
+		// Stream drained (or batch full): flush and persist the token.
+		if len(batch) > 0 {
+			if err := s.flush(branch, batch, stream.ResumeToken()); err != nil {
+				return err
+			}
+			batch = batch[:0]
+		}
+	}
+}
+
+// changeEvent is the subset of change-stream event fields the ingester
+// consumes.
+type changeEvent struct {
+	OperationType string `bson:"operationType"`
+	NS            struct {
+		Collection string `bson:"coll"`
+	} `bson:"ns"`
+	DocumentKey struct {
+		ID interface{} `bson:"_id"`
+	} `bson:"documentKey"`
+	FullDocument             bson.Raw `bson:"fullDocument"`
+	FullDocumentBeforeChange bson.Raw `bson:"fullDocumentBeforeChange"`
+}
+
+// convertEvent maps one change event to a WAL entry (nil for events that
+// carry no document state).
+func (s *Service) convertEvent(ctx context.Context, physical *mongo.Database, branch *wal.Branch, raw bson.Raw) (*wal.Entry, error) {
+	var event changeEvent
+	if err := bson.Unmarshal(raw, &event); err != nil {
+		return nil, fmt.Errorf("failed to decode change event: %w", err)
+	}
+
+	switch event.OperationType {
+	case "insert", "update", "replace":
+		if len(event.FullDocument) == 0 {
+			// The document vanished between the update and the lookup; the
+			// upcoming delete event carries the removal.
+			log.Printf("ingest: skipping %s on %s without a post-image (document deleted before lookup)",
+				event.OperationType, event.NS.Collection)
+			return nil, nil
+		}
+		s.ensurePrePostImages(ctx, physical, event.NS.Collection)
+		return &wal.Entry{
+			ProjectID:  branch.ProjectID,
+			BranchID:   branch.ID,
+			Operation:  wal.OpPut,
+			Collection: event.NS.Collection,
+			DocumentID: wal.DocumentIDString(event.DocumentKey.ID),
+			PostImage:  event.FullDocument,
+			PreImage:   event.FullDocumentBeforeChange,
+			Actor:      "ingest",
+		}, nil
+
+	case "delete":
+		return &wal.Entry{
+			ProjectID:  branch.ProjectID,
+			BranchID:   branch.ID,
+			Operation:  wal.OpDelete,
+			Collection: event.NS.Collection,
+			DocumentID: wal.DocumentIDString(event.DocumentKey.ID),
+			PreImage:   event.FullDocumentBeforeChange,
+			Actor:      "ingest",
+		}, nil
+
+	case "drop", "dropDatabase", "rename":
+		// Collection-level DDL carries no document images; representing it
+		// needs dedicated WAL operations (roadmap). Loud, not silent:
+		log.Printf("ingest: %s on %s is not captured in the WAL yet — branch history for this collection is now incomplete",
+			event.OperationType, event.NS.Collection)
+		return nil, nil
+
+	case "invalidate":
+		return nil, fmt.Errorf("change stream invalidated (physical database dropped?)")
+
+	default:
+		return nil, nil
+	}
+}
+
+// ensurePrePostImages best-effort enables exact images on collections the
+// application created directly (checkout-created ones already have it).
+func (s *Service) ensurePrePostImages(ctx context.Context, physical *mongo.Database, collection string) {
+	s.seenMu.Lock()
+	if s.seen[collection] {
+		s.seenMu.Unlock()
+		return
+	}
+	s.seen[collection] = true
+	s.seenMu.Unlock()
+	_ = checkout.EnablePrePostImages(ctx, physical, collection)
+}
+
+// flush appends a batch, advances the branch head and persists the resume
+// token — in that order, so a crash can only re-deliver, never lose. It
+// runs on its own context: durability of already-received events must not
+// depend on whether the caller is being canceled at that instant.
+func (s *Service) flush(branch *wal.Branch, batch []*wal.Entry, token bson.Raw) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if len(batch) > 0 {
+		lsns, err := s.wal.AppendBatch(batch)
+		if err != nil {
+			return fmt.Errorf("failed to append ingested entries: %w", err)
+		}
+		if err := s.branches.UpdateBranchHead(branch.ID, lsns[len(lsns)-1]); err != nil {
+			return fmt.Errorf("failed to advance branch head: %w", err)
+		}
+	}
+	if len(token) == 0 {
+		return nil
+	}
+	_, err := s.state.UpdateOne(ctx,
+		bson.M{"_id": branch.ID},
+		bson.M{"$set": bson.M{"resume_token": token, "updated_at": time.Now()}},
+		options.Update().SetUpsert(true),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to persist resume token: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) loadResumeToken(ctx context.Context, branchID string) (bson.Raw, error) {
+	var doc struct {
+		ResumeToken bson.Raw `bson:"resume_token"`
+	}
+	err := s.state.FindOne(ctx, bson.M{"_id": branchID}).Decode(&doc)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to load resume token: %w", err)
+	}
+	return doc.ResumeToken, nil
+}
+
+// ClearResumeState drops the persisted token (used when a branch is
+// re-checked out from scratch, which invalidates the old stream position).
+func (s *Service) ClearResumeState(ctx context.Context, branchID string) error {
+	_, err := s.state.DeleteOne(ctx, bson.M{"_id": branchID})
+	return err
+}

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -10,6 +10,7 @@ import (
 	"github.com/argon-lab/argon/internal/checkout"
 	"github.com/argon-lab/argon/internal/gc"
 	"github.com/argon-lab/argon/internal/importer"
+	"github.com/argon-lab/argon/internal/ingest"
 	"github.com/argon-lab/argon/internal/materializer"
 	"github.com/argon-lab/argon/internal/migrate"
 	projectwal "github.com/argon-lab/argon/internal/project/wal"
@@ -34,6 +35,7 @@ type Services struct {
 	Snapshots    *snapshot.Service
 	GC           *gc.Service
 	Checkout     *checkout.Service
+	Ingest       *ingest.Service
 	Monitor      *wal.Monitor
 	MongoURI     string
 }
@@ -94,7 +96,8 @@ func NewServices() (*Services, error) {
 	}
 	snapshotService.EnableAuto(snapshot.DefaultAutoConfig())
 	gcService := gc.NewService(walService, branchService, snapshotService)
-	checkoutService := checkout.NewService(client, branchService, materializerService)
+	checkoutService := checkout.NewService(client, db, branchService, materializerService)
+	ingestService := ingest.NewService(client, db, walService, branchService)
 	// Reclaim a deleted branch's WAL entries and snapshots. Safe because
 	// regular deletion refuses branches with children.
 	branchService.SetDeleteHook(func(branchID string) {
@@ -131,6 +134,7 @@ func NewServices() (*Services, error) {
 		Snapshots:    snapshotService,
 		GC:           gcService,
 		Checkout:     checkoutService,
+		Ingest:       ingestService,
 		Monitor:      monitor,
 		MongoURI:     mongoURI,
 	}, nil

--- a/tests/wal/checkout_test.go
+++ b/tests/wal/checkout_test.go
@@ -21,7 +21,7 @@ func newCheckoutFixture(t *testing.T) (*snapshotFixture, *checkout.Service, *mon
 	db := setupTestDB(t)
 	f := newSnapshotFixture(t, db)
 	client := db.Client()
-	svc := checkout.NewService(client, f.branches, f.mat)
+	svc := checkout.NewService(client, db, f.branches, f.mat)
 	return f, svc, client
 }
 

--- a/tests/wal/ingest_test.go
+++ b/tests/wal/ingest_test.go
@@ -1,0 +1,225 @@
+package wal_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/argon-lab/argon/internal/checkout"
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/ingest"
+	"github.com/argon-lab/argon/internal/wal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// ingestFixture holds a checked-out branch with a running ingester.
+type ingestFixture struct {
+	*snapshotFixture
+	checkout *checkout.Service
+	ingest   *ingest.Service
+	client   *mongo.Client
+	branchID string
+	physical *mongo.Database
+}
+
+func newIngestFixture(t *testing.T, project string) *ingestFixture {
+	t.Helper()
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	client := db.Client()
+	co := checkout.NewService(client, db, f.branches, f.mat)
+	ing := ingest.NewService(client, db, f.wal, f.branches)
+
+	main, err := f.branches.CreateBranch(project, "main", "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = client.Database(checkout.PhysicalDBName(main.ID)).Drop(context.Background())
+	})
+
+	// Seed through the SDK so the checkout has content.
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	_, err = writer.InsertOne(context.Background(), "users", bson.M{"_id": "seed", "n": int32(0)})
+	require.NoError(t, err)
+
+	info, err := co.Checkout(context.Background(), main.ID)
+	require.NoError(t, err)
+
+	return &ingestFixture{
+		snapshotFixture: f,
+		checkout:        co,
+		ingest:          ing,
+		client:          client,
+		branchID:        main.ID,
+		physical:        client.Database(info.PhysicalDB),
+	}
+}
+
+// startIngester runs the ingester in the background and returns a stop
+// function that drains it.
+func (f *ingestFixture) startIngester(t *testing.T) (stop func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	ready := make(chan struct{})
+	go func() { done <- f.ingest.Run(ctx, f.branchID, ingest.WithReady(ready)) }()
+	select {
+	case <-ready:
+	case err := <-done:
+		cancel()
+		t.Fatalf("ingester exited before opening the stream: %v", err)
+	case <-time.After(15 * time.Second):
+		cancel()
+		t.Fatal("ingester never became ready")
+	}
+	return func() {
+		cancel()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(15 * time.Second):
+			t.Fatal("ingester did not stop")
+		}
+	}
+}
+
+// waitForHead polls until the branch head reaches at least target entries
+// for the given collection, guarding against ingest lag in assertions.
+func (f *ingestFixture) waitForEntries(t *testing.T, collection string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		branch, err := f.branches.GetBranchByID(f.branchID)
+		require.NoError(t, err)
+		entries, err := f.wal.GetBranchEntries(f.branchID, collection, 0, branch.HeadLSN)
+		require.NoError(t, err)
+		if len(entries) >= want {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d %s entries", want, collection)
+}
+
+// physicalState reads a collection from the physical database keyed the way
+// the materializer keys state.
+func (f *ingestFixture) physicalState(t *testing.T, collection string) map[string]bson.M {
+	t.Helper()
+	cursor, err := f.physical.Collection(collection).Find(context.Background(), bson.M{})
+	require.NoError(t, err)
+	state := make(map[string]bson.M)
+	var docs []bson.M
+	require.NoError(t, cursor.All(context.Background(), &docs))
+	for _, doc := range docs {
+		state[wal.DocumentIDString(doc["_id"])] = doc
+	}
+	return state
+}
+
+func TestIngest_DirectWritesReachTheWAL(t *testing.T) {
+	f := newIngestFixture(t, "ingest-e2e")
+	ctx := context.Background()
+	stop := f.startIngester(t)
+	defer stop()
+
+	users := f.physical.Collection("users")
+
+	// The full write mix, straight through the official driver.
+	_, err := users.InsertOne(ctx, bson.M{"_id": "alice", "score": int32(10)})
+	require.NoError(t, err)
+	_, err = users.UpdateOne(ctx, bson.M{"_id": "alice"}, bson.M{"$inc": bson.M{"score": int32(5)}})
+	require.NoError(t, err)
+	_, err = users.ReplaceOne(ctx, bson.M{"_id": "seed"}, bson.M{"replaced": true})
+	require.NoError(t, err)
+	_, err = users.InsertOne(ctx, bson.M{"_id": "bob", "score": int32(1)})
+	require.NoError(t, err)
+	_, err = users.DeleteOne(ctx, bson.M{"_id": "bob"})
+	require.NoError(t, err)
+
+	// A brand-new collection created directly by the application.
+	_, err = f.physical.Collection("events").InsertOne(ctx, bson.M{"_id": "e1", "kind": "direct"})
+	require.NoError(t, err)
+
+	f.waitForEntries(t, "users", 5)
+	f.waitForEntries(t, "events", 1)
+
+	branch, err := f.branches.GetBranchByID(f.branchID)
+	require.NoError(t, err)
+
+	t.Run("WAL state converges to the physical database", func(t *testing.T) {
+		for _, coll := range []string{"users", "events"} {
+			walState, err := f.matFull.MaterializeCollection(branch, coll)
+			require.NoError(t, err)
+			assert.Equal(t, f.physicalState(t, coll), walState,
+				"collection %s: WAL materialization must equal the physical database", coll)
+		}
+	})
+
+	t.Run("Entries carry images and the ingest actor", func(t *testing.T) {
+		entries, err := f.wal.GetBranchEntries(f.branchID, "users", 0, branch.HeadLSN)
+		require.NoError(t, err)
+
+		var sawUpdateWithPre, sawDelete bool
+		for _, e := range entries {
+			if e.Actor != "ingest" {
+				continue
+			}
+			switch {
+			case e.Operation == wal.OpPut && e.DocumentID == "alice" && len(e.PreImage) > 0:
+				sawUpdateWithPre = true
+				var pre bson.M
+				require.NoError(t, bson.Unmarshal(e.PreImage, &pre))
+				assert.EqualValues(t, 10, pre["score"], "pre-image captures the replaced document")
+			case e.Operation == wal.OpDelete && e.DocumentID == "bob":
+				sawDelete = true
+				var pre bson.M
+				require.NoError(t, bson.Unmarshal(e.PreImage, &pre))
+				assert.EqualValues(t, 1, pre["score"], "delete pre-image captured")
+			}
+		}
+		assert.True(t, sawUpdateWithPre, "update must be ingested as a put with a pre-image")
+		assert.True(t, sawDelete, "delete must be ingested with its pre-image")
+	})
+
+	t.Run("Branching from directly-written data works", func(t *testing.T) {
+		fork, err := f.branches.CreateBranch("ingest-e2e", "fork", f.branchID)
+		require.NoError(t, err)
+		state, err := f.mat.MaterializeCollection(fork, "users")
+		require.NoError(t, err)
+		assert.EqualValues(t, 15, state["alice"]["score"], "fork sees the ingested direct writes")
+	})
+}
+
+func TestIngest_ResumesAfterRestart(t *testing.T) {
+	f := newIngestFixture(t, "ingest-resume")
+	ctx := context.Background()
+
+	// First run captures the first write.
+	stop := f.startIngester(t)
+	docs := f.physical.Collection("docs")
+	_, err := docs.InsertOne(ctx, bson.M{"_id": "first"})
+	require.NoError(t, err)
+	f.waitForEntries(t, "docs", 1)
+	stop()
+
+	// Writes while no ingester is running.
+	for i := 0; i < 5; i++ {
+		_, err := docs.InsertOne(ctx, bson.M{"_id": fmt.Sprintf("offline-%d", i)})
+		require.NoError(t, err)
+	}
+
+	// The restarted ingester resumes from the persisted token and catches up.
+	stop2 := f.startIngester(t)
+	defer stop2()
+	f.waitForEntries(t, "docs", 6)
+
+	branch, err := f.branches.GetBranchByID(f.branchID)
+	require.NoError(t, err)
+	walState, err := f.matFull.MaterializeCollection(branch, "docs")
+	require.NoError(t, err)
+	assert.Len(t, walState, 6, "no offline write may be lost")
+	assert.Equal(t, f.physicalState(t, "docs"), walState)
+}


### PR DESCRIPTION
Second slice of M3 — the loop closes: applications write to a checked-out branch **directly through any MongoDB driver**, and `argon watch` turns those writes into versioned history.

## How it works

The ingester tails the physical database's change stream (`fullDocument: updateLookup`, `fullDocumentBeforeChange: whenAvailable`) and converts events into the same physical WAL entries the SDK path produces: puts with post-images (+ pre-images where available), deletes with pre-images. Everything downstream — branching, time travel, snapshots, GC, diff/undo — works on directly-written data unchanged. There's a test asserting the WAL materialization converges to **exactly** the physical database state under the full write mix, and that a fork taken after direct writes sees them.

## Delivery semantics (honest version)

- **At-least-once**: entries append + head advances *before* the resume token persists, so a crash can only re-deliver — and puts/deletes replay idempotently, so duplicates can't corrupt state (they just take space).
- **Restart-safe**: resumes from the persisted token (tested: writes made while the ingester was down are captured on restart). Checkout clears the token, since a rebuilt database invalidates the old stream position.
- **Flush durability is cancellation-independent**: draining received events runs on its own context.
- **Known windows, documented loudly**: a first watch with no prior token starts at *now* (writes between checkout and first watch are not captured; `WithReady` gives a hard guarantee for programmatic callers). Collection drop/rename isn't representable in the WAL yet and logs a warning instead of silently corrupting history.

## CI

MongoDB moves from a standalone service container to a **single-node replica set** started via `docker run` — change streams require it. (Same pattern as the MinIO step.)

## CLI

`argon watch -p <project> -b <branch>` — runs until Ctrl-C, prints that the stream position is saved.