### PR TITLE
Docs: M2 complete — public benchmarks live, measured numbers return

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Argon gives MongoDB superpowers with **Git-like branching** and **time travel**.
 
 ### 🎯 Key Benefits
 
-- **⚡ Millisecond Branches** - Creating a branch writes metadata, not data copies
+- **⚡ Millisecond Branches** - Creating a branch writes metadata, not data copies: [0.86 ms p50 / 1.93 ms p99 on a 50k-entry project, 479 bytes of storage per branch — measured](https://github.com/argon-lab/benchmarks/blob/main/RESULTS.md)
 - **⏰ Time Travel** - Inspect and restore your data from any point in history, addressed by LSN or timestamp
 - **🔬 Deterministic Replay** - The same history always reconstructs the same state, byte for byte — verified by property tests in CI
 - **🔄 Safe Restore** - Preview changes before restoring; restores are themselves logged, so you can undo the undo
 - **🗜️ Smart Compression** - WAL entries are automatically compressed with zstd
-- **🧭 Honest Engineering** - Performance numbers will return to this README when our public, reproducible benchmark suite ships (see roadmap below)
+- **🧭 Honest Engineering** - Every performance number links to a run of the [public benchmark suite](https://github.com/argon-lab/benchmarks) that you can reproduce with `docker compose up`
 
-> **A note on claims:** earlier versions of this README quoted numbers like "1ms branching" and "220,000+ queries/sec" that we could not back with reproducible benchmarks. We removed them. From now on, every number we publish links to a benchmark you can run yourself.
+> **A note on claims:** earlier versions of this README quoted numbers like "1ms branching" and "220,000+ queries/sec" that we could not back with reproducible benchmarks. We removed them. Numbers now come exclusively from [argon-lab/benchmarks](https://github.com/argon-lab/benchmarks) — pinned engine ref, recorded environment, reproducible by anyone.
 
 ## Quick Demo
 
@@ -124,8 +124,8 @@ Argon's engine is being rebuilt milestone by milestone, correctness first ([full
 | Milestone | Scope | Status |
 |---|---|---|
 | **M1 · Correctness** | Deterministic replay (property-tested), distributed LSN sequencer, branch ancestry isolation, truthful write results, WAL v2 migration | ✅ Shipped |
-| **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · **public reproducible benchmarks** 🚧 | Engine shipped · benchmarks in progress |
-| **M3 · True drop-in** | One physical MongoDB database per branch, change-stream capture, per-branch connection strings, `argon undo --session` | Planned |
+| **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · [public reproducible benchmarks](https://github.com/argon-lab/benchmarks) ✅ | ✅ Shipped |
+| **M3 · True drop-in** | Physical MongoDB database per branch ✅ · change-stream write capture ✅ · per-branch connection strings 🚧 · `argon undo --session` 🚧 | 🚧 In progress |
 | **M4 · Merge & diff** | Document-level diff, three-way merge, reviewable data PRs | Planned |
 | **M5 · Agent ecosystem** | MCP server, LangGraph checkpointer, TTL sandboxes, eval pinning | Planned |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -248,19 +248,20 @@ Current limitations (deliberate scope):
   snapshots cover them; snapshot chunks can additionally live in an
   S3-compatible or filesystem chunk store (see "Chunk store backends"
   above). GCS is not yet a backend.
-- No published performance numbers yet: the public, reproducible benchmark
-  suite is the remaining M2 deliverable, and numbers return only with it.
+- Per-operation write throughput and divergence storage amplification are
+  not yet benchmarked — blocked on a public write surface (#16).
+
+Performance characteristics are measured by the public benchmark suite at
+https://github.com/argon-lab/benchmarks — reproducible with
+`docker compose up`, results recorded with pinned engine refs.
 
 Planned next (in order):
 
-1. **M2 (remaining) — public benchmarks**: a reproducible benchmark repo
-   (`docker compose up`); every published performance number links to a
-   run you can reproduce.
-2. **M3 — mongod as compute**: branches materialize into real MongoDB
-   databases (lazily), reads/writes run on mongod with change-stream
-   capture into the WAL, per-branch connection strings — full query
-   compatibility without reimplementing MongoDB.
-3. **M4 — merge and diff**: three-way document-level merge with reviewable
+1. **M3 (remaining) — true drop-in**: physical per-branch MongoDB databases
+   and change-stream capture are merged; per-branch connection strings and
+   `argon undo --session` are in progress. Drop-in compatibility is claimed
+   only once official driver test suites pass against branch databases.
+2. **M4 — merge and diff**: three-way document-level merge with reviewable
    merge plans.
 
 ## Storage collections

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,9 +1,10 @@
 # Argon Features Overview
 
 > This document describes what is implemented **today**. Where a capability is
-> planned but not built, it says so and names the milestone. Performance
-> numbers will be published together with the reproducible benchmark suite in
-> M2 — until then we deliberately don't quote any. See
+> planned but not built, it says so and names the milestone. Every performance
+> number quoted here links to a run of the
+> [public benchmark suite](https://github.com/argon-lab/benchmarks) you can
+> reproduce with `docker compose up`. See
 > [ARCHITECTURE.md](ARCHITECTURE.md) for how each feature works.
 
 ## 🚀 Core Features
@@ -85,14 +86,19 @@ with full document images:
 
 ## 📈 Performance
 
-We removed the performance table that used to live here: its numbers had no
-reproducible benchmark behind them. M2 ships a public benchmark repo
-(`docker compose up`), and every number we publish will link to a run you can
-reproduce. What we can say structurally today:
+All numbers below come from the
+[first official run](https://github.com/argon-lab/benchmarks/blob/main/RESULTS.md)
+of the public benchmark suite (engine `8bf0f1e`, MongoDB 7.0.25 in Docker on
+Apple Silicon, 50k-document history). Absolute values vary with hardware —
+reproduce on yours with `docker compose up`:
 
-- Branch creation cost is **one metadata write**, independent of data size
-- Snapshots keep time-travel replay **bounded** regardless of history length
-- WAL entries are compressed per entry (zstd)
+- **Branch creation: 0.86 ms p50 / 1.93 ms p99** on a project with a
+  50k-entry history — one metadata write, independent of data size
+- **Storage per branch: 479 bytes** (data+index delta, n=200)
+- **Bulk import: ~48k documents/second** through `walcli.ImportDatabase`
+- **Time-travel materialization: 9.5 ms at LSN 1k → 296.8 ms at 50k**
+  (full replay in that run; see RESULTS.md for the honest notes on
+  snapshot behavior)
 
 ## ⚠️ Current Limitations (deliberate scope)
 
@@ -104,16 +110,17 @@ reproduce. What we can say structurally today:
 - WAL entries live in MongoDB and are reclaimed by retention-window GC once
   snapshots cover them; snapshot chunks can additionally live in an
   S3-compatible or filesystem chunk store.
-- No published performance numbers yet: the public benchmark suite is the
-  remaining M2 deliverable, and numbers return only with it.
+- Per-operation write throughput and divergence storage amplification are
+  not yet benchmarked — blocked on a public write surface
+  ([#16](https://github.com/argon-lab/argon/issues/16)).
 
 ## 🔮 Roadmap
 
 | Milestone | Scope | Status |
 |---|---|---|
 | **M1 · Correctness** | Deterministic replay (property-tested), distributed LSN sequencer, branch ancestry isolation, truthful write results, WAL v2 migration | ✅ Shipped |
-| **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · **public reproducible benchmarks** 🚧 | Engine shipped · benchmarks in progress |
-| **M3 · True drop-in** | One physical MongoDB database per branch, change-stream capture, per-branch connection strings, `argon undo --session` | Planned |
+| **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · [public reproducible benchmarks](https://github.com/argon-lab/benchmarks) ✅ | ✅ Shipped |
+| **M3 · True drop-in** | Physical MongoDB database per branch ✅ · change-stream write capture ✅ · per-branch connection strings 🚧 · `argon undo --session` 🚧 | 🚧 In progress |
 | **M4 · Merge & diff** | Document-level diff, three-way merge, reviewable data PRs | Planned |
 | **M5 · Agent ecosystem** | MCP server, LangGraph checkpointer, TTL sandboxes, eval pinning | Planned |
 


### PR DESCRIPTION
The public benchmark suite is live: https://github.com/argon-lab/benchmarks — `docker compose up --build`, engine ref pinned in go.mod and embedded in every report. First official run is recorded in its RESULTS.md (engine `8bf0f1e`, MongoDB 7.0.25, Apple Silicon/Docker):

- Branch creation **0.86 ms p50 / 1.93 ms p99** on a project with 50k-entry history (n=200)
- **479 bytes** of storage per branch (data+index delta, n=200)
- Bulk import **~48k docs/s** through `walcli.ImportDatabase`
- Time-travel **9.5 ms @ LSN 1k → 296.8 ms @ 50k** (linear in that run — see findings below)

This closes the last M2 deliverable. Changes here:

- README key benefits + claims note now link measured numbers to the suite; milestone table shows **M2 ✅ shipped** and **M3 🚧 in progress** (reflecting #14/#15 merged, connection strings + undo remaining)
- FEATURES.md performance section carries the measured numbers with links; limitations updated
- ARCHITECTURE.md roadmap section updated the same way; drop-in stays unclaimed until official driver suites pass

Two findings from the run worth engine attention:
1. **Import does not trigger auto-snapshots** (0 existed after a 50k-doc import) — auto-snapshotting hooks the driver write path only, so imported projects get linear replay until someone writes or snapshots manually.
2. **Snapshot-at-head reads are bounded by chunk decode** (209 ms for 50k docs), so the snapshot win at moderate scale is ~30%, growing with replay depth avoided.

Write-path benchmark suites remain blocked on #16.