### PR TITLE
Agent sandboxes with TTLs and an MCP server

### DIFF
--- a/cli/cmd/mcp.go
+++ b/cli/cmd/mcp.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/argon-lab/argon/pkg/mcpserver"
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Serve Argon to AI agents over the Model Context Protocol",
+	Long: `Runs an MCP server on stdin/stdout exposing the agent workflow as
+tools: fork a TTL sandbox and get a connection string, list branches,
+diff and merge, undo, snapshot. The server supervises change-stream
+capture for every sandbox it hands out, so agent writes become
+versioned history automatically.
+
+Register it with an MCP client, e.g. Claude Code:
+
+  claude mcp add argon -- argon mcp`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		return mcpserver.New(services, os.Stdin, os.Stdout).Run(context.Background())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(mcpCmd)
+}

--- a/cli/cmd/sandbox.go
+++ b/cli/cmd/sandbox.go
@@ -1,0 +1,207 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+var sandboxCmd = &cobra.Command{
+	Use:   "sandbox",
+	Short: "Ephemeral agent branches with a TTL",
+	Long: `A sandbox is a branch forked from a parent, checked out into its own
+physical database, and stamped with a TTL. Point an agent at the
+connection string; merge what you like ("argon merge preview/apply"),
+undo what you don't ("argon undo"), and let the sweep reclaim whatever
+is left when the TTL passes.`,
+}
+
+var sandboxCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Fork, check out and TTL-stamp a sandbox",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		from, _ := cmd.Flags().GetString("from")
+		name, _ := cmd.Flags().GetString("name")
+		ttl, _ := cmd.Flags().GetDuration("ttl")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+		parentID, err := resolveBranch(services, projectName, from)
+		if err != nil {
+			return err
+		}
+
+		info, err := services.Sandbox.Create(context.Background(), project.ID, parentID, name, ttl)
+		if err != nil {
+			return fmt.Errorf("sandbox creation failed: %w", err)
+		}
+
+		fmt.Printf("Sandbox %q forked from %s at LSN %d.\n", info.BranchName, info.ForkedFrom, info.ForkLSN)
+		fmt.Printf("Expires: %s\n", info.ExpiresAt.Format(time.RFC3339))
+		fmt.Printf("Connection string:\n  %s\n", services.BranchConnectionString(info.PhysicalDB))
+		fmt.Printf("Capture its writes with: argon watch -p %s -b %s\n", projectName, info.BranchName)
+		return nil
+	},
+}
+
+var sandboxListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List a project's sandboxes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+		sandboxes, err := services.Sandbox.ListSandboxes(context.Background(), project.ID)
+		if err != nil {
+			return err
+		}
+		if len(sandboxes) == 0 {
+			fmt.Println("No sandboxes.")
+			return nil
+		}
+		now := time.Now()
+		fmt.Printf("%-20s %-10s %-25s %s\n", "SANDBOX", "STATE", "EXPIRES", "PHYSICAL DB")
+		for _, b := range sandboxes {
+			state := b.State
+			if state == "" {
+				state = "released"
+			}
+			expiry := b.ExpiresAt.Format(time.RFC3339)
+			if b.IsExpired(now) {
+				expiry += " (expired)"
+			}
+			fmt.Printf("%-20s %-10s %-25s %s\n", b.Name, state, expiry, b.PhysicalDB)
+		}
+		return nil
+	},
+}
+
+var sandboxDiscardCmd = &cobra.Command{
+	Use:   "discard",
+	Short: "Release and delete a sandbox immediately",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" || branchName == "" {
+			return fmt.Errorf("--project and --branch are required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		branchID, err := resolveBranch(services, projectName, branchName)
+		if err != nil {
+			return err
+		}
+		if err := services.Sandbox.Discard(context.Background(), branchID); err != nil {
+			return fmt.Errorf("discard failed: %w", err)
+		}
+		fmt.Println("Discarded; storage reclaimed.")
+		return nil
+	},
+}
+
+var sandboxKeepCmd = &cobra.Command{
+	Use:   "keep",
+	Short: "Remove a sandbox's TTL, keeping it as an ordinary branch",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		if projectName == "" || branchName == "" {
+			return fmt.Errorf("--project and --branch are required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		branchID, err := resolveBranch(services, projectName, branchName)
+		if err != nil {
+			return err
+		}
+		if err := services.Sandbox.Keep(context.Background(), branchID); err != nil {
+			return fmt.Errorf("keep failed: %w", err)
+		}
+		fmt.Println("TTL removed; the branch is permanent now.")
+		return nil
+	},
+}
+
+var sandboxSweepCmd = &cobra.Command{
+	Use:   "sweep",
+	Short: "Discard every expired sandbox in a project",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		if projectName == "" {
+			return fmt.Errorf("--project is required")
+		}
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+		report, err := services.Sandbox.Sweep(context.Background(), project.ID)
+		if err != nil {
+			return fmt.Errorf("sweep failed: %w", err)
+		}
+		for _, name := range report.Reaped {
+			fmt.Printf("Reaped %s\n", name)
+		}
+		for _, s := range report.Skipped {
+			fmt.Printf("Skipped %s\n", s)
+		}
+		if len(report.Reaped) == 0 && len(report.Skipped) == 0 {
+			fmt.Println("Nothing expired.")
+		}
+		return nil
+	},
+}
+
+func init() {
+	sandboxCreateCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	sandboxCreateCmd.Flags().String("from", "", "Parent branch to fork (default: main)")
+	sandboxCreateCmd.Flags().String("name", "", "Sandbox name (default: generated)")
+	sandboxCreateCmd.Flags().Duration("ttl", time.Hour, "Time to live before the sweep reclaims it")
+	for _, c := range []*cobra.Command{sandboxListCmd, sandboxSweepCmd} {
+		c.Flags().StringP("project", "p", "", "Project name (required)")
+	}
+	for _, c := range []*cobra.Command{sandboxDiscardCmd, sandboxKeepCmd} {
+		c.Flags().StringP("project", "p", "", "Project name (required)")
+		c.Flags().StringP("branch", "b", "", "Sandbox branch name (required)")
+	}
+
+	sandboxCmd.AddCommand(sandboxCreateCmd)
+	sandboxCmd.AddCommand(sandboxListCmd)
+	sandboxCmd.AddCommand(sandboxDiscardCmd)
+	sandboxCmd.AddCommand(sandboxKeepCmd)
+	sandboxCmd.AddCommand(sandboxSweepCmd)
+	rootCmd.AddCommand(sandboxCmd)
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -165,6 +165,24 @@ without one, fall back to full replay unchanged.
   children) drops its WAL entries, its manifests and any chunks no other
   manifest references.
 
