### PR TITLE
Docs: M4 shipped; M5 core shipped (MCP + sandboxes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Argon's engine is being rebuilt milestone by milestone, correctness first ([full
 | **M1 · Correctness** | Deterministic replay (property-tested), distributed LSN sequencer, branch ancestry isolation, truthful write results, WAL v2 migration | ✅ Shipped |
 | **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · [public reproducible benchmarks](https://github.com/argon-lab/benchmarks) ✅ | ✅ Shipped |
 | **M3 · True drop-in** | Physical MongoDB database per branch (`argon checkout` → connection string) ✅ · change-stream write capture ✅ · `argon undo` with per-actor conflict detection ✅ · official driver test suites in CI 🚧 | Shipped · driver-suite validation pending |
-| **M4 · Merge & diff** | Document-level diff, three-way merge, reviewable data PRs | Planned |
-| **M5 · Agent ecosystem** | MCP server, LangGraph checkpointer, TTL sandboxes, eval pinning | Planned |
+| **M4 · Merge & diff** | `argon diff` ✅ · three-way merge with persisted, reviewable plans (`argon merge preview/apply`) ✅ · conflicts never resolved silently ✅ · merges undoable like any range ✅ | ✅ Shipped |
+| **M5 · Agent ecosystem** | MCP server (`argon mcp`, 9 tools, supervised ingesters) ✅ · TTL sandboxes (`argon sandbox`) ✅ · LangGraph checkpointer 🚧 · eval dataset pinning 🚧 | MCP + sandboxes shipped · integrations remaining |
 
 ## Installation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -256,10 +256,9 @@ entries removed). Migration is idempotent.
 
 Current limitations (deliberate scope):
 
-- Reads materialize in memory: no indexes, no aggregation pipeline, Find
-  options (sort/skip/limit/projection) not applied; results in canonical
-  document-ID order.
-- No merge/diff commands yet (pre-images already carry the data they need).
+- Time-travel and metadata-only branch reads materialize in memory (no
+  indexes or aggregation on that path); live branches checked out to a
+  physical database get real mongod reads with everything that implies.
 - WAL entries live in MongoDB and are reclaimed by retention-window GC once
   snapshots cover them; snapshot chunks can additionally live in an
   S3-compatible or filesystem chunk store (see "Chunk store backends"
@@ -273,14 +272,13 @@ https://github.com/argon-lab/benchmarks — reproducible with
 
 Planned next (in order):
 
-1. **M3 (last box) — driver-suite validation**: physical per-branch
-   databases (`argon checkout`), change-stream ingestion, and per-actor
-   `argon undo` are all merged. What remains is running the official
+1. **M3 (last box) — driver-suite validation**: running the official
    pymongo/mongoose test suites against branch databases in CI — until
    then, "any driver connects" is stated as an architectural fact, not an
    unqualified drop-in claim.
-2. **M4 — merge and diff**: three-way document-level merge with reviewable
-   merge plans.
+2. **M5 (remaining) — integrations**: LangGraph checkpointer with fork and
+   rewind; eval dataset pinning. The MCP server and TTL sandboxes shipped
+   in #23.
 
 ## Storage collections
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -31,8 +31,8 @@
 ### Audit trail
 - Every write is a WAL entry with **full pre/post document images** and an
   **actor** field (`user:...`, `agent:...`, `importer`)
-- Immutable, append-only log — the foundation for diff, undo, and compliance
-  (merge/diff commands land in M4)
+- Immutable, append-only log — the foundation for `argon diff`,
+  `argon merge` (reviewable data PRs), `argon undo`, and compliance
 - WAL entries are compressed per entry (zstd by default)
 
 ## 📊 Developer Experience
@@ -102,11 +102,9 @@ reproduce on yours with `docker compose up`:
 
 ## ⚠️ Current Limitations (deliberate scope)
 
-- Reads materialize in memory: no indexes, no aggregation pipeline; Find
-  options (sort/skip/limit/projection) are not applied yet. M3 fixes this
-  structurally by running reads on real mongod.
-- No merge/diff commands yet (M4) — pre-images already record the data they
-  will need.
+- Time-travel and metadata-only branch reads materialize in memory; live
+  branches checked out to a physical database get real mongod reads
+  (indexes, aggregation, everything).
 - WAL entries live in MongoDB and are reclaimed by retention-window GC once
   snapshots cover them; snapshot chunks can additionally live in an
   S3-compatible or filesystem chunk store.
@@ -121,8 +119,8 @@ reproduce on yours with `docker compose up`:
 | **M1 · Correctness** | Deterministic replay (property-tested), distributed LSN sequencer, branch ancestry isolation, truthful write results, WAL v2 migration | ✅ Shipped |
 | **M2 · Bounded time travel** | Snapshots that bound replay depth ✅ · retention-window WAL GC + full branch reclamation ✅ · S3/filesystem snapshot chunk stores ✅ · [public reproducible benchmarks](https://github.com/argon-lab/benchmarks) ✅ | ✅ Shipped |
 | **M3 · True drop-in** | Physical MongoDB database per branch (`argon checkout` → connection string) ✅ · change-stream write capture ✅ · `argon undo` with per-actor conflict detection ✅ · official driver test suites in CI 🚧 | Shipped · driver-suite validation pending |
-| **M4 · Merge & diff** | Document-level diff, three-way merge, reviewable data PRs | Planned |
-| **M5 · Agent ecosystem** | MCP server, LangGraph checkpointer, TTL sandboxes, eval pinning | Planned |
+| **M4 · Merge & diff** | `argon diff` ✅ · three-way merge with persisted, reviewable plans (`argon merge preview/apply`) ✅ · conflicts never resolved silently ✅ · merges undoable like any range ✅ | ✅ Shipped |
+| **M5 · Agent ecosystem** | MCP server (`argon mcp`, 9 tools, supervised ingesters) ✅ · TTL sandboxes (`argon sandbox`) ✅ · LangGraph checkpointer 🚧 · eval dataset pinning 🚧 | MCP + sandboxes shipped · integrations remaining |
 
 Full roadmap: https://www.argonlabs.tech/roadmap
 


### PR DESCRIPTION
Companion to the website update. Milestone tables and limitations now reflect #20–#23:

- M4 → ✅ shipped: `argon diff`, `argon merge preview/apply` with persisted reviewable plans, conflict semantics, undoable merges
- M5 → "MCP + sandboxes shipped · integrations remaining": `argon mcp` (9 tools, supervised ingesters) and `argon sandbox` TTL lifecycle are in; LangGraph checkpointer and eval pinning are not yet started and stay 🚧
- Reads-in-memory limitation reworded post-#14/#20: live branches read on real mongod; time-travel/metadata-only reads still materialize in memory
- Planned-next narrows to the two real gaps: driver-suite CI (M3's last box) and M5's integrations