### PR TITLE
Range and actor undo built on pre-images

### DIFF
--- a/cli/cmd/undo.go
+++ b/cli/cmd/undo.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+var undoCmd = &cobra.Command{
+	Use:   "undo",
+	Short: "Revert a range of a branch's history",
+	Long: `Undo restores every document touched in an LSN range to its state
+just before the range began, using the pre-images recorded in the WAL.
+History stays append-only: the undo itself is written as new history, so
+it is audited and can be undone in turn.
+
+With --actor, only that actor's writes are reverted; documents another
+actor modified afterwards are reported as conflicts and skipped.
+
+Use "argon time-travel info" to find LSNs, and --dry-run to preview.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		fromLSN, _ := cmd.Flags().GetInt64("from-lsn")
+		toLSN, _ := cmd.Flags().GetInt64("to-lsn")
+		actor, _ := cmd.Flags().GetString("actor")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+		if fromLSN <= 0 {
+			return fmt.Errorf("--from-lsn is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		branchID, err := resolveBranch(services, projectName, branchName)
+		if err != nil {
+			return err
+		}
+
+		plan, err := services.BuildUndoPlan(branchID, fromLSN, toLSN, actor)
+		if err != nil {
+			return fmt.Errorf("failed to plan undo: %w", err)
+		}
+
+		fmt.Printf("Undo [%d, %d]", plan.FromLSN, plan.ToLSN)
+		if plan.Actor != "" {
+			fmt.Printf(" for actor %q", plan.Actor)
+		}
+		fmt.Printf(": %d document(s) to revert\n", len(plan.Compensations))
+		for _, c := range plan.Compensations {
+			action := "restore"
+			if c.Restore == nil {
+				action = "delete "
+			}
+			fmt.Printf("  %s %s/%s\n", action, c.Collection, c.DocumentID)
+		}
+		for _, c := range plan.Conflicts {
+			fmt.Printf("  CONFLICT %s/%s: modified by %q at LSN %d — skipped\n",
+				c.Collection, c.DocumentID, c.OtherActor, c.AtLSN)
+		}
+		for _, u := range plan.Unrecoverable {
+			fmt.Printf("  UNRECOVERABLE %s: no pre-image available — skipped\n", u)
+		}
+
+		if dryRun {
+			fmt.Println("Dry run: nothing applied.")
+			return nil
+		}
+
+		restored, deleted, err := services.ApplyUndoPlan(context.Background(), branchID, plan)
+		if err != nil {
+			return fmt.Errorf("undo failed: %w", err)
+		}
+		fmt.Printf("Done: %d restored, %d deleted.\n", restored, deleted)
+		return nil
+	},
+}
+
+func init() {
+	undoCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	undoCmd.Flags().StringP("branch", "b", "", "Branch name (default: main)")
+	undoCmd.Flags().Int64("from-lsn", 0, "Start of the range to revert (required)")
+	undoCmd.Flags().Int64("to-lsn", 0, "End of the range (default: branch head)")
+	undoCmd.Flags().String("actor", "", "Only revert writes by this actor")
+	undoCmd.Flags().Bool("dry-run", false, "Preview without applying")
+	rootCmd.AddCommand(undoCmd)
+}

--- a/internal/undo/service.go
+++ b/internal/undo/service.go
@@ -1,0 +1,243 @@
+// Package undo reverts a range of WAL history by writing compensating
+// operations. History stays append-only: an undo produces new entries (or
+// new physical writes on a live branch) rather than deleting anything, so
+// undos are themselves audited and can be undone.
+//
+// For every document touched in [fromLSN, toLSN], the state to restore is
+// the pre-image of the *oldest* in-range entry for that document — the
+// document as it stood just before the range began. An oldest entry without
+// a pre-image is an insert, so the compensation is a delete.
+package undo
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/wal"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Service plans and applies range/actor undos.
+type Service struct {
+	wal      *wal.Service
+	branches *branchwal.BranchService
+	client   *mongo.Client
+}
+
+// NewService creates an undo service. The client reaches physical branch
+// databases for live-branch application.
+func NewService(walService *wal.Service, branches *branchwal.BranchService, client *mongo.Client) *Service {
+	return &Service{wal: walService, branches: branches, client: client}
+}
+
+// Compensation is one document's planned restoration.
+type Compensation struct {
+	Collection string
+	DocumentID string
+	// ID is the document's real BSON _id (recovered from the images), used
+	// to address the document in a physical database.
+	ID interface{}
+	// Restore is the document to put back; nil means the document did not
+	// exist before the range (the compensation is a delete).
+	Restore bson.M
+}
+
+// Conflict marks a document that cannot be undone safely under an actor
+// filter: another actor modified it after the filtered writes, so blindly
+// restoring would discard their change.
+type Conflict struct {
+	Collection string
+	DocumentID string
+	OtherActor string
+	AtLSN      int64
+}
+
+// Plan describes what an undo would do.
+type Plan struct {
+	BranchID      string
+	FromLSN       int64
+	ToLSN         int64
+	Actor         string // empty: all actors
+	Compensations []Compensation
+	Conflicts     []Conflict
+	// Unrecoverable documents were touched in-range but their oldest entry
+	// carries no pre-image (degraded capture); they cannot be restored.
+	Unrecoverable []string
+}
+
+// BuildPlan computes the compensations for undoing [fromLSN, toLSN] on a
+// branch, optionally restricted to one actor's writes.
+func (s *Service) BuildPlan(branch *wal.Branch, fromLSN, toLSN int64, actor string) (*Plan, error) {
+	if toLSN == 0 {
+		toLSN = branch.HeadLSN
+	}
+	if fromLSN <= 0 || fromLSN > toLSN {
+		return nil, fmt.Errorf("invalid undo range [%d, %d]", fromLSN, toLSN)
+	}
+	if toLSN > branch.HeadLSN {
+		return nil, fmt.Errorf("undo range end %d is beyond branch head %d", toLSN, branch.HeadLSN)
+	}
+	if fromLSN <= branch.BaseLSN {
+		return nil, fmt.Errorf("undo range start %d is at or below the branch fork point %d: undo operates on the branch's own history", fromLSN, branch.BaseLSN)
+	}
+
+	entries, err := s.wal.GetBranchEntries(branch.ID, "", fromLSN, toLSN)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load range: %w", err)
+	}
+
+	plan := &Plan{BranchID: branch.ID, FromLSN: fromLSN, ToLSN: toLSN, Actor: actor}
+
+	type docKey struct{ collection, id string }
+	oldest := make(map[docKey]*wal.Entry)
+	conflicted := make(map[docKey]bool)
+
+	for _, entry := range entries {
+		if !entry.IsData() || branch.IsDiscardedForRead(entry.LSN, toLSN) {
+			continue
+		}
+		key := docKey{entry.Collection, entry.DocumentID}
+
+		if actor != "" && entry.Actor != actor {
+			// Another actor touched this document. If our actor wrote it
+			// earlier in the range, restoring would clobber this write.
+			if _, ours := oldest[key]; ours && !conflicted[key] {
+				conflicted[key] = true
+				plan.Conflicts = append(plan.Conflicts, Conflict{
+					Collection: entry.Collection,
+					DocumentID: entry.DocumentID,
+					OtherActor: entry.Actor,
+					AtLSN:      entry.LSN,
+				})
+			}
+			continue
+		}
+		if _, seen := oldest[key]; !seen {
+			oldest[key] = entry
+		}
+	}
+
+	for key, entry := range oldest {
+		if conflicted[key] {
+			continue
+		}
+		switch {
+		case len(entry.PreImage) > 0:
+			var pre bson.M
+			if err := bson.Unmarshal(entry.PreImage, &pre); err != nil {
+				return nil, fmt.Errorf("failed to decode pre-image for %s/%s: %w", key.collection, key.id, err)
+			}
+			plan.Compensations = append(plan.Compensations, Compensation{
+				Collection: key.collection,
+				DocumentID: key.id,
+				ID:         pre["_id"],
+				Restore:    pre,
+			})
+		case entry.Operation == wal.OpPut:
+			// No pre-image on a put: the document was created in-range;
+			// its real _id comes from the post-image.
+			var post bson.M
+			if err := bson.Unmarshal(entry.PostImage, &post); err != nil {
+				return nil, fmt.Errorf("failed to decode post-image for %s/%s: %w", key.collection, key.id, err)
+			}
+			plan.Compensations = append(plan.Compensations, Compensation{
+				Collection: key.collection,
+				DocumentID: key.id,
+				ID:         post["_id"],
+			})
+		default:
+			// A delete without a pre-image cannot be restored.
+			plan.Unrecoverable = append(plan.Unrecoverable,
+				fmt.Sprintf("%s/%s", key.collection, key.id))
+		}
+	}
+
+	// Deterministic order for application and display.
+	sort.Slice(plan.Compensations, func(i, j int) bool {
+		a, b := plan.Compensations[i], plan.Compensations[j]
+		if a.Collection != b.Collection {
+			return a.Collection < b.Collection
+		}
+		return a.DocumentID < b.DocumentID
+	})
+	sort.Strings(plan.Unrecoverable)
+	return plan, nil
+}
+
+// Apply executes a plan. On a live branch the compensations are written to
+// the physical database (the ingester records them as new history); on a
+// metadata-only branch they append directly to the WAL. Returns how many
+// documents were restored and how many deleted.
+func (s *Service) Apply(ctx context.Context, branch *wal.Branch, plan *Plan) (restored, deleted int, err error) {
+	if branch.ID != plan.BranchID {
+		return 0, 0, fmt.Errorf("plan belongs to branch %s, not %s", plan.BranchID, branch.ID)
+	}
+	if branch.IsLive() {
+		return s.applyPhysical(ctx, branch, plan)
+	}
+	return s.applyWAL(branch, plan)
+}
+
+func (s *Service) applyPhysical(ctx context.Context, branch *wal.Branch, plan *Plan) (restored, deleted int, err error) {
+	physical := s.client.Database(branch.PhysicalDB)
+	for _, c := range plan.Compensations {
+		coll := physical.Collection(c.Collection)
+		if c.Restore == nil {
+			if _, err := coll.DeleteOne(ctx, bson.M{"_id": c.ID}); err != nil {
+				return restored, deleted, fmt.Errorf("failed to delete %s/%s: %w", c.Collection, c.DocumentID, err)
+			}
+			deleted++
+			continue
+		}
+		if _, err := coll.ReplaceOne(ctx,
+			bson.M{"_id": c.ID},
+			c.Restore,
+			options.Replace().SetUpsert(true),
+		); err != nil {
+			return restored, deleted, fmt.Errorf("failed to restore %s/%s: %w", c.Collection, c.DocumentID, err)
+		}
+		restored++
+	}
+	return restored, deleted, nil
+}
+
+func (s *Service) applyWAL(branch *wal.Branch, plan *Plan) (restored, deleted int, err error) {
+	entries := make([]*wal.Entry, 0, len(plan.Compensations))
+	for _, c := range plan.Compensations {
+		entry := &wal.Entry{
+			ProjectID:  branch.ProjectID,
+			BranchID:   branch.ID,
+			Collection: c.Collection,
+			DocumentID: c.DocumentID,
+			Actor:      "undo",
+		}
+		if c.Restore == nil {
+			entry.Operation = wal.OpDelete
+			deleted++
+		} else {
+			entry.Operation = wal.OpPut
+			post, err := bson.Marshal(c.Restore)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to encode restoration for %s/%s: %w", c.Collection, c.DocumentID, err)
+			}
+			entry.PostImage = post
+			restored++
+		}
+		entries = append(entries, entry)
+	}
+	if len(entries) == 0 {
+		return 0, 0, nil
+	}
+	lsns, err := s.wal.AppendBatch(entries)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to append compensations: %w", err)
+	}
+	if err := s.branches.UpdateBranchHead(branch.ID, lsns[len(lsns)-1]); err != nil {
+		return 0, 0, fmt.Errorf("failed to advance branch head: %w", err)
+	}
+	return restored, deleted, nil
+}

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argon-lab/argon/internal/restore"
 	"github.com/argon-lab/argon/internal/snapshot"
 	"github.com/argon-lab/argon/internal/timetravel"
+	"github.com/argon-lab/argon/internal/undo"
 	"github.com/argon-lab/argon/internal/wal"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -36,6 +37,7 @@ type Services struct {
 	GC           *gc.Service
 	Checkout     *checkout.Service
 	Ingest       *ingest.Service
+	Undo         *undo.Service
 	Monitor      *wal.Monitor
 	MongoURI     string
 }
@@ -98,6 +100,7 @@ func NewServices() (*Services, error) {
 	gcService := gc.NewService(walService, branchService, snapshotService)
 	checkoutService := checkout.NewService(client, db, branchService, materializerService)
 	ingestService := ingest.NewService(client, db, walService, branchService)
+	undoService := undo.NewService(walService, branchService, client)
 	// Reclaim a deleted branch's WAL entries and snapshots. Safe because
 	// regular deletion refuses branches with children.
 	branchService.SetDeleteHook(func(branchID string) {
@@ -135,9 +138,29 @@ func NewServices() (*Services, error) {
 		GC:           gcService,
 		Checkout:     checkoutService,
 		Ingest:       ingestService,
+		Undo:         undoService,
 		Monitor:      monitor,
 		MongoURI:     mongoURI,
 	}, nil
+}
+
+// BuildUndoPlan and ApplyUndoPlan wrap the undo service for CLI use (the
+// cli module cannot import internal packages).
+func (s *Services) BuildUndoPlan(branchID string, fromLSN, toLSN int64, actor string) (*undo.Plan, error) {
+	branch, err := s.Branches.GetBranchByID(branchID)
+	if err != nil {
+		return nil, err
+	}
+	return s.Undo.BuildPlan(branch, fromLSN, toLSN, actor)
+}
+
+// ApplyUndoPlan executes a previously built plan.
+func (s *Services) ApplyUndoPlan(ctx context.Context, branchID string, plan *undo.Plan) (restored, deleted int, err error) {
+	branch, err := s.Branches.GetBranchByID(branchID)
+	if err != nil {
+		return 0, 0, err
+	}
+	return s.Undo.Apply(ctx, branch, plan)
 }
 
 // BranchConnectionString renders the URI applications use to reach a

--- a/tests/wal/undo_test.go
+++ b/tests/wal/undo_test.go
@@ -1,0 +1,177 @@
+package wal_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	driverwal "github.com/argon-lab/argon/internal/driver/wal"
+	"github.com/argon-lab/argon/internal/undo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestUndo_RestoresPreRangeState(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	undoService := undo.NewService(f.wal, f.branches, db.Client())
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("undo-test", "main", "")
+	require.NoError(t, err)
+	writer := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+
+	// Segment A: the baseline the undo must restore.
+	_, err = writer.InsertOne(ctx, "docs", bson.M{"_id": "keep", "v": int32(1)})
+	require.NoError(t, err)
+	_, err = writer.InsertOne(ctx, "docs", bson.M{"_id": "victim", "v": int32(10)})
+	require.NoError(t, err)
+	_, err = writer.InsertOne(ctx, "docs", bson.M{"_id": "doomed", "v": int32(5)})
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+	baselineLSN := main.HeadLSN
+	baseline, err := f.matFull.MaterializeBranch(main)
+	require.NoError(t, err)
+
+	// Segment B: the damage — an update, a delete, an insert, and a
+	// second update of the same victim (only the oldest pre-image counts).
+	_, err = writer.UpdateOne(ctx, "docs", bson.M{"_id": "victim"}, bson.M{"$set": bson.M{"v": int32(99)}}, false)
+	require.NoError(t, err)
+	_, err = writer.DeleteOne(ctx, "docs", bson.M{"_id": "doomed"})
+	require.NoError(t, err)
+	_, err = writer.InsertOne(ctx, "docs", bson.M{"_id": "intruder", "v": int32(666)})
+	require.NoError(t, err)
+	_, err = writer.UpdateOne(ctx, "docs", bson.M{"_id": "victim"}, bson.M{"$inc": bson.M{"v": int32(1)}}, false)
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	plan, err := undoService.BuildPlan(main, baselineLSN+1, main.HeadLSN, "")
+	require.NoError(t, err)
+	assert.Len(t, plan.Compensations, 3, "victim restored, doomed restored, intruder deleted")
+	assert.Empty(t, plan.Conflicts)
+	assert.Empty(t, plan.Unrecoverable)
+
+	restored, deleted, err := undoService.Apply(ctx, main, plan)
+	require.NoError(t, err)
+	assert.Equal(t, 2, restored)
+	assert.Equal(t, 1, deleted)
+
+	// The branch state equals the baseline again — via new history, not
+	// history rewriting.
+	main, _ = f.branches.GetBranchByID(main.ID)
+	after, err := f.matFull.MaterializeBranch(main)
+	require.NoError(t, err)
+	requireSameState(t, baseline, after, "state after undo")
+	assert.Greater(t, main.HeadLSN, baselineLSN, "undo appends; it never rewrites")
+
+	// Undo entries are attributed.
+	entries, err := f.wal.GetBranchEntries(main.ID, "docs", 0, main.HeadLSN)
+	require.NoError(t, err)
+	last := entries[len(entries)-1]
+	assert.Equal(t, "undo", last.Actor)
+}
+
+func TestUndo_ActorFilterAndConflicts(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	undoService := undo.NewService(f.wal, f.branches, db.Client())
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("undo-actor", "main", "")
+	require.NoError(t, err)
+
+	human := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	human.SetActor("user:jake")
+	agent := driverwal.NewInterceptor(f.wal, main, f.branches, f.mat)
+	agent.SetActor("agent:rogue")
+
+	// Baseline by the human.
+	_, err = human.InsertOne(ctx, "cfg", bson.M{"_id": "a", "v": "human"})
+	require.NoError(t, err)
+	_, err = human.InsertOne(ctx, "cfg", bson.M{"_id": "b", "v": "human"})
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+	fromLSN := main.HeadLSN + 1
+
+	// The agent damages a and creates c; the human then edits a again
+	// (conflict) but leaves the agent's other damage alone.
+	_, err = agent.UpdateOne(ctx, "cfg", bson.M{"_id": "a"}, bson.M{"$set": bson.M{"v": "agent"}}, false)
+	require.NoError(t, err)
+	_, err = agent.InsertOne(ctx, "cfg", bson.M{"_id": "c", "v": "agent"})
+	require.NoError(t, err)
+	_, err = agent.UpdateOne(ctx, "cfg", bson.M{"_id": "b"}, bson.M{"$set": bson.M{"v": "agent"}}, false)
+	require.NoError(t, err)
+	_, err = human.UpdateOne(ctx, "cfg", bson.M{"_id": "a"}, bson.M{"$set": bson.M{"v": "human-again"}}, false)
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	plan, err := undoService.BuildPlan(main, fromLSN, main.HeadLSN, "agent:rogue")
+	require.NoError(t, err)
+
+	require.Len(t, plan.Conflicts, 1, "the human's later edit of a is a conflict")
+	assert.Equal(t, "a", plan.Conflicts[0].DocumentID)
+	assert.Equal(t, "user:jake", plan.Conflicts[0].OtherActor)
+	assert.Len(t, plan.Compensations, 2, "b restored, c deleted; a skipped")
+
+	_, _, err = undoService.Apply(ctx, main, plan)
+	require.NoError(t, err)
+
+	main, _ = f.branches.GetBranchByID(main.ID)
+	state, err := f.matFull.MaterializeCollection(main, "cfg")
+	require.NoError(t, err)
+	assert.Equal(t, "human-again", state["a"]["v"], "conflicted document keeps the human's edit")
+	assert.Equal(t, "human", state["b"]["v"], "agent damage reverted")
+	assert.NotContains(t, state, "c", "agent-created document removed")
+}
+
+func TestUndo_OnLiveBranchThroughPhysicalDB(t *testing.T) {
+	f := newIngestFixture(t, "undo-live")
+	undoService := undo.NewService(f.wal, f.branches, f.client)
+	ctx := context.Background()
+	stop := f.startIngester(t)
+	defer stop()
+
+	docs := f.physical.Collection("docs")
+
+	// Baseline written directly, captured by the ingester.
+	_, err := docs.InsertOne(ctx, bson.M{"_id": "base", "v": int32(1)})
+	require.NoError(t, err)
+	f.waitForEntries(t, "docs", 1)
+	branch, _ := f.branches.GetBranchByID(f.branchID)
+	baselineLSN := branch.HeadLSN
+
+	// Damage, also direct.
+	_, err = docs.UpdateOne(ctx, bson.M{"_id": "base"}, bson.M{"$set": bson.M{"v": int32(999)}})
+	require.NoError(t, err)
+	for i := 0; i < 3; i++ {
+		_, err = docs.InsertOne(ctx, bson.M{"_id": fmt.Sprintf("junk-%d", i)})
+		require.NoError(t, err)
+	}
+	f.waitForEntries(t, "docs", 5)
+
+	branch, _ = f.branches.GetBranchByID(f.branchID)
+	plan, err := undoService.BuildPlan(branch, baselineLSN+1, branch.HeadLSN, "")
+	require.NoError(t, err)
+	assert.Len(t, plan.Compensations, 4)
+
+	restored, deleted, err := undoService.Apply(ctx, branch, plan)
+	require.NoError(t, err)
+	assert.Equal(t, 1, restored)
+	assert.Equal(t, 3, deleted)
+
+	// The physical database is back to the baseline...
+	var base bson.M
+	require.NoError(t, docs.FindOne(ctx, bson.M{"_id": "base"}).Decode(&base))
+	assert.EqualValues(t, 1, base["v"])
+	count, err := docs.CountDocuments(ctx, bson.M{})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, count)
+
+	// ...and the compensations flow through the ingester as new history.
+	f.waitForEntries(t, "docs", 9)
+	branch, _ = f.branches.GetBranchByID(f.branchID)
+	walState, err := f.matFull.MaterializeCollection(branch, "docs")
+	require.NoError(t, err)
+	assert.Equal(t, f.physicalState(t, "docs"), walState, "WAL converges to the undone physical state")
+}


### PR DESCRIPTION
Final M3 slice: **the undo button**.

`argon undo -p <project> --from-lsn X [--to-lsn Y] [--actor NAME] [--dry-run]`

## Semantics

For every document touched in the range, the state to restore is the **pre-image of the oldest in-range entry** for that document (its state just before the range began); an oldest entry without a pre-image is an insert, so the compensation is a delete. One pass, per-document, no reverse replay needed.

History stays **append-only**: compensations are new history (actor `undo`), so undos are audited and can be undone in turn.

- `--actor` reverts only that actor's writes. A document another actor modified afterwards is a **conflict**: reported and skipped, never silently clobbered. (Test: agent damage reverted, the human's later edit on the contested document survives.)
- Documents whose oldest entry lacks a pre-image (degraded capture) are reported as **unrecoverable**, not guessed at.
- **Live branches**: compensations go through the physical database and flow back via the ingester — the WAL converges to the undone state (tested end-to-end). Metadata-only branches append directly to the WAL.

This is the agent-safety primitive the roadmap has been building toward: check out a branch, point an agent at the connection string, and if it wrecks the data — `argon undo` from the pre-session LSN, with per-actor precision.