+## Agent sandboxes and the MCP server
+
+A sandbox is a branch forked from a parent, checked out into its own
+physical database and stamped with a TTL (`argon sandbox create -p proj
+--ttl 1h`): hand an agent the connection string, merge what you like,
+undo what you don't, and let `argon sandbox sweep` reclaim whatever is
+left when the TTL passes (deletion reclaims WAL entries, snapshots and
+chunks). `keep` removes the TTL; `extend` pushes it out.
+
+`argon mcp` serves this workflow to AI agents over the Model Context
+Protocol (stdio): `argon_sandbox_create` returns a connection string,
+`argon_diff` / `argon_merge_preview` / `argon_merge_apply` bring the work
+back, `argon_undo` reverts it, `argon_sandbox_discard` throws it away.
+The MCP server supervises a change-stream ingester for every sandbox it
+hands out, so agent writes become versioned history without anyone
+running `argon watch` by hand. Register with an MCP client, e.g.
+`claude mcp add argon -- argon mcp`.
+
 ## Garbage collection (retention window)
 
 `argon gc` (and `Services.RunGC`) deletes WAL entries that no reader can

--- a/internal/branch/wal/service.go
+++ b/internal/branch/wal/service.go
@@ -188,6 +188,17 @@ func (s *BranchService) GetBranchByIDAny(branchID string) (*wal.Branch, error) {
 	return &branch, nil
 }
 
+// SetExpiry stamps (or clears, with nil) a branch's sandbox TTL.
+func (s *BranchService) SetExpiry(branchID string, expiresAt *time.Time) error {
+	ctx := context.Background()
+	update := bson.M{"$unset": bson.M{"expires_at": ""}}
+	if expiresAt != nil {
+		update = bson.M{"$set": bson.M{"expires_at": *expiresAt}}
+	}
+	_, err := s.collection.UpdateOne(ctx, bson.M{"_id": branchID}, update)
+	return err
+}
+
 // SetCheckoutState records (or clears, with empty values) a branch's
 // physical-database checkout.
 func (s *BranchService) SetCheckoutState(branchID, physicalDB, state string, checkedOutLSN int64) error {

--- a/internal/sandbox/service.go
+++ b/internal/sandbox/service.go
@@ -1,0 +1,166 @@
+// Package sandbox implements ephemeral agent branches: fork, check out,
+// hand an agent the connection string, and let the TTL clean up whatever
+// wasn't merged or explicitly kept. This is the Neon-style workflow that
+// makes it safe to point an AI agent at production-shaped data.
+package sandbox
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"github.com/argon-lab/argon/internal/checkout"
+	"github.com/argon-lab/argon/internal/wal"
+)
+
+// DefaultTTL bounds sandboxes that don't specify one.
+const DefaultTTL = time.Hour
+
+// Service creates and reaps sandbox branches.
+type Service struct {
+	branches *branchwal.BranchService
+	checkout *checkout.Service
+}
+
+// NewService creates a sandbox service.
+func NewService(branches *branchwal.BranchService, co *checkout.Service) *Service {
+	return &Service{branches: branches, checkout: co}
+}
+
+// Info describes a created sandbox.
+type Info struct {
+	BranchID   string
+	BranchName string
+	PhysicalDB string
+	ExpiresAt  time.Time
+	ForkedFrom string
+	ForkLSN    int64
+}
+
+// Create forks a sandbox branch from the given parent, checks it out and
+// stamps the TTL. The returned physical database is what the agent
+// connects to; run the ingester (argon watch) to capture its writes.
+func (s *Service) Create(ctx context.Context, projectID, parentBranchID, name string, ttl time.Duration) (*Info, error) {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	if name == "" {
+		suffix := make([]byte, 4)
+		if _, err := rand.Read(suffix); err != nil {
+			return nil, fmt.Errorf("failed to generate sandbox name: %w", err)
+		}
+		name = "sandbox-" + hex.EncodeToString(suffix)
+	}
+
+	parent, err := s.branches.GetBranchByID(parentBranchID)
+	if err != nil {
+		return nil, fmt.Errorf("parent branch not found: %w", err)
+	}
+
+	branch, err := s.branches.CreateBranch(projectID, name, parent.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fork sandbox: %w", err)
+	}
+
+	expires := time.Now().Add(ttl)
+	if err := s.branches.SetExpiry(branch.ID, &expires); err != nil {
+		return nil, fmt.Errorf("failed to stamp sandbox TTL: %w", err)
+	}
+
+	info, err := s.checkout.Checkout(ctx, branch.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check the sandbox out: %w", err)
+	}
+
+	return &Info{
+		BranchID:   branch.ID,
+		BranchName: branch.Name,
+		PhysicalDB: info.PhysicalDB,
+		ExpiresAt:  expires,
+		ForkedFrom: parent.Name,
+		ForkLSN:    branch.BaseLSN,
+	}, nil
+}
+
+// Extend pushes a sandbox's expiry further out from now.
+func (s *Service) Extend(ctx context.Context, branchID string, ttl time.Duration) (time.Time, error) {
+	branch, err := s.branches.GetBranchByID(branchID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("sandbox not found: %w", err)
+	}
+	if branch.ExpiresAt == nil {
+		return time.Time{}, fmt.Errorf("branch %s is not a sandbox (no TTL)", branch.Name)
+	}
+	expires := time.Now().Add(ttl)
+	if err := s.branches.SetExpiry(branch.ID, &expires); err != nil {
+		return time.Time{}, err
+	}
+	return expires, nil
+}
+
+// Keep removes the TTL, converting the sandbox into an ordinary branch.
+func (s *Service) Keep(ctx context.Context, branchID string) error {
+	return s.branches.SetExpiry(branchID, nil)
+}
+
+// Discard releases and deletes a sandbox immediately. Deletion reclaims
+// its WAL entries and snapshots through the branch delete hook.
+func (s *Service) Discard(ctx context.Context, branchID string) error {
+	branch, err := s.branches.GetBranchByID(branchID)
+	if err != nil {
+		return fmt.Errorf("sandbox not found: %w", err)
+	}
+	if branch.IsLive() {
+		if err := s.checkout.Release(ctx, branch.ID); err != nil {
+			return fmt.Errorf("failed to release the sandbox: %w", err)
+		}
+	}
+	return s.branches.DeleteBranch(branch.ProjectID, branch.Name)
+}
+
+// SweepReport summarizes one reaping pass.
+type SweepReport struct {
+	Reaped  []string // branch names removed
+	Skipped []string // expired but blocked (e.g. live children)
+}
+
+// Sweep discards every expired sandbox in a project. Expired sandboxes
+// with live children are skipped loudly — children pin their parents.
+func (s *Service) Sweep(ctx context.Context, projectID string) (*SweepReport, error) {
+	branches, err := s.branches.ListBranches(projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list branches: %w", err)
+	}
+
+	now := time.Now()
+	report := &SweepReport{}
+	for _, branch := range branches {
+		if !branch.IsExpired(now) {
+			continue
+		}
+		if err := s.Discard(ctx, branch.ID); err != nil {
+			report.Skipped = append(report.Skipped, fmt.Sprintf("%s (%v)", branch.Name, err))
+			continue
+		}
+		report.Reaped = append(report.Reaped, branch.Name)
+	}
+	return report, nil
+}
+
+// ListSandboxes returns a project's live sandbox branches (TTL-stamped).
+func (s *Service) ListSandboxes(ctx context.Context, projectID string) ([]*wal.Branch, error) {
+	branches, err := s.branches.ListBranches(projectID)
+	if err != nil {
+		return nil, err
+	}
+	sandboxes := make([]*wal.Branch, 0)
+	for _, b := range branches {
+		if b.ExpiresAt != nil {
+			sandboxes = append(sandboxes, b)
+		}
+	}
+	return sandboxes, nil
+}

