### PR TITLE
Three-way merge with reviewable plans: the data pull request

### DIFF
--- a/cli/cmd/merge.go
+++ b/cli/cmd/merge.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+var diffCmd = &cobra.Command{
+	Use:   "diff",
+	Short: "Show what merging a branch into its parent would change",
+	Long: `Diff computes the three-way, document-level comparison between a
+branch and its parent: the documents the merge would adopt, and the
+documents both sides changed differently since the fork (conflicts).
+Nothing is persisted; use "argon merge preview" to open a reviewable
+merge plan.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" || branchName == "" {
+			return fmt.Errorf("--project and --branch are required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		branchID, err := resolveBranch(services, projectName, branchName)
+		if err != nil {
+			return err
+		}
+
+		plan, err := services.Merge.Compute(branchID)
+		if err != nil {
+			return fmt.Errorf("diff failed: %w", err)
+		}
+		fmt.Printf("Merging %s → %s\n", plan.SourceBranch, plan.TargetBranch)
+		for _, c := range plan.Changes {
+			action := "put   "
+			if c.Delete {
+				action = "delete"
+			}
+			fmt.Printf("  %s %s/%s\n", action, c.Collection, c.DocumentID)
+		}
+		for _, c := range plan.Conflicts {
+			fmt.Printf("  CONFLICT %s/%s (both sides changed since the fork)\n", c.Collection, c.DocumentID)
+		}
+		fmt.Printf("%d change(s), %d conflict(s)\n", len(plan.Changes), len(plan.Conflicts))
+		return nil
+	},
+}
+
+var mergeCmd = &cobra.Command{
+	Use:   "merge",
+	Short: "Merge a branch into its parent through a reviewable plan",
+}
+
+var mergePreviewCmd = &cobra.Command{
+	Use:   "preview",
+	Short: "Compute and persist a merge plan (a data pull request)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" || branchName == "" {
+			return fmt.Errorf("--project and --branch are required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		branchID, err := resolveBranch(services, projectName, branchName)
+		if err != nil {
+			return err
+		}
+
+		plan, err := services.Merge.Preview(context.Background(), branchID)
+		if err != nil {
+			return fmt.Errorf("preview failed: %w", err)
+		}
+		fmt.Printf("Merging %s → %s\n", plan.SourceBranch, plan.TargetBranch)
+		for _, c := range plan.Changes {
+			action := "put   "
+			if c.Delete {
+				action = "delete"
+			}
+			fmt.Printf("  %s %s/%s\n", action, c.Collection, c.DocumentID)
+		}
+		for _, c := range plan.Conflicts {
+			fmt.Printf("  CONFLICT %s/%s (both sides changed since the fork)\n", c.Collection, c.DocumentID)
+		}
+		fmt.Printf("%d change(s), %d conflict(s)\n", len(plan.Changes), len(plan.Conflicts))
+		fmt.Printf("\nPlan %s saved (pending).\n", plan.ID.Hex())
+		if len(plan.Conflicts) > 0 {
+			fmt.Printf("Apply with: argon merge apply %s --strategy theirs|ours\n", plan.ID.Hex())
+		} else {
+			fmt.Printf("Apply with: argon merge apply %s\n", plan.ID.Hex())
+		}
+		return nil
+	},
+}
+
+var mergeApplyCmd = &cobra.Command{
+	Use:   "apply <plan-id>",
+	Short: "Apply a pending merge plan",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		strategy, _ := cmd.Flags().GetString("strategy")
+
+		planID, err := primitive.ObjectIDFromHex(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid plan ID %q", args[0])
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+
+		result, err := services.Merge.Apply(context.Background(), planID, strategy)
+		if err != nil {
+			return fmt.Errorf("apply failed: %w", err)
+		}
+		fmt.Printf("Merged: %d change(s) applied", result.Applied)
+		if result.ConflictsResolved > 0 {
+			fmt.Printf(", %d conflict(s) resolved via --strategy %s", result.ConflictsResolved, strategy)
+		}
+		fmt.Println(".")
+		return nil
+	},
+}
+
+var mergeListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List a project's merge plans",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+
+		plans, err := services.Merge.ListPlans(context.Background(), project.ID)
+		if err != nil {
+			return err
+		}
+		if len(plans) == 0 {
+			fmt.Println("No merge plans.")
+			return nil
+		}
+		fmt.Printf("%-26s %-10s %-16s %8s %10s %s\n", "PLAN", "STATUS", "SOURCE→TARGET", "CHANGES", "CONFLICTS", "CREATED")
+		for _, p := range plans {
+			fmt.Printf("%-26s %-10s %-16s %8d %10d %s\n",
+				p.ID.Hex(), p.Status, p.SourceBranch+"→"+p.TargetBranch,
+				len(p.Changes), len(p.Conflicts), p.CreatedAt.Format("2006-01-02 15:04:05"))
+		}
+		return nil
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{diffCmd, mergePreviewCmd} {
+		c.Flags().StringP("project", "p", "", "Project name (required)")
+		c.Flags().StringP("branch", "b", "", "Source branch to merge into its parent (required)")
+	}
+	mergeListCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	mergeApplyCmd.Flags().String("strategy", "", "Conflict resolution: theirs (take the branch) or ours (keep the target)")
+
+	mergeCmd.AddCommand(mergePreviewCmd)
+	mergeCmd.AddCommand(mergeApplyCmd)
+	mergeCmd.AddCommand(mergeListCmd)
+	rootCmd.AddCommand(diffCmd)
+	rootCmd.AddCommand(mergeCmd)
+}

--- a/internal/merge/service.go
+++ b/internal/merge/service.go
@@ -1,0 +1,465 @@
+// Package merge implements three-way, document-level merges between a
+// branch and its parent, with a reviewable persisted plan in between — the
+// "data pull request".
+//
+// The three states are: base (the source branch's inherited state at its
+// fork point), ours (the target branch's current state) and theirs (the
+// source branch's current state). Per document:
+//
+//   - theirs unchanged            → nothing to merge
+//   - only theirs changed         → adopt theirs (put or delete)
+//   - both changed identically    → nothing to do
+//   - both changed differently    → conflict, resolved by an explicit
+//     strategy (theirs/ours) or by aborting
+//
+// Comparison is canonical (sorted-key) BSON equality. Plans are persisted
+// pending, then applied exactly once against the exact target head they
+// were computed for — a moved head means the plan is stale and must be
+// recomputed. Application appends ordinary puts/deletes (or writes to the
+// physical database when the target is live) plus one merge control entry
+// carrying the audit metadata; history stays append-only, so a merge can
+// be undone like any other range.
+package merge
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/argon-lab/argon/internal/mongoexpr"
+	"github.com/argon-lab/argon/internal/wal"
+	"github.com/argon-lab/argon/internal/walwriter"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Plan statuses.
+const (
+	StatusPending = "pending"
+	StatusApplied = "applied"
+)
+
+// Conflict strategies.
+const (
+	StrategyTheirs = "theirs"
+	StrategyOurs   = "ours"
+)
+
+// Change is one document the merge would adopt from the source branch.
+type Change struct {
+	Collection string `bson:"collection" json:"collection"`
+	DocumentID string `bson:"document_id" json:"document_id"`
+	// Delete marks a removal; otherwise Document is the adopted state.
+	Delete   bool   `bson:"delete,omitempty" json:"delete,omitempty"`
+	Document bson.M `bson:"document,omitempty" json:"document,omitempty"`
+}
+
+// Conflict is a document both sides changed differently since the fork.
+type Conflict struct {
+	Collection string `bson:"collection" json:"collection"`
+	DocumentID string `bson:"document_id" json:"document_id"`
+	Base       bson.M `bson:"base,omitempty" json:"base,omitempty"`
+	Ours       bson.M `bson:"ours,omitempty" json:"ours,omitempty"`
+	Theirs     bson.M `bson:"theirs,omitempty" json:"theirs,omitempty"`
+}
+
+// Plan is a persisted, reviewable merge proposal.
+type Plan struct {
+	ID             primitive.ObjectID `bson:"_id,omitempty" json:"id"`
+	ProjectID      string             `bson:"project_id" json:"project_id"`
+	SourceBranchID string             `bson:"source_branch_id" json:"source_branch_id"`
+	SourceBranch   string             `bson:"source_branch" json:"source_branch"`
+	TargetBranchID string             `bson:"target_branch_id" json:"target_branch_id"`
+	TargetBranch   string             `bson:"target_branch" json:"target_branch"`
+	SourceHead     int64              `bson:"source_head" json:"source_head"`
+	TargetHead     int64              `bson:"target_head" json:"target_head"`
+	BaseLSN        int64              `bson:"base_lsn" json:"base_lsn"`
+	Changes        []Change           `bson:"changes" json:"changes"`
+	Conflicts      []Conflict         `bson:"conflicts" json:"conflicts"`
+	Status         string             `bson:"status" json:"status"`
+	Strategy       string             `bson:"strategy,omitempty" json:"strategy,omitempty"`
+	CreatedAt      time.Time          `bson:"created_at" json:"created_at"`
+	AppliedAt      *time.Time         `bson:"applied_at,omitempty" json:"applied_at,omitempty"`
+}
+
+// Service computes, persists and applies merge plans.
+type Service struct {
+	wal          *wal.Service
+	branches     *branchwal.BranchService
+	materializer *materializer.Service
+	client       *mongo.Client
+	plans        *mongo.Collection
+}
+
+// NewService creates a merge service. The client reaches physical branch
+// databases for live-target application.
+func NewService(db *mongo.Database, walService *wal.Service, branches *branchwal.BranchService, mat *materializer.Service, client *mongo.Client) *Service {
+	return &Service{
+		wal:          walService,
+		branches:     branches,
+		materializer: mat,
+		client:       client,
+		plans:        db.Collection("wal_merge_plans"),
+	}
+}
+
+// Compute builds a merge plan for merging a branch into its parent,
+// without persisting it (the diff view).
+func (s *Service) Compute(sourceBranchID string) (*Plan, error) {
+	source, err := s.branches.GetBranchByID(sourceBranchID)
+	if err != nil {
+		return nil, fmt.Errorf("source branch not found: %w", err)
+	}
+	if source.ParentID == "" {
+		return nil, fmt.Errorf("branch %s has no parent to merge into", source.Name)
+	}
+	target, err := s.branches.GetBranchByID(source.ParentID)
+	if err != nil {
+		return nil, fmt.Errorf("target branch not found: %w", err)
+	}
+
+	base, err := s.materializer.MaterializeBranchAtLSN(source, source.BaseLSN)
+	if err != nil {
+		return nil, fmt.Errorf("failed to materialize fork state: %w", err)
+	}
+	theirs, err := s.materializer.MaterializeBranch(source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to materialize source: %w", err)
+	}
+	ours, err := s.materializer.MaterializeBranch(target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to materialize target: %w", err)
+	}
+
+	plan := &Plan{
+		ProjectID:      source.ProjectID,
+		SourceBranchID: source.ID,
+		SourceBranch:   source.Name,
+		TargetBranchID: target.ID,
+		TargetBranch:   target.Name,
+		SourceHead:     source.HeadLSN,
+		TargetHead:     target.HeadLSN,
+		BaseLSN:        source.BaseLSN,
+		Status:         StatusPending,
+		CreatedAt:      time.Now(),
+	}
+
+	for _, collection := range unionKeys3(base, ours, theirs) {
+		baseDocs := base[collection]
+		ourDocs := ours[collection]
+		theirDocs := theirs[collection]
+
+		for _, docID := range unionKeys3(baseDocs, ourDocs, theirDocs) {
+			b, o, th := baseDocs[docID], ourDocs[docID], theirDocs[docID]
+
+			theirsChanged, err := docsUnequal(b, th)
+			if err != nil {
+				return nil, err
+			}
+			if !theirsChanged {
+				continue // Source did nothing; ours stands either way.
+			}
+			oursChanged, err := docsUnequal(b, o)
+			if err != nil {
+				return nil, err
+			}
+			if oursChanged {
+				identical, err := docsUnequal(o, th)
+				if err != nil {
+					return nil, err
+				}
+				if !identical {
+					continue // Both sides made the same change.
+				}
+				plan.Conflicts = append(plan.Conflicts, Conflict{
+					Collection: collection,
+					DocumentID: docID,
+					Base:       b,
+					Ours:       o,
+					Theirs:     th,
+				})
+				continue
+			}
+			plan.Changes = append(plan.Changes, Change{
+				Collection: collection,
+				DocumentID: docID,
+				Delete:     th == nil,
+				Document:   th,
+			})
+		}
+	}
+
+	sortChanges(plan.Changes)
+	sort.Slice(plan.Conflicts, func(i, j int) bool {
+		a, b := plan.Conflicts[i], plan.Conflicts[j]
+		if a.Collection != b.Collection {
+			return a.Collection < b.Collection
+		}
+		return a.DocumentID < b.DocumentID
+	})
+	return plan, nil
+}
+
+// Preview computes a plan and persists it pending review — the data PR.
+func (s *Service) Preview(ctx context.Context, sourceBranchID string) (*Plan, error) {
+	plan, err := s.Compute(sourceBranchID)
+	if err != nil {
+		return nil, err
+	}
+	result, err := s.plans.InsertOne(ctx, plan)
+	if err != nil {
+		return nil, fmt.Errorf("failed to persist merge plan: %w", err)
+	}
+	plan.ID = result.InsertedID.(primitive.ObjectID)
+	return plan, nil
+}
+
+// GetPlan loads a persisted plan.
+func (s *Service) GetPlan(ctx context.Context, planID primitive.ObjectID) (*Plan, error) {
+	var plan Plan
+	if err := s.plans.FindOne(ctx, bson.M{"_id": planID}).Decode(&plan); err != nil {
+		return nil, fmt.Errorf("merge plan not found: %w", err)
+	}
+	return &plan, nil
+}
+
+// ListPlans returns a project's plans, newest first.
+func (s *Service) ListPlans(ctx context.Context, projectID string) ([]*Plan, error) {
+	cursor, err := s.plans.Find(ctx, bson.M{"project_id": projectID},
+		options.Find().SetSort(bson.M{"created_at": -1}))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	var plans []*Plan
+	if err := cursor.All(ctx, &plans); err != nil {
+		return nil, err
+	}
+	return plans, nil
+}
+
+// ApplyResult summarizes an executed merge.
+type ApplyResult struct {
+	Applied           int
+	ConflictsResolved int
+}
+
+// Apply executes a pending plan against the exact heads it was computed
+// for. Conflicts require an explicit strategy; without one, a conflicted
+// plan refuses to apply.
+func (s *Service) Apply(ctx context.Context, planID primitive.ObjectID, strategy string) (*ApplyResult, error) {
+	plan, err := s.GetPlan(ctx, planID)
+	if err != nil {
+		return nil, err
+	}
+	if plan.Status != StatusPending {
+		return nil, fmt.Errorf("merge plan is %s, not pending", plan.Status)
+	}
+
+	target, err := s.branches.GetBranchByID(plan.TargetBranchID)
+	if err != nil {
+		return nil, fmt.Errorf("target branch not found: %w", err)
+	}
+	source, err := s.branches.GetBranchByID(plan.SourceBranchID)
+	if err != nil {
+		return nil, fmt.Errorf("source branch not found: %w", err)
+	}
+	if target.HeadLSN != plan.TargetHead {
+		return nil, fmt.Errorf("stale plan: target advanced from LSN %d to %d since preview; run preview again", plan.TargetHead, target.HeadLSN)
+	}
+	if source.HeadLSN != plan.SourceHead {
+		return nil, fmt.Errorf("stale plan: source advanced from LSN %d to %d since preview; run preview again", plan.SourceHead, source.HeadLSN)
+	}
+
+	changes := append([]Change{}, plan.Changes...)
+	resolved := 0
+	if len(plan.Conflicts) > 0 {
+		switch strategy {
+		case StrategyTheirs:
+			for _, c := range plan.Conflicts {
+				changes = append(changes, Change{
+					Collection: c.Collection,
+					DocumentID: c.DocumentID,
+					Delete:     c.Theirs == nil,
+					Document:   c.Theirs,
+				})
+				resolved++
+			}
+			sortChanges(changes)
+		case StrategyOurs:
+			resolved = len(plan.Conflicts) // Keep ours: nothing to write.
+		case "":
+			return nil, fmt.Errorf("plan has %d conflict(s); pass a strategy (theirs/ours) to resolve them", len(plan.Conflicts))
+		default:
+			return nil, fmt.Errorf("unknown strategy %q (want theirs or ours)", strategy)
+		}
+	}
+
+	if target.IsLive() {
+		err = s.applyPhysical(ctx, target, changes)
+	} else {
+		err = s.applyWAL(ctx, target, source, changes)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// The audit marker: which branch merged in, under which plan.
+	mergeRecord := &wal.Entry{
+		ProjectID: target.ProjectID,
+		BranchID:  target.ID,
+		Operation: wal.OpMerge,
+		Actor:     "merge",
+		Metadata: map[string]interface{}{
+			"plan_id":            plan.ID.Hex(),
+			"source_branch_id":   plan.SourceBranchID,
+			"source_branch":      plan.SourceBranch,
+			"source_head":        plan.SourceHead,
+			"changes":            len(changes),
+			"conflicts_resolved": resolved,
+			"strategy":           strategy,
+		},
+	}
+	if lsn, err := s.wal.Append(mergeRecord); err != nil {
+		return nil, fmt.Errorf("failed to record the merge: %w", err)
+	} else if !target.IsLive() {
+		if err := s.branches.UpdateBranchHead(target.ID, lsn); err != nil {
+			return nil, fmt.Errorf("failed to advance target head: %w", err)
+		}
+	}
+
+	now := time.Now()
+	_, err = s.plans.UpdateOne(ctx,
+		bson.M{"_id": plan.ID, "status": StatusPending},
+		bson.M{"$set": bson.M{"status": StatusApplied, "strategy": strategy, "applied_at": now}},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to mark plan applied: %w", err)
+	}
+	return &ApplyResult{Applied: len(changes), ConflictsResolved: resolved}, nil
+}
+
+func (s *Service) applyWAL(ctx context.Context, target, source *wal.Branch, changes []Change) error {
+	writer := walwriter.New(s.wal, s.branches, s.materializer, target)
+	writer.SetActor("merge:" + source.Name)
+
+	// Group puts per collection for contiguous batches; deletes go singly.
+	putsByCollection := make(map[string][]bson.M)
+	for _, c := range changes {
+		if !c.Delete {
+			putsByCollection[c.Collection] = append(putsByCollection[c.Collection], c.Document)
+		}
+	}
+	for _, collection := range sortedKeys(putsByCollection) {
+		if _, err := writer.PutMany(ctx, collection, putsByCollection[collection]); err != nil {
+			return fmt.Errorf("failed to apply merge puts to %s: %w", collection, err)
+		}
+	}
+	for _, c := range changes {
+		if !c.Delete {
+			continue
+		}
+		id, err := documentIDValue(c)
+		if err != nil {
+			return err
+		}
+		if _, _, err := writer.Delete(ctx, c.Collection, id); err != nil {
+			return fmt.Errorf("failed to apply merge delete to %s/%s: %w", c.Collection, c.DocumentID, err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) applyPhysical(ctx context.Context, target *wal.Branch, changes []Change) error {
+	physical := s.client.Database(target.PhysicalDB)
+	for _, c := range changes {
+		coll := physical.Collection(c.Collection)
+		if c.Delete {
+			id, err := documentIDValue(c)
+			if err != nil {
+				return err
+			}
+			if _, err := coll.DeleteOne(ctx, bson.M{"_id": id}); err != nil {
+				return fmt.Errorf("failed to delete %s/%s: %w", c.Collection, c.DocumentID, err)
+			}
+			continue
+		}
+		if _, err := coll.ReplaceOne(ctx,
+			bson.M{"_id": c.Document["_id"]},
+			c.Document,
+			options.Replace().SetUpsert(true),
+		); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", c.Collection, c.DocumentID, err)
+		}
+	}
+	return nil
+}
+
+// documentIDValue recovers the real _id for a delete change: from the base
+// or ours image if present in a conflict-resolution, otherwise the change
+// document. For plain deletes theirs is nil, so the materialized target
+// state supplies it.
+func documentIDValue(c Change) (interface{}, error) {
+	if c.Document != nil {
+		if id, ok := c.Document["_id"]; ok {
+			return id, nil
+		}
+	}
+	// Deletes carry no document; the canonical string form round-trips for
+	// the common _id types (ObjectID hex and strings).
+	if oid, err := primitive.ObjectIDFromHex(c.DocumentID); err == nil {
+		return oid, nil
+	}
+	return c.DocumentID, nil
+}
+
+// docsUnequal is canonical BSON inequality with nil meaning "absent".
+func docsUnequal(a, b bson.M) (bool, error) {
+	if a == nil || b == nil {
+		return (a == nil) != (b == nil), nil
+	}
+	equal, err := mongoexpr.CanonicalEqual(a, b)
+	if err != nil {
+		return false, err
+	}
+	return !equal, nil
+}
+
+func sortChanges(changes []Change) {
+	sort.Slice(changes, func(i, j int) bool {
+		a, b := changes[i], changes[j]
+		if a.Collection != b.Collection {
+			return a.Collection < b.Collection
+		}
+		return a.DocumentID < b.DocumentID
+	})
+}
+
+func unionKeys3[V any](maps ...map[string]V) []string {
+	seen := make(map[string]bool)
+	for _, m := range maps {
+		for k := range m {
+			seen[k] = true
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/wal/models.go
+++ b/internal/wal/models.go
@@ -26,6 +26,10 @@ const (
 	OpDeleteBranch  OperationType = "delete_branch"
 	OpCreateProject OperationType = "create_project"
 	OpDeleteProject OperationType = "delete_project"
+	// OpMerge records that another branch's changes were merged in; the
+	// data itself arrives as ordinary puts/deletes, this entry is the
+	// audit marker carrying the plan metadata.
+	OpMerge OperationType = "merge"
 )
 
 // Legacy schema-v1 data operations. v1 update/delete entries stored the
@@ -111,7 +115,7 @@ func (e *Entry) ValidateForAppend() error {
 		if e.BranchID == "" || e.Collection == "" || e.DocumentID == "" {
 			return fmt.Errorf("delete entry requires branch, collection and document ID")
 		}
-	case OpCreateBranch, OpDeleteBranch, OpCreateProject, OpDeleteProject:
+	case OpCreateBranch, OpDeleteBranch, OpCreateProject, OpDeleteProject, OpMerge:
 		// Control entries carry their payload in Metadata.
 	case LegacyOpInsert, LegacyOpUpdate:
 		return fmt.Errorf("operation %q is a legacy schema-v1 operation and can no longer be written", e.Operation)

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -12,6 +12,7 @@ import (
 	"github.com/argon-lab/argon/internal/importer"
 	"github.com/argon-lab/argon/internal/ingest"
 	"github.com/argon-lab/argon/internal/materializer"
+	"github.com/argon-lab/argon/internal/merge"
 	"github.com/argon-lab/argon/internal/migrate"
 	projectwal "github.com/argon-lab/argon/internal/project/wal"
 	"github.com/argon-lab/argon/internal/restore"
@@ -39,6 +40,7 @@ type Services struct {
 	Checkout     *checkout.Service
 	Ingest       *ingest.Service
 	Undo         *undo.Service
+	Merge        *merge.Service
 	Monitor      *wal.Monitor
 	MongoURI     string
 }
@@ -102,6 +104,7 @@ func NewServices() (*Services, error) {
 	checkoutService := checkout.NewService(client, db, branchService, materializerService)
 	ingestService := ingest.NewService(client, db, walService, branchService)
 	undoService := undo.NewService(walService, branchService, client)
+	mergeService := merge.NewService(db, walService, branchService, materializerService, client)
 	// Snapshot immediately after imports: an imported history is otherwise
 	// pure linear replay until something trips the auto-snapshot threshold.
 	importerService.SetImportedHook(func(branch *wal.Branch) {
@@ -147,6 +150,7 @@ func NewServices() (*Services, error) {
 		Checkout:     checkoutService,
 		Ingest:       ingestService,
 		Undo:         undoService,
+		Merge:        mergeService,
 		Monitor:      monitor,
 		MongoURI:     mongoURI,
 	}, nil

--- a/tests/wal/ingest_test.go
+++ b/tests/wal/ingest_test.go
@@ -22,6 +22,7 @@ type ingestFixture struct {
 	checkout *checkout.Service
 	ingest   *ingest.Service
 	client   *mongo.Client
+	metaDB   *mongo.Database
 	branchID string
 	physical *mongo.Database
 }
@@ -53,6 +54,7 @@ func newIngestFixture(t *testing.T, project string) *ingestFixture {
 		checkout:        co,
 		ingest:          ing,
 		client:          client,
+		metaDB:          db,
 		branchID:        main.ID,
 		physical:        client.Database(info.PhysicalDB),
 	}

--- a/tests/wal/merge_test.go
+++ b/tests/wal/merge_test.go
@@ -1,0 +1,302 @@
+package wal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argon-lab/argon/internal/merge"
+	"github.com/argon-lab/argon/internal/wal"
+	"github.com/argon-lab/argon/internal/walwriter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// mergeFixture: a main branch with seeded data and a forked feature branch,
+// each with its own writer.
+type mergeFixture struct {
+	*snapshotFixture
+	merge      *merge.Service
+	main       *wal.Branch
+	feature    *wal.Branch
+	mainWriter *walwriter.Writer
+	featWriter *walwriter.Writer
+}
+
+func newMergeFixture(t *testing.T, db *mongo.Database, project string) *mergeFixture {
+	t.Helper()
+	f := newSnapshotFixture(t, db)
+	mergeService := merge.NewService(db, f.wal, f.branches, f.mat, db.Client())
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch(project, "main", "")
+	require.NoError(t, err)
+	mainWriter := walwriter.New(f.wal, f.branches, f.mat, main)
+
+	// Shared baseline.
+	_, err = mainWriter.PutMany(ctx, "docs", []bson.M{
+		{"_id": "stable", "v": "base"},
+		{"_id": "contested", "v": "base"},
+		{"_id": "doomed", "v": "base"},
+	})
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	feature, err := f.branches.CreateBranch(project, "feature", main.ID)
+	require.NoError(t, err)
+	featWriter := walwriter.New(f.wal, f.branches, f.mat, feature)
+
+	return &mergeFixture{
+		snapshotFixture: f,
+		merge:           mergeService,
+		main:            main,
+		feature:         feature,
+		mainWriter:      mainWriter,
+		featWriter:      featWriter,
+	}
+}
+
+func (f *mergeFixture) refresh(t *testing.T) {
+	t.Helper()
+	f.main, _ = f.branches.GetBranchByID(f.main.ID)
+	f.feature, _ = f.branches.GetBranchByID(f.feature.ID)
+}
+
+func TestMerge_CleanMerge(t *testing.T) {
+	db := setupTestDB(t)
+	f := newMergeFixture(t, db, "merge-clean")
+	ctx := context.Background()
+
+	// Feature: modify one doc, add one, delete one. Main: untouched.
+	_, err := f.featWriter.Put(ctx, "docs", bson.M{"_id": "contested", "v": "feature"})
+	require.NoError(t, err)
+	_, err = f.featWriter.Put(ctx, "docs", bson.M{"_id": "new", "v": "feature"})
+	require.NoError(t, err)
+	_, _, err = f.featWriter.Delete(ctx, "docs", "doomed")
+	require.NoError(t, err)
+	f.refresh(t)
+
+	plan, err := f.merge.Preview(ctx, f.feature.ID)
+	require.NoError(t, err)
+	assert.Len(t, plan.Changes, 3)
+	assert.Empty(t, plan.Conflicts)
+
+	result, err := f.merge.Apply(ctx, plan.ID, "")
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.Applied)
+
+	f.refresh(t)
+	state, err := f.matFull.MaterializeCollection(f.main, "docs")
+	require.NoError(t, err)
+	assert.Equal(t, "feature", state["contested"]["v"])
+	assert.Equal(t, "feature", state["new"]["v"])
+	assert.Equal(t, "base", state["stable"]["v"], "untouched documents stay")
+	assert.NotContains(t, state, "doomed", "feature's delete merged")
+
+	// The audit marker is on the target.
+	entries, err := f.wal.GetBranchEntries(f.main.ID, "", 0, f.main.HeadLSN)
+	require.NoError(t, err)
+	var sawMerge bool
+	for _, e := range entries {
+		if e.Operation == wal.OpMerge {
+			sawMerge = true
+			assert.Equal(t, plan.ID.Hex(), e.Metadata["plan_id"])
+		}
+	}
+	assert.True(t, sawMerge, "merge control entry recorded")
+
+	// The plan is spent.
+	applied, err := f.merge.GetPlan(ctx, plan.ID)
+	require.NoError(t, err)
+	assert.Equal(t, merge.StatusApplied, applied.Status)
+	_, err = f.merge.Apply(ctx, plan.ID, "")
+	assert.Error(t, err, "a plan applies exactly once")
+}
+
+func TestMerge_BothSidesNonOverlapping(t *testing.T) {
+	db := setupTestDB(t)
+	f := newMergeFixture(t, db, "merge-both")
+	ctx := context.Background()
+
+	_, err := f.featWriter.Put(ctx, "docs", bson.M{"_id": "from-feature", "v": 1})
+	require.NoError(t, err)
+	_, err = f.mainWriter.Put(ctx, "docs", bson.M{"_id": "from-main", "v": 2})
+	require.NoError(t, err)
+	f.refresh(t)
+
+	plan, err := f.merge.Preview(ctx, f.feature.ID)
+	require.NoError(t, err)
+	assert.Len(t, plan.Changes, 1, "only the feature's addition merges")
+	assert.Empty(t, plan.Conflicts)
+
+	_, err = f.merge.Apply(ctx, plan.ID, "")
+	require.NoError(t, err)
+
+	f.refresh(t)
+	state, err := f.matFull.MaterializeCollection(f.main, "docs")
+	require.NoError(t, err)
+	assert.Contains(t, state, "from-feature")
+	assert.Contains(t, state, "from-main", "the target's own progress is kept")
+}
+
+func TestMerge_IdenticalChangeIsNotAConflict(t *testing.T) {
+	db := setupTestDB(t)
+	f := newMergeFixture(t, db, "merge-identical")
+	ctx := context.Background()
+
+	_, err := f.featWriter.Put(ctx, "docs", bson.M{"_id": "contested", "v": "same"})
+	require.NoError(t, err)
+	_, err = f.mainWriter.Put(ctx, "docs", bson.M{"_id": "contested", "v": "same"})
+	require.NoError(t, err)
+	f.refresh(t)
+
+	plan, err := f.merge.Compute(f.feature.ID)
+	require.NoError(t, err)
+	assert.Empty(t, plan.Changes, "identical change needs no merge")
+	assert.Empty(t, plan.Conflicts, "identical change is not a conflict")
+}
+
+func TestMerge_ConflictStrategies(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	setup := func(project string) *mergeFixture {
+		f := newMergeFixture(t, db, project)
+		_, err := f.featWriter.Put(ctx, "docs", bson.M{"_id": "contested", "v": "theirs"})
+		require.NoError(t, err)
+		_, err = f.mainWriter.Put(ctx, "docs", bson.M{"_id": "contested", "v": "ours"})
+		require.NoError(t, err)
+		f.refresh(t)
+		return f
+	}
+
+	t.Run("Without a strategy the apply refuses", func(t *testing.T) {
+		f := setup("merge-conflict-a")
+		plan, err := f.merge.Preview(ctx, f.feature.ID)
+		require.NoError(t, err)
+		require.Len(t, plan.Conflicts, 1)
+		assert.Empty(t, plan.Changes)
+
+		_, err = f.merge.Apply(ctx, plan.ID, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflict")
+	})
+
+	t.Run("Strategy theirs adopts the branch", func(t *testing.T) {
+		f := setup("merge-conflict-b")
+		plan, err := f.merge.Preview(ctx, f.feature.ID)
+		require.NoError(t, err)
+
+		result, err := f.merge.Apply(ctx, plan.ID, merge.StrategyTheirs)
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.ConflictsResolved)
+
+		f.refresh(t)
+		state, err := f.matFull.MaterializeCollection(f.main, "docs")
+		require.NoError(t, err)
+		assert.Equal(t, "theirs", state["contested"]["v"])
+	})
+
+	t.Run("Strategy ours keeps the target", func(t *testing.T) {
+		f := setup("merge-conflict-c")
+		plan, err := f.merge.Preview(ctx, f.feature.ID)
+		require.NoError(t, err)
+
+		result, err := f.merge.Apply(ctx, plan.ID, merge.StrategyOurs)
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.ConflictsResolved)
+		assert.Equal(t, 0, result.Applied)
+
+		f.refresh(t)
+		state, err := f.matFull.MaterializeCollection(f.main, "docs")
+		require.NoError(t, err)
+		assert.Equal(t, "ours", state["contested"]["v"])
+	})
+}
+
+func TestMerge_DeleteVersusModifyConflict(t *testing.T) {
+	db := setupTestDB(t)
+	f := newMergeFixture(t, db, "merge-delmod")
+	ctx := context.Background()
+
+	_, _, err := f.featWriter.Delete(ctx, "docs", "contested")
+	require.NoError(t, err)
+	_, err = f.mainWriter.Put(ctx, "docs", bson.M{"_id": "contested", "v": "ours-edit"})
+	require.NoError(t, err)
+	f.refresh(t)
+
+	plan, err := f.merge.Preview(ctx, f.feature.ID)
+	require.NoError(t, err)
+	require.Len(t, plan.Conflicts, 1, "delete versus modify is a conflict")
+	assert.Nil(t, plan.Conflicts[0].Theirs, "theirs side is the deletion")
+
+	_, err = f.merge.Apply(ctx, plan.ID, merge.StrategyTheirs)
+	require.NoError(t, err)
+
+	f.refresh(t)
+	state, err := f.matFull.MaterializeCollection(f.main, "docs")
+	require.NoError(t, err)
+	assert.NotContains(t, state, "contested", "strategy theirs applies the deletion")
+}
+
+func TestMerge_StalePlanRefusesToApply(t *testing.T) {
+	db := setupTestDB(t)
+	f := newMergeFixture(t, db, "merge-stale")
+	ctx := context.Background()
+
+	_, err := f.featWriter.Put(ctx, "docs", bson.M{"_id": "new", "v": 1})
+	require.NoError(t, err)
+	f.refresh(t)
+
+	plan, err := f.merge.Preview(ctx, f.feature.ID)
+	require.NoError(t, err)
+
+	// The target moves on after the preview.
+	_, err = f.mainWriter.Put(ctx, "docs", bson.M{"_id": "late", "v": 2})
+	require.NoError(t, err)
+
+	_, err = f.merge.Apply(ctx, plan.ID, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stale")
+}
+
+func TestMerge_IntoLiveTarget(t *testing.T) {
+	f := newIngestFixture(t, "merge-live")
+	mergeService := merge.NewService(f.metaDB, f.wal, f.branches, f.mat, f.client)
+	ctx := context.Background()
+	stop := f.startIngester(t)
+	defer stop()
+
+	// The live main gets its baseline through the ingester.
+	_, err := f.physical.Collection("docs").InsertOne(ctx, bson.M{"_id": "base", "v": int32(1)})
+	require.NoError(t, err)
+	f.waitForEntries(t, "docs", 1)
+
+	// Fork a (metadata-only) feature branch and change data there.
+	main, _ := f.branches.GetBranchByID(f.branchID)
+	feature, err := f.branches.CreateBranch("merge-live", "feature", main.ID)
+	require.NoError(t, err)
+	featWriter := walwriter.New(f.wal, f.branches, f.mat, feature)
+	_, err = featWriter.Put(ctx, "docs", bson.M{"_id": "merged-in", "v": int32(42)})
+	require.NoError(t, err)
+
+	plan, err := mergeService.Preview(ctx, feature.ID)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+
+	_, err = mergeService.Apply(ctx, plan.ID, "")
+	require.NoError(t, err)
+
+	// The change landed in the physical database...
+	var doc bson.M
+	require.NoError(t, f.physical.Collection("docs").FindOne(ctx, bson.M{"_id": "merged-in"}).Decode(&doc))
+	assert.EqualValues(t, 42, doc["v"])
+
+	// ...and flows back through the ingester into the WAL.
+	f.waitForEntries(t, "docs", 2)
+	branch, _ := f.branches.GetBranchByID(f.branchID)
+	walState, err := f.matFull.MaterializeCollection(branch, "docs")
+	require.NoError(t, err)
+	assert.Equal(t, f.physicalState(t, "docs"), walState)
+}


### PR DESCRIPTION
M4: `argon diff`, `argon merge preview/apply/list` — document-level three-way merges between a branch and its parent, with a persisted, reviewable plan in between.

## Semantics

Base = the source's inherited state at its fork point; ours = target head; theirs = source head. Per document: theirs-unchanged → skip; only-theirs-changed → adopt (put/delete); identical change → skip; both-changed-differently → **conflict**. Canonical BSON comparison throughout.

## The data PR

`merge preview` persists the plan as *pending* in `wal_merge_plans`; `merge apply <id>` executes it **exactly once**, and only against the exact source/target heads it was computed for — a moved head means *stale*, re-preview. Conflicts never resolve silently: no strategy → refuse; `--strategy theirs` adopts the branch; `--strategy ours` keeps the target.

## Application

Non-live targets get ordinary puts/deletes through the writer (actor `merge:<source>`); **live targets get physical-database writes that flow back through the ingester** — tested end-to-end. Either way one `merge` control entry records the plan ID, source head, change count and strategy. History stays append-only: a merge is undoable like any other range with `argon undo`.

## Tests

Nine scenarios: clean merge (modify/add/delete + audit marker + exactly-once), two-sided non-overlapping progress, identical-change dedup, conflict refuse/theirs/ours, delete-versus-modify, stale plan, live-target merge through the change stream. Full suite green, lint clean.