### PR TITLE
Decode snapshot chunks in parallel

### DIFF
--- a/internal/snapshot/service.go
+++ b/internal/snapshot/service.go
@@ -194,15 +194,59 @@ func (s *Service) usable(snap *Snapshot, branch *wal.Branch, readUpperBound int6
 	return true
 }
 
+// load fetches and decodes a snapshot's chunks in parallel. Chunks hold
+// disjoint, contiguous key ranges (the encoder cuts a sorted stream), so
+// each decodes into a private map and the merge is a plain union.
+// Decompression and per-document BSON decoding dominate snapshot reads —
+// benchmark feedback measured them at ~70% of a warm read — and they
+// parallelize embarrassingly.
 func (s *Service) load(ctx context.Context, snap *Snapshot) (map[string]bson.M, error) {
-	state := make(map[string]bson.M, snap.DocCount)
-	for _, chunkID := range snap.ChunkIDs {
-		data, err := s.store.Get(ctx, chunkID)
+	if len(snap.ChunkIDs) == 0 {
+		return make(map[string]bson.M), nil
+	}
+	if len(snap.ChunkIDs) == 1 {
+		state := make(map[string]bson.M, snap.DocCount)
+		data, err := s.store.Get(ctx, snap.ChunkIDs[0])
 		if err != nil {
 			return nil, err
 		}
 		if err := decodeChunk(data, s.compressor, state); err != nil {
-			return nil, fmt.Errorf("chunk %s: %w", chunkID, err)
+			return nil, fmt.Errorf("chunk %s: %w", snap.ChunkIDs[0], err)
+		}
+		return state, nil
+	}
+
+	partials := make([]map[string]bson.M, len(snap.ChunkIDs))
+	errs := make([]error, len(snap.ChunkIDs))
+	var wg sync.WaitGroup
+	for i, chunkID := range snap.ChunkIDs {
+		wg.Add(1)
+		go func(i int, chunkID string) {
+			defer wg.Done()
+			data, err := s.store.Get(ctx, chunkID)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			partial := make(map[string]bson.M)
+			if err := decodeChunk(data, s.compressor, partial); err != nil {
+				errs[i] = fmt.Errorf("chunk %s: %w", chunkID, err)
+				return
+			}
+			partials[i] = partial
+		}(i, chunkID)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	state := make(map[string]bson.M, snap.DocCount)
+	for _, partial := range partials {
+		for k, v := range partial {
+			state[k] = v
 		}
 	}
 	return state, nil

--- a/tests/wal/snapshot_test.go
+++ b/tests/wal/snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -288,4 +289,50 @@ func TestSnapshot_BoundsReplayDepth(t *testing.T) {
 	// replay on a 20k-entry history.
 	assert.Less(t, snapElapsed, fullElapsed,
 		"snapshot-backed materialization should be faster than full replay")
+}
+
+// TestSnapshot_MultiChunkParallelLoad forces a snapshot to span multiple
+// chunks and requires the (parallel) load to reproduce full replay exactly.
+func TestSnapshot_MultiChunkParallelLoad(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("snap-chunks", "main", "")
+	require.NoError(t, err)
+	writer := walwriter.New(f.wal, f.branches, f.mat, main)
+
+	// ~6MB of documents (300 × 20KB) exceeds the 4MB chunk cut-off.
+	payload := strings.Repeat("x", 20*1024)
+	batch := make([]bson.M, 0, 50)
+	for i := 0; i < 300; i++ {
+		batch = append(batch, bson.M{"_id": fmt.Sprintf("doc-%03d", i), "n": int32(i), "payload": payload})
+		if len(batch) == 50 {
+			_, err := writer.PutMany(ctx, "bulk", batch)
+			require.NoError(t, err)
+			batch = batch[:0]
+		}
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	snaps, err := f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+	var bulk *snapshot.Snapshot
+	for _, s := range snaps {
+		if s.Collection == "bulk" {
+			bulk = s
+		}
+	}
+	require.NotNil(t, bulk)
+	require.Greater(t, len(bulk.ChunkIDs), 1, "the snapshot must span multiple chunks for this test to mean anything")
+
+	start := time.Now()
+	accelerated, err := f.mat.MaterializeCollection(main, "bulk")
+	require.NoError(t, err)
+	t.Logf("parallel load of %d chunks (%d docs): %v", len(bulk.ChunkIDs), bulk.DocCount, time.Since(start))
+
+	full, err := f.matFull.MaterializeCollection(main, "bulk")
+	require.NoError(t, err)
+	assert.Equal(t, full, accelerated, "parallel chunk load must equal full replay")
+	assert.Len(t, accelerated, 300)
 }


### PR DESCRIPTION
Addresses the benchmark-repo finding that snapshot reads are dominated by chunk decode cost (zstd + per-document BSON, ~70% of a warm read).

Chunks hold **disjoint, contiguous key ranges** (the encoder cuts a sorted stream), so each decodes into a private map on its own goroutine and the merge is a plain union — no coordination, no ordering concerns. Single-chunk snapshots keep the serial path. `zstd.DecodeAll` is documented safe for concurrent use; gzip/snappy paths construct per-call state.

Test: forces a snapshot past the 4MB cut-off (300×20KB docs → multiple chunks) and requires the parallel load to equal full replay exactly, with timing logged.

Refreshing the public RESULTS.md numbers after this lands is the benchmarks repo's normal update flow.