### PR TITLE
Docs: M3 shipped — one box open (driver-suite CI validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Argon's engine is being rebuilt milestone by milestone, correctness first ([full
 |---|---|---|
 | **M1 · Correctness** | Deterministic replay (property-tested), distributed LSN sequencer, branch ancestry isolation, truthful write results, WAL v2 migration | ✅ Shipped |
 | **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · [public reproducible benchmarks](https://github.com/argon-lab/benchmarks) ✅ | ✅ Shipped |
-| **M3 · True drop-in** | Physical MongoDB database per branch ✅ · change-stream write capture ✅ · per-branch connection strings 🚧 · `argon undo --session` 🚧 | 🚧 In progress |
+| **M3 · True drop-in** | Physical MongoDB database per branch (`argon checkout` → connection string) ✅ · change-stream write capture ✅ · `argon undo` with per-actor conflict detection ✅ · official driver test suites in CI 🚧 | Shipped · driver-suite validation pending |
 | **M4 · Merge & diff** | Document-level diff, three-way merge, reviewable data PRs | Planned |
 | **M5 · Agent ecosystem** | MCP server, LangGraph checkpointer, TTL sandboxes, eval pinning | Planned |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -257,10 +257,12 @@ https://github.com/argon-lab/benchmarks — reproducible with
 
 Planned next (in order):
 
-1. **M3 (remaining) — true drop-in**: physical per-branch MongoDB databases
-   and change-stream capture are merged; per-branch connection strings and
-   `argon undo --session` are in progress. Drop-in compatibility is claimed
-   only once official driver test suites pass against branch databases.
+1. **M3 (last box) — driver-suite validation**: physical per-branch
+   databases (`argon checkout`), change-stream ingestion, and per-actor
+   `argon undo` are all merged. What remains is running the official
+   pymongo/mongoose test suites against branch databases in CI — until
+   then, "any driver connects" is stated as an architectural fact, not an
+   unqualified drop-in claim.
 2. **M4 — merge and diff**: three-way document-level merge with reviewable
    merge plans.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -120,7 +120,7 @@ reproduce on yours with `docker compose up`:
 |---|---|---|
 | **M1 · Correctness** | Deterministic replay (property-tested), distributed LSN sequencer, branch ancestry isolation, truthful write results, WAL v2 migration | ✅ Shipped |
 | **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · [public reproducible benchmarks](https://github.com/argon-lab/benchmarks) ✅ | ✅ Shipped |
-| **M3 · True drop-in** | Physical MongoDB database per branch ✅ · change-stream write capture ✅ · per-branch connection strings 🚧 · `argon undo --session` 🚧 | 🚧 In progress |
+| **M3 · True drop-in** | Physical MongoDB database per branch (`argon checkout` → connection string) ✅ · change-stream write capture ✅ · `argon undo` with per-actor conflict detection ✅ · official driver test suites in CI 🚧 | Shipped · driver-suite validation pending |
 | **M4 · Merge & diff** | Document-level diff, three-way merge, reviewable data PRs | Planned |
 | **M5 · Agent ecosystem** | MCP server, LangGraph checkpointer, TTL sandboxes, eval pinning | Planned |
 


### PR DESCRIPTION
Companion to the "Built for Agents" website relaunch (argonlabs.tech now leads with the undo-button narrative and a new /agents page).

- Milestone tables (README, FEATURES.md): M3 → "Shipped · driver-suite validation pending", with `argon checkout`/connection strings, change-stream capture, and per-actor `argon undo` all ✅ per #14/#15/#17.
- ARCHITECTURE.md "Planned next": M3's remaining item is now precisely the official pymongo/mongoose suites running against branch databases in CI. Until then the docs and the website both say "any driver connects" (architectural fact — it's a real mongod, and #14's tests assert indexes/sort/aggregation work) rather than an unqualified "drop-in, no asterisks".

Suggestion for whoever picks up the last box: a CI job that checks out a branch database and runs a curated subset of the official driver test suites against its URI would close this out and unlock the unqualified claim.