--- a/internal/wal/models.go
+++ b/internal/wal/models.go
@@ -165,6 +165,16 @@ type Branch struct {
 	PhysicalDB     string `bson:"physical_db,omitempty" json:"physical_db,omitempty"`
 	State          string `bson:"state,omitempty" json:"state,omitempty"` // "" | BranchStateLive
 	CheckedOutLSN  int64  `bson:"checked_out_lsn,omitempty" json:"checked_out_lsn,omitempty"`
+
+	// ExpiresAt marks an ephemeral sandbox branch: past this instant, a
+	// sweep releases and deletes it (storage reclaimed through the delete
+	// hook). Merge or discard it before then — or extend it.
+	ExpiresAt *time.Time `bson:"expires_at,omitempty" json:"expires_at,omitempty"`
+}
+
+// IsExpired reports whether a sandbox branch has passed its TTL.
+func (b *Branch) IsExpired(now time.Time) bool {
+	return b.ExpiresAt != nil && now.After(*b.ExpiresAt)
 }
 
 // BranchStateLive marks a branch as checked out into a physical database.

--- a/pkg/mcpserver/server.go
+++ b/pkg/mcpserver/server.go
@@ -1,0 +1,213 @@
+// Package mcpserver exposes Argon to AI agents over the Model Context
+// Protocol (stdio, JSON-RPC 2.0, newline-delimited). The tool surface is
+// the agent loop end to end: fork a TTL sandbox and get a connection
+// string, work through any MongoDB driver, diff/merge the result back or
+// undo it, and let the TTL reclaim whatever is left.
+//
+// The server supervises a change-stream ingester for every sandbox it
+// creates or connects, so agent writes become versioned history without
+// anyone running "argon watch" by hand. Protocol traffic owns stdout;
+// logs go to stderr.
+package mcpserver
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"sync"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+)
+
+const protocolVersion = "2024-11-05"
+
+// Server speaks MCP over a reader/writer pair (stdin/stdout in production).
+type Server struct {
+	services *walcli.Services
+	in       io.Reader
+	outMu    sync.Mutex
+	out      io.Writer
+
+	// Ingesters supervised for sandboxes created/connected via this server.
+	ingestMu sync.Mutex
+	ingest   map[string]context.CancelFunc
+}
+
+// New creates an MCP server over the given transport.
+func New(services *walcli.Services, in io.Reader, out io.Writer) *Server {
+	return &Server{
+		services: services,
+		in:       in,
+		out:      out,
+		ingest:   make(map[string]context.CancelFunc),
+	}
+}
+
+// jsonRPCRequest is an incoming JSON-RPC 2.0 message.
+type jsonRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+// Run serves until the input closes or the context is canceled. Sandbox
+// ingesters started by this server stop with it.
+func (s *Server) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	defer s.stopAllIngesters()
+
+	scanner := bufio.NewScanner(s.in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return nil
+		}
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var req jsonRPCRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			log.Printf("mcp: dropping unparseable message: %v", err)
+			continue
+		}
+		s.dispatch(ctx, &req)
+	}
+	return scanner.Err()
+}
+
+func (s *Server) dispatch(ctx context.Context, req *jsonRPCRequest) {
+	switch req.Method {
+	case "initialize":
+		s.reply(req.ID, map[string]interface{}{
+			"protocolVersion": protocolVersion,
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"serverInfo": map[string]interface{}{
+				"name":    "argon",
+				"version": "2.0",
+			},
+		})
+	case "notifications/initialized", "notifications/cancelled":
+		// Notifications get no response.
+	case "ping":
+		s.reply(req.ID, map[string]interface{}{})
+	case "tools/list":
+		s.reply(req.ID, map[string]interface{}{"tools": toolDescriptors()})
+	case "tools/call":
+		s.handleToolCall(ctx, req)
+	default:
+		if len(req.ID) != 0 {
+			s.replyError(req.ID, -32601, fmt.Sprintf("method %q not found", req.Method))
+		}
+	}
+}
+
+type toolCallParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments"`
+}
+
+func (s *Server) handleToolCall(ctx context.Context, req *jsonRPCRequest) {
+	var params toolCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.replyError(req.ID, -32602, fmt.Sprintf("invalid tools/call params: %v", err))
+		return
+	}
+
+	handler, ok := toolHandlers[params.Name]
+	if !ok {
+		s.replyError(req.ID, -32602, fmt.Sprintf("unknown tool %q", params.Name))
+		return
+	}
+
+	text, err := handler(ctx, s, params.Arguments)
+	if err != nil {
+		// Tool-level failures are results with isError, not protocol errors.
+		s.reply(req.ID, map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": err.Error()}},
+			"isError": true,
+		})
+		return
+	}
+	s.reply(req.ID, map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": text}},
+	})
+}
+
+func (s *Server) reply(id json.RawMessage, result interface{}) {
+	if len(id) == 0 {
+		return
+	}
+	s.write(&jsonRPCResponse{JSONRPC: "2.0", ID: id, Result: result})
+}
+
+func (s *Server) replyError(id json.RawMessage, code int, message string) {
+	if len(id) == 0 {
+		return
+	}
+	s.write(&jsonRPCResponse{JSONRPC: "2.0", ID: id, Error: &jsonRPCError{Code: code, Message: message}})
+}
+
+func (s *Server) write(resp *jsonRPCResponse) {
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		log.Printf("mcp: failed to encode response: %v", err)
+		return
+	}
+	s.outMu.Lock()
+	defer s.outMu.Unlock()
+	_, _ = s.out.Write(append(payload, '\n'))
+}
+
+// startIngester supervises a change-stream ingester for a branch until the
+// server stops or the branch is discarded.
+func (s *Server) startIngester(branchID string) {
+	s.ingestMu.Lock()
+	defer s.ingestMu.Unlock()
+	if _, running := s.ingest[branchID]; running {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.ingest[branchID] = cancel
+	go func() {
+		if err := s.services.Ingest.Run(ctx, branchID); err != nil && ctx.Err() == nil {
+			log.Printf("mcp: ingester for branch %s stopped: %v", branchID, err)
+		}
+	}()
+}
+
+func (s *Server) stopIngester(branchID string) {
+	s.ingestMu.Lock()
+	defer s.ingestMu.Unlock()
+	if cancel, ok := s.ingest[branchID]; ok {
+		cancel()
+		delete(s.ingest, branchID)
+	}
+}
+
+func (s *Server) stopAllIngesters() {
+	s.ingestMu.Lock()
+	defer s.ingestMu.Unlock()
+	for id, cancel := range s.ingest {
+		cancel()
+		delete(s.ingest, id)
+	}
+}

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -1,0 +1,391 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// toolHandler executes one tool call and returns the text result.
+type toolHandler func(ctx context.Context, s *Server, args map[string]interface{}) (string, error)
+
+var toolHandlers = map[string]toolHandler{
+	"argon_sandbox_create":  toolSandboxCreate,
+	"argon_sandbox_discard": toolSandboxDiscard,
+	"argon_sandbox_keep":    toolSandboxKeep,
+	"argon_branch_list":     toolBranchList,
+	"argon_connect":         toolConnect,
+	"argon_diff":            toolDiff,
+	"argon_merge_preview":   toolMergePreview,
+	"argon_merge_apply":     toolMergeApply,
+	"argon_undo":            toolUndo,
+	"argon_snapshot_create": toolSnapshotCreate,
+}
+
+// schema builds the JSON schema for a tool's arguments.
+func schema(required []string, props map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{
+		"type":       "object",
+		"properties": props,
+	}
+	if len(required) > 0 {
+		out["required"] = required
+	}
+	return out
+}
+
+func str(desc string) map[string]interface{} {
+	return map[string]interface{}{"type": "string", "description": desc}
+}
+
+func num(desc string) map[string]interface{} {
+	return map[string]interface{}{"type": "number", "description": desc}
+}
+
+func boolean(desc string) map[string]interface{} {
+	return map[string]interface{}{"type": "boolean", "description": desc}
+}
+
+// toolDescriptors lists the tools for tools/list.
+func toolDescriptors() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"name": "argon_sandbox_create",
+			"description": "Fork an isolated, disposable copy of a MongoDB branch and get a connection string. " +
+				"Work against it with any MongoDB driver; every write is captured as versioned history. " +
+				"Merge the result back, undo it, or let the TTL reclaim it.",
+			"inputSchema": schema([]string{"project"}, map[string]interface{}{
+				"project":     str("Project name"),
+				"from":        str("Parent branch to fork (default: main)"),
+				"name":        str("Sandbox name (default: generated)"),
+				"ttl_minutes": num("Minutes until the sandbox is reclaimed (default: 60)"),
+			}),
+		},
+		{
+			"name":        "argon_sandbox_discard",
+			"description": "Delete a sandbox immediately and reclaim its storage. Unmerged changes are lost.",
+			"inputSchema": schema([]string{"project", "branch"}, map[string]interface{}{
+				"project": str("Project name"),
+				"branch":  str("Sandbox branch name"),
+			}),
+		},
+		{
+			"name":        "argon_sandbox_keep",
+			"description": "Remove a sandbox's TTL, keeping it as a permanent branch.",
+			"inputSchema": schema([]string{"project", "branch"}, map[string]interface{}{
+				"project": str("Project name"),
+				"branch":  str("Sandbox branch name"),
+			}),
+		},
+		{
+			"name":        "argon_branch_list",
+			"description": "List a project's branches with their heads, checkout state and TTLs.",
+			"inputSchema": schema([]string{"project"}, map[string]interface{}{
+				"project": str("Project name"),
+			}),
+		},
+		{
+			"name": "argon_connect",
+			"description": "Get a MongoDB connection string for a branch, checking it out if needed. " +
+				"Writes through that connection become versioned history.",
+			"inputSchema": schema([]string{"project", "branch"}, map[string]interface{}{
+				"project": str("Project name"),
+				"branch":  str("Branch name"),
+			}),
+		},
+		{
+			"name":        "argon_diff",
+			"description": "Show what merging a branch into its parent would change: adopted documents and conflicts.",
+			"inputSchema": schema([]string{"project", "branch"}, map[string]interface{}{
+				"project": str("Project name"),
+				"branch":  str("Branch to compare against its parent"),
+			}),
+		},
+		{
+			"name":        "argon_merge_preview",
+			"description": "Compute and persist a reviewable merge plan (a data pull request). Returns the plan ID.",
+			"inputSchema": schema([]string{"project", "branch"}, map[string]interface{}{
+				"project": str("Project name"),
+				"branch":  str("Branch to merge into its parent"),
+			}),
+		},
+		{
+			"name":        "argon_merge_apply",
+			"description": "Apply a pending merge plan. Conflicted plans need a strategy: theirs (take the branch) or ours (keep the target).",
+			"inputSchema": schema([]string{"plan_id"}, map[string]interface{}{
+				"plan_id":  str("Plan ID from argon_merge_preview"),
+				"strategy": str("Conflict resolution: theirs or ours"),
+			}),
+		},
+		{
+			"name": "argon_undo",
+			"description": "Revert a range of a branch's history: every touched document returns to its state " +
+				"before the range. Optionally restricted to one actor's writes. Use dry_run to preview.",
+			"inputSchema": schema([]string{"project", "branch", "from_lsn"}, map[string]interface{}{
+				"project":  str("Project name"),
+				"branch":   str("Branch name"),
+				"from_lsn": num("Start of the range to revert"),
+				"to_lsn":   num("End of the range (default: branch head)"),
+				"actor":    str("Only revert writes by this actor"),
+				"dry_run":  boolean("Preview without applying"),
+			}),
+		},
+		{
+			"name":        "argon_snapshot_create",
+			"description": "Snapshot a branch at its current head so reads replay only the delta above it.",
+			"inputSchema": schema([]string{"project", "branch"}, map[string]interface{}{
+				"project": str("Project name"),
+				"branch":  str("Branch name"),
+			}),
+		},
+	}
+}
+
+// --- argument helpers ---
+
+func argString(args map[string]interface{}, key string) string {
+	if v, ok := args[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func argNumber(args map[string]interface{}, key string) (float64, bool) {
+	v, ok := args[key].(float64)
+	return v, ok
+}
+
+func argBool(args map[string]interface{}, key string) bool {
+	v, _ := args[key].(bool)
+	return v
+}
+
+func (s *Server) resolveBranchID(project, branch string) (projectID, branchID string, err error) {
+	p, err := s.services.Projects.GetProjectByName(project)
+	if err != nil {
+		return "", "", fmt.Errorf("project %q not found", project)
+	}
+	if branch == "" {
+		branch = "main"
+	}
+	b, err := s.services.Branches.GetBranch(p.ID, branch)
+	if err != nil {
+		return "", "", fmt.Errorf("branch %q not found in project %q", branch, project)
+	}
+	return p.ID, b.ID, nil
+}
+
+// --- tool implementations ---
+
+func toolSandboxCreate(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	project := argString(args, "project")
+	projectID, parentID, err := s.resolveBranchID(project, argString(args, "from"))
+	if err != nil {
+		return "", err
+	}
+
+	ttl := time.Hour
+	if minutes, ok := argNumber(args, "ttl_minutes"); ok && minutes > 0 {
+		ttl = time.Duration(minutes) * time.Minute
+	}
+
+	info, err := s.services.Sandbox.Create(ctx, projectID, parentID, argString(args, "name"), ttl)
+	if err != nil {
+		return "", fmt.Errorf("sandbox creation failed: %w", err)
+	}
+	s.startIngester(info.BranchID)
+
+	return fmt.Sprintf(
+		"Sandbox %q created (forked from %s at LSN %d).\n"+
+			"Connection string: %s\n"+
+			"Expires: %s\n"+
+			"Writes through this connection are captured as versioned history. "+
+			"Merge back with argon_merge_preview/apply, revert with argon_undo, or discard with argon_sandbox_discard.",
+		info.BranchName, info.ForkedFrom, info.ForkLSN,
+		s.services.BranchConnectionString(info.PhysicalDB),
+		info.ExpiresAt.Format(time.RFC3339),
+	), nil
+}
+
+func toolSandboxDiscard(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	_, branchID, err := s.resolveBranchID(argString(args, "project"), argString(args, "branch"))
+	if err != nil {
+		return "", err
+	}
+	s.stopIngester(branchID)
+	if err := s.services.Sandbox.Discard(ctx, branchID); err != nil {
+		return "", fmt.Errorf("discard failed: %w", err)
+	}
+	return "Sandbox discarded; storage reclaimed.", nil
+}
+
+func toolSandboxKeep(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	_, branchID, err := s.resolveBranchID(argString(args, "project"), argString(args, "branch"))
+	if err != nil {
+		return "", err
+	}
+	if err := s.services.Sandbox.Keep(ctx, branchID); err != nil {
+		return "", err
+	}
+	return "TTL removed; the branch is permanent now.", nil
+}
+
+func toolBranchList(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	project, err := s.services.Projects.GetProjectByName(argString(args, "project"))
+	if err != nil {
+		return "", fmt.Errorf("project %q not found", argString(args, "project"))
+	}
+	branches, err := s.services.Branches.ListBranches(project.ID)
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	for _, b := range branches {
+		fmt.Fprintf(&sb, "%s: head LSN %d", b.Name, b.HeadLSN)
+		if b.IsLive() {
+			fmt.Fprintf(&sb, ", checked out as %s", b.PhysicalDB)
+		}
+		if b.ExpiresAt != nil {
+			fmt.Fprintf(&sb, ", expires %s", b.ExpiresAt.Format(time.RFC3339))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String(), nil
+}
+
+func toolConnect(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	_, branchID, err := s.resolveBranchID(argString(args, "project"), argString(args, "branch"))
+	if err != nil {
+		return "", err
+	}
+	branch, err := s.services.Branches.GetBranchByID(branchID)
+	if err != nil {
+		return "", err
+	}
+	if !branch.IsLive() {
+		info, err := s.services.Checkout.Checkout(ctx, branchID)
+		if err != nil {
+			return "", fmt.Errorf("checkout failed: %w", err)
+		}
+		branch.PhysicalDB = info.PhysicalDB
+	}
+	s.startIngester(branchID)
+	return fmt.Sprintf("Connection string: %s\nWrites through this connection are captured as versioned history.",
+		s.services.BranchConnectionString(branch.PhysicalDB)), nil
+}
+
+func formatPlanSummary(sb *strings.Builder, changes, conflicts int) {
+	fmt.Fprintf(sb, "%d change(s), %d conflict(s)\n", changes, conflicts)
+}
+
+func toolDiff(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	_, branchID, err := s.resolveBranchID(argString(args, "project"), argString(args, "branch"))
+	if err != nil {
+		return "", err
+	}
+	plan, err := s.services.Merge.Compute(branchID)
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Merging %s into %s would:\n", plan.SourceBranch, plan.TargetBranch)
+	for _, c := range plan.Changes {
+		action := "put"
+		if c.Delete {
+			action = "delete"
+		}
+		fmt.Fprintf(&sb, "  %s %s/%s\n", action, c.Collection, c.DocumentID)
+	}
+	for _, c := range plan.Conflicts {
+		fmt.Fprintf(&sb, "  CONFLICT %s/%s (both sides changed since the fork)\n", c.Collection, c.DocumentID)
+	}
+	formatPlanSummary(&sb, len(plan.Changes), len(plan.Conflicts))
+	return sb.String(), nil
+}
+
+func toolMergePreview(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	_, branchID, err := s.resolveBranchID(argString(args, "project"), argString(args, "branch"))
+	if err != nil {
+		return "", err
+	}
+	plan, err := s.services.Merge.Preview(ctx, branchID)
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Merge plan %s (%s into %s): ", plan.ID.Hex(), plan.SourceBranch, plan.TargetBranch)
+	formatPlanSummary(&sb, len(plan.Changes), len(plan.Conflicts))
+	if len(plan.Conflicts) > 0 {
+		sb.WriteString("Apply with argon_merge_apply and strategy theirs or ours.")
+	} else {
+		sb.WriteString("Apply with argon_merge_apply.")
+	}
+	return sb.String(), nil
+}
+
+func toolMergeApply(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	planID, err := primitive.ObjectIDFromHex(argString(args, "plan_id"))
+	if err != nil {
+		return "", fmt.Errorf("invalid plan_id")
+	}
+	result, err := s.services.Merge.Apply(ctx, planID, argString(args, "strategy"))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Merged: %d change(s) applied, %d conflict(s) resolved.", result.Applied, result.ConflictsResolved), nil
+}
+
+func toolUndo(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	_, branchID, err := s.resolveBranchID(argString(args, "project"), argString(args, "branch"))
+	if err != nil {
+		return "", err
+	}
+	fromLSN, ok := argNumber(args, "from_lsn")
+	if !ok {
+		return "", fmt.Errorf("from_lsn is required")
+	}
+	toLSN, _ := argNumber(args, "to_lsn")
+
+	plan, err := s.services.BuildUndoPlan(branchID, int64(fromLSN), int64(toLSN), argString(args, "actor"))
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Undo [%d, %d]: %d document(s) to revert, %d conflict(s), %d unrecoverable.\n",
+		plan.FromLSN, plan.ToLSN, len(plan.Compensations), len(plan.Conflicts), len(plan.Unrecoverable))
+
+	if argBool(args, "dry_run") {
+		sb.WriteString("Dry run: nothing applied.")
+		return sb.String(), nil
+	}
+
+	restored, deleted, err := s.services.ApplyUndoPlan(ctx, branchID, plan)
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintf(&sb, "Done: %d restored, %d deleted.", restored, deleted)
+	return sb.String(), nil
+}
+
+func toolSnapshotCreate(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	_, branchID, err := s.resolveBranchID(argString(args, "project"), argString(args, "branch"))
+	if err != nil {
+		return "", err
+	}
+	branch, err := s.services.Branches.GetBranchByID(branchID)
+	if err != nil {
+		return "", err
+	}
+	snaps, err := s.services.Snapshots.CreateSnapshot(ctx, branchID, branch.HeadLSN)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Snapshotted %d collection(s) at LSN %d.", len(snaps), branch.HeadLSN), nil
+}

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -16,6 +16,7 @@ import (
 	"github.com/argon-lab/argon/internal/migrate"
 	projectwal "github.com/argon-lab/argon/internal/project/wal"
 	"github.com/argon-lab/argon/internal/restore"
+	"github.com/argon-lab/argon/internal/sandbox"
 	"github.com/argon-lab/argon/internal/snapshot"
 	"github.com/argon-lab/argon/internal/timetravel"
 	"github.com/argon-lab/argon/internal/undo"
@@ -41,6 +42,7 @@ type Services struct {
 	Ingest       *ingest.Service
 	Undo         *undo.Service
 	Merge        *merge.Service
+	Sandbox      *sandbox.Service
 	Monitor      *wal.Monitor
 	MongoURI     string
 }
@@ -105,6 +107,7 @@ func NewServices() (*Services, error) {
 	ingestService := ingest.NewService(client, db, walService, branchService)
 	undoService := undo.NewService(walService, branchService, client)
 	mergeService := merge.NewService(db, walService, branchService, materializerService, client)
+	sandboxService := sandbox.NewService(branchService, checkoutService)
 	// Snapshot immediately after imports: an imported history is otherwise
 	// pure linear replay until something trips the auto-snapshot threshold.
 	importerService.SetImportedHook(func(branch *wal.Branch) {
@@ -151,6 +154,7 @@ func NewServices() (*Services, error) {
 		Ingest:       ingestService,
 		Undo:         undoService,
 		Merge:        mergeService,
+		Sandbox:      sandboxService,
 		Monitor:      monitor,
 		MongoURI:     mongoURI,
 	}, nil

--- a/tests/wal/mcpserver_test.go
+++ b/tests/wal/mcpserver_test.go
@@ -1,0 +1,222 @@
+package wal_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/argon-lab/argon/internal/checkout"
+	"github.com/argon-lab/argon/internal/gc"
+	"github.com/argon-lab/argon/internal/ingest"
+	"github.com/argon-lab/argon/internal/merge"
+	projectwal "github.com/argon-lab/argon/internal/project/wal"
+	"github.com/argon-lab/argon/internal/sandbox"
+	"github.com/argon-lab/argon/internal/timetravel"
+	"github.com/argon-lab/argon/internal/undo"
+	"github.com/argon-lab/argon/pkg/mcpserver"
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// mcpClient drives an in-process MCP server over pipes.
+type mcpClient struct {
+	t      *testing.T
+	in     io.WriteCloser
+	out    *bufio.Scanner
+	nextID int
+}
+
+func startMCP(t *testing.T, db *mongo.Database) (*mcpClient, *walcli.Services) {
+	t.Helper()
+	f := newSnapshotFixture(t, db)
+	client := db.Client()
+	co := checkout.NewService(client, db, f.branches, f.mat)
+	gcService := gc.NewService(f.wal, f.branches, f.snapshots)
+	f.branches.SetDeleteHook(func(branchID string) {
+		_, _, _, _ = gcService.ReclaimDeletedBranch(context.Background(), branchID)
+	})
+	projectService, err := projectwal.NewProjectService(db, f.wal, f.branches)
+	require.NoError(t, err)
+
+	services := &walcli.Services{
+		WAL:          f.wal,
+		Branches:     f.branches,
+		Projects:     projectService,
+		Materializer: f.mat,
+		TimeTravel:   timetravel.NewService(f.wal, f.mat),
+		Snapshots:    f.snapshots,
+		GC:           gcService,
+		Checkout:     co,
+		Ingest:       ingest.NewService(client, db, f.wal, f.branches),
+		Undo:         undo.NewService(f.wal, f.branches, client),
+		Merge:        merge.NewService(db, f.wal, f.branches, f.mat, client),
+		Sandbox:      sandbox.NewService(f.branches, co),
+		MongoURI:     "mongodb://localhost:27017",
+	}
+
+	clientIn, serverOut := io.Pipe()
+	serverIn, clientOut := io.Pipe()
+	server := mcpserver.New(services, serverIn, serverOut)
+	go func() { _ = server.Run(context.Background()) }()
+	t.Cleanup(func() { _ = clientOut.Close() })
+
+	scanner := bufio.NewScanner(clientIn)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	return &mcpClient{t: t, in: clientOut, out: scanner}, services
+}
+
+// call sends a request and decodes the matching response.
+func (c *mcpClient) call(method string, params interface{}) map[string]interface{} {
+	c.t.Helper()
+	c.nextID++
+	req := map[string]interface{}{"jsonrpc": "2.0", "id": c.nextID, "method": method}
+	if params != nil {
+		req["params"] = params
+	}
+	payload, err := json.Marshal(req)
+	require.NoError(c.t, err)
+	_, err = c.in.Write(append(payload, '\n'))
+	require.NoError(c.t, err)
+
+	require.True(c.t, c.out.Scan(), "server closed the stream")
+	var resp map[string]interface{}
+	require.NoError(c.t, json.Unmarshal(c.out.Bytes(), &resp))
+	require.EqualValues(c.t, c.nextID, resp["id"], "response id matches request")
+	require.Nil(c.t, resp["error"], "unexpected protocol error: %v", resp["error"])
+	return resp["result"].(map[string]interface{})
+}
+
+// toolText calls a tool and returns its text payload.
+func (c *mcpClient) toolText(name string, args map[string]interface{}) (string, bool) {
+	c.t.Helper()
+	result := c.call("tools/call", map[string]interface{}{"name": name, "arguments": args})
+	content := result["content"].([]interface{})
+	text := content[0].(map[string]interface{})["text"].(string)
+	isError, _ := result["isError"].(bool)
+	return text, isError
+}
+
+func TestMCP_ProtocolAndAgentLoop(t *testing.T) {
+	db := setupTestDB(t)
+	c, services := startMCP(t, db)
+	ctx := context.Background()
+
+	// Handshake.
+	init := c.call("initialize", map[string]interface{}{"protocolVersion": "2024-11-05"})
+	assert.Equal(t, "argon", init["serverInfo"].(map[string]interface{})["name"])
+
+	// Tool inventory.
+	list := c.call("tools/list", nil)
+	tools := list["tools"].([]interface{})
+	names := make(map[string]bool)
+	for _, tl := range tools {
+		names[tl.(map[string]interface{})["name"].(string)] = true
+	}
+	for _, want := range []string{"argon_sandbox_create", "argon_connect", "argon_diff", "argon_merge_preview", "argon_merge_apply", "argon_undo", "argon_sandbox_discard"} {
+		assert.True(t, names[want], "tool %s advertised", want)
+	}
+
+	// Seed a project through the services.
+	project, err := services.Projects.CreateProject("agent-loop")
+	require.NoError(t, err)
+	writer, err := services.WriterFor("agent-loop", "main")
+	require.NoError(t, err)
+	_, err = writer.Put(ctx, "docs", bson.M{"_id": "prod", "v": int32(1)})
+	require.NoError(t, err)
+	_ = project
+
+	// 1. The agent forks a sandbox and gets a connection string.
+	text, isErr := c.toolText("argon_sandbox_create", map[string]interface{}{
+		"project": "agent-loop", "name": "agent-sbx", "ttl_minutes": 30,
+	})
+	require.False(t, isErr, text)
+	assert.Contains(t, text, "Connection string:")
+	uriMatch := regexp.MustCompile(`mongodb://\S+`).FindString(text)
+	require.NotEmpty(t, uriMatch)
+	physName := uriMatch[strings.LastIndex(uriMatch, "/")+1:]
+	t.Cleanup(func() { _ = db.Client().Database(physName).Drop(context.Background()) })
+
+	// 2. The agent writes through a plain MongoDB driver.
+	agentClient, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017"))
+	require.NoError(t, err)
+	defer func() { _ = agentClient.Disconnect(context.Background()) }()
+	agentDB := agentClient.Database(physName)
+	_, err = agentDB.Collection("docs").InsertOne(ctx, bson.M{"_id": "agent-made", "v": int32(42)})
+	require.NoError(t, err)
+
+	// The server-supervised ingester captures it.
+	sbx, err := services.Branches.GetBranch(project.ID, "agent-sbx")
+	require.NoError(t, err)
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		branch, err := services.Branches.GetBranchByID(sbx.ID)
+		require.NoError(t, err)
+		entries, err := services.WAL.GetBranchEntries(sbx.ID, "docs", 0, branch.HeadLSN)
+		require.NoError(t, err)
+		if len(entries) >= 1 {
+			break
+		}
+		require.True(t, time.Now().Before(deadline), "ingester never captured the agent write")
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// 3. The agent inspects the diff and merges back.
+	text, isErr = c.toolText("argon_diff", map[string]interface{}{"project": "agent-loop", "branch": "agent-sbx"})
+	require.False(t, isErr, text)
+	assert.Contains(t, text, "put docs/agent-made")
+
+	text, isErr = c.toolText("argon_merge_preview", map[string]interface{}{"project": "agent-loop", "branch": "agent-sbx"})
+	require.False(t, isErr, text)
+	planID := regexp.MustCompile(`[0-9a-f]{24}`).FindString(text)
+	require.NotEmpty(t, planID, "preview returns a plan id: %s", text)
+
+	text, isErr = c.toolText("argon_merge_apply", map[string]interface{}{"plan_id": planID})
+	require.False(t, isErr, text)
+	assert.Contains(t, text, "1 change(s) applied")
+
+	main, err := services.Branches.GetBranch(project.ID, "main")
+	require.NoError(t, err)
+	state, err := services.Materializer.MaterializeCollection(main, "docs")
+	require.NoError(t, err)
+	assert.Contains(t, state, "agent-made", "the agent's work landed on main")
+
+	// 4. The undo button, from the agent's point of view (dry run).
+	text, isErr = c.toolText("argon_undo", map[string]interface{}{
+		"project": "agent-loop", "branch": "main",
+		"from_lsn": float64(main.HeadLSN), "dry_run": true,
+	})
+	require.False(t, isErr, text)
+	assert.Contains(t, text, "Dry run")
+
+	// 5. Discard the sandbox; storage reclaims.
+	text, isErr = c.toolText("argon_sandbox_discard", map[string]interface{}{"project": "agent-loop", "branch": "agent-sbx"})
+	require.False(t, isErr, text)
+	_, err = services.Branches.GetBranchByID(sbx.ID)
+	assert.Error(t, err, "sandbox gone")
+
+	// Tool-level failures surface as isError results, not protocol errors.
+	text, isErr = c.toolText("argon_connect", map[string]interface{}{"project": "no-such", "branch": "main"})
+	assert.True(t, isErr)
+	assert.Contains(t, text, "not found")
+
+	// Unknown methods are proper JSON-RPC errors.
+	c.nextID++
+	payload, _ := json.Marshal(map[string]interface{}{"jsonrpc": "2.0", "id": c.nextID, "method": "bogus/method"})
+	_, err = c.in.Write(append(payload, '\n'))
+	require.NoError(t, err)
+	require.True(t, c.out.Scan())
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(c.out.Bytes(), &resp))
+	require.NotNil(t, resp["error"])
+	assert.EqualValues(t, -32601, resp["error"].(map[string]interface{})["code"])
+
+}

--- a/tests/wal/sandbox_test.go
+++ b/tests/wal/sandbox_test.go
@@ -1,0 +1,125 @@
+package wal_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/argon-lab/argon/internal/checkout"
+	"github.com/argon-lab/argon/internal/gc"
+	"github.com/argon-lab/argon/internal/sandbox"
+	"github.com/argon-lab/argon/internal/walwriter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func newSandboxFixture(t *testing.T, db *mongo.Database, project string) (*snapshotFixture, *sandbox.Service, string) {
+	t.Helper()
+	f := newSnapshotFixture(t, db)
+	co := checkout.NewService(db.Client(), db, f.branches, f.mat)
+	sandboxService := sandbox.NewService(f.branches, co)
+
+	// Reclaim on delete, the way walcli wires it.
+	gcService := gc.NewService(f.wal, f.branches, f.snapshots)
+	f.branches.SetDeleteHook(func(branchID string) {
+		_, _, _, err := gcService.ReclaimDeletedBranch(context.Background(), branchID)
+		require.NoError(t, err)
+	})
+
+	main, err := f.branches.CreateBranch(project, "main", "")
+	require.NoError(t, err)
+	writer := walwriter.New(f.wal, f.branches, f.mat, main)
+	_, err = writer.Put(context.Background(), "docs", bson.M{"_id": "seed", "v": int32(1)})
+	require.NoError(t, err)
+	main, _ = f.branches.GetBranchByID(main.ID)
+	return f, sandboxService, main.ID
+}
+
+func TestSandbox_Lifecycle(t *testing.T) {
+	db := setupTestDB(t)
+	f, svc, mainID := newSandboxFixture(t, db, "sbx-life")
+	ctx := context.Background()
+
+	info, err := svc.Create(ctx, "sbx-life", mainID, "", time.Hour)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Client().Database(info.PhysicalDB).Drop(context.Background()) })
+
+	assert.Contains(t, info.BranchName, "sandbox-")
+	assert.NotEmpty(t, info.PhysicalDB)
+	assert.True(t, info.ExpiresAt.After(time.Now()))
+
+	// The physical database holds the fork state: agents query it directly.
+	var doc bson.M
+	require.NoError(t, db.Client().Database(info.PhysicalDB).Collection("docs").
+		FindOne(ctx, bson.M{"_id": "seed"}).Decode(&doc))
+	assert.EqualValues(t, 1, doc["v"])
+
+	// Keep removes the TTL.
+	require.NoError(t, svc.Keep(ctx, info.BranchID))
+	branch, _ := f.branches.GetBranchByID(info.BranchID)
+	assert.Nil(t, branch.ExpiresAt)
+
+	// Discard releases and deletes it; storage reclaims.
+	require.NoError(t, svc.Discard(ctx, info.BranchID))
+	assert.Zero(t, countBranchEntries(t, f, info.BranchID), "sandbox entries reclaimed")
+	_, err = f.branches.GetBranchByID(info.BranchID)
+	assert.Error(t, err, "sandbox branch gone")
+
+	// Main is untouched.
+	main, _ := f.branches.GetBranchByID(mainID)
+	state, err := f.mat.MaterializeCollection(main, "docs")
+	require.NoError(t, err)
+	assert.Len(t, state, 1)
+}
+
+func TestSandbox_SweepReapsOnlyExpired(t *testing.T) {
+	db := setupTestDB(t)
+	f, svc, mainID := newSandboxFixture(t, db, "sbx-sweep")
+	ctx := context.Background()
+
+	expired, err := svc.Create(ctx, "sbx-sweep", mainID, "old", 1*time.Millisecond)
+	require.NoError(t, err)
+	fresh, err := svc.Create(ctx, "sbx-sweep", mainID, "new", time.Hour)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Client().Database(expired.PhysicalDB).Drop(context.Background())
+		_ = db.Client().Database(fresh.PhysicalDB).Drop(context.Background())
+	})
+	time.Sleep(10 * time.Millisecond)
+
+	report, err := svc.Sweep(ctx, "sbx-sweep")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"old"}, report.Reaped)
+	assert.Empty(t, report.Skipped)
+
+	_, err = f.branches.GetBranchByID(expired.BranchID)
+	assert.Error(t, err, "expired sandbox reaped")
+	still, err := f.branches.GetBranchByID(fresh.BranchID)
+	require.NoError(t, err, "fresh sandbox survives")
+	assert.NotNil(t, still.ExpiresAt)
+
+	// Sweep is idempotent.
+	report, err = svc.Sweep(ctx, "sbx-sweep")
+	require.NoError(t, err)
+	assert.Empty(t, report.Reaped)
+}
+
+func TestSandbox_ExtendPushesExpiry(t *testing.T) {
+	db := setupTestDB(t)
+	_, svc, mainID := newSandboxFixture(t, db, "sbx-extend")
+	ctx := context.Background()
+
+	info, err := svc.Create(ctx, "sbx-extend", mainID, "extend-me", time.Minute)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Client().Database(info.PhysicalDB).Drop(context.Background()) })
+
+	newExpiry, err := svc.Extend(ctx, info.BranchID, 2*time.Hour)
+	require.NoError(t, err)
+	assert.True(t, newExpiry.After(info.ExpiresAt), "extension moves the expiry out")
+
+	// Extending a non-sandbox branch fails.
+	_, err = svc.Extend(ctx, mainID, time.Hour)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
M5: the agent story becomes a product surface.

## Sandboxes (`argon sandbox create/list/keep/discard/sweep`)

Fork → checkout → TTL-stamp, in one command: the agent gets a connection string to an isolated physical database. `keep` removes the TTL (promotion to a real branch), `discard` releases + deletes immediately, `sweep` reaps everything expired — deletion reclaims WAL entries, snapshots and unshared chunks through the existing delete hook. Expired sandboxes that can't be deleted (children pin them) are skipped loudly, never forced.

## MCP server (`argon mcp`)

Model Context Protocol over stdio: `argon_sandbox_create` (returns the connection string), `argon_branch_list`, `argon_connect` (checkout-on-demand), `argon_diff`, `argon_merge_preview` / `argon_merge_apply`, `argon_undo` (with dry-run), `argon_snapshot_create`, `argon_sandbox_keep/discard`.

**The server supervises a change-stream ingester for every sandbox it hands out** — agent writes become versioned history with no `argon watch` babysitting. Ingesters stop with the server or when their sandbox is discarded. Protocol traffic owns stdout; logs go to stderr; tool failures are `isError` results; unknown methods are JSON-RPC `-32601`.

Register with `claude mcp add argon -- argon mcp`.

## Tests

Sandbox lifecycle with storage reclamation, idempotent expired-only sweep, expiry extension — plus an in-process MCP protocol test that drives the **entire agent loop**: handshake → tools/list → sandbox create → a real `mongo.Client` write captured by the supervised ingester → diff → merge preview/apply landing on main → undo dry-run → discard → error surfaces. Full suite green, lint clean.