### PR TITLE
Driver-compatibility harness: PyMongo and Mongoose against branches, in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,47 @@ jobs:
       working-directory: ./cli
       run: go build -v .
     
+  driver-compat:
+    name: Driver Compatibility
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Start MongoDB (single-node replica set)
+      run: |
+        docker run -d --name compat-mongo -p 27017:27017 mongo:7 --replSet rs0 --bind_ip_all
+        for i in $(seq 1 30); do
+          docker exec compat-mongo mongosh --quiet --eval 'db.runCommand({ping: 1})' && break
+          sleep 1
+        done
+        docker exec compat-mongo mongosh --quiet --eval 'rs.initiate({_id: "rs0", members: [{_id: 0, host: "localhost:27017"}]})'
+        for i in $(seq 1 30); do
+          [ "$(docker exec compat-mongo mongosh --quiet --eval 'db.hello().isWritablePrimary')" = "true" ] && break
+          sleep 1
+        done
+
+    - name: Install Python driver
+      run: pip install pymongo pytest
+
+    - name: Run the driver-compat harness
+      run: bash compat/run.sh
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ argon.exe
 *.test
 *.out
 vendor/
+compat/mongoose/node_modules/

--- a/cmd/compat-verify/main.go
+++ b/cmd/compat-verify/main.go
@@ -1,0 +1,132 @@
+// compat-verify checks that a branch's WAL materialization converges to
+// exactly the state of its physical database — the acceptance check behind
+// the driver-compatibility harness: whatever an unmodified driver did to
+// the branch database, the versioned history must reproduce it.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/argon-lab/argon/internal/mongoexpr"
+	"github.com/argon-lab/argon/internal/wal"
+	"github.com/argon-lab/argon/pkg/walcli"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func main() {
+	project := flag.String("project", "", "project name")
+	branch := flag.String("branch", "main", "branch name")
+	timeout := flag.Duration("timeout", 60*time.Second, "how long to wait for convergence")
+	flag.Parse()
+	if *project == "" {
+		fmt.Fprintln(os.Stderr, "--project is required")
+		os.Exit(2)
+	}
+
+	services, err := walcli.NewServices()
+	if err != nil {
+		fatal("connect: %v", err)
+	}
+	p, err := services.Projects.GetProjectByName(*project)
+	if err != nil {
+		fatal("project %q: %v", *project, err)
+	}
+	b, err := services.Branches.GetBranch(p.ID, *branch)
+	if err != nil {
+		fatal("branch %q: %v", *branch, err)
+	}
+	if !b.IsLive() {
+		fatal("branch %q is not checked out", *branch)
+	}
+
+	ctx := context.Background()
+	deadline := time.Now().Add(*timeout)
+	var lastDiff string
+	for {
+		diff, err := compare(ctx, services, b.ID)
+		if err != nil {
+			fatal("compare: %v", err)
+		}
+		if diff == "" {
+			fresh, _ := services.Branches.GetBranchByID(b.ID)
+			fmt.Printf("CONVERGED: WAL state equals the physical database (branch head LSN %d)\n", fresh.HeadLSN)
+			return
+		}
+		lastDiff = diff
+		if time.Now().After(deadline) {
+			fatal("did not converge within %v; last difference: %s", *timeout, lastDiff)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// compare returns "" when the WAL materialization equals the physical
+// database, or a description of the first difference found.
+func compare(ctx context.Context, services *walcli.Services, branchID string) (string, error) {
+	branch, err := services.Branches.GetBranchByID(branchID)
+	if err != nil {
+		return "", err
+	}
+	walState, err := services.Materializer.MaterializeBranch(branch)
+	if err != nil {
+		return "", err
+	}
+
+	physical := services.Client.Database(branch.PhysicalDB)
+	names, err := physical.ListCollectionNames(ctx, bson.M{})
+	if err != nil {
+		return "", err
+	}
+
+	physState := make(map[string]map[string]bson.M)
+	for _, name := range names {
+		cursor, err := physical.Collection(name).Find(ctx, bson.M{})
+		if err != nil {
+			return "", err
+		}
+		var docs []bson.M
+		if err := cursor.All(ctx, &docs); err != nil {
+			return "", err
+		}
+		collState := make(map[string]bson.M, len(docs))
+		for _, doc := range docs {
+			collState[wal.DocumentIDString(doc["_id"])] = doc
+		}
+		physState[name] = collState
+	}
+
+	for name, phys := range physState {
+		walColl := walState[name]
+		if len(walColl) != len(phys) {
+			return fmt.Sprintf("collection %s: %d docs in WAL vs %d physical", name, len(walColl), len(phys)), nil
+		}
+		for id, physDoc := range phys {
+			walDoc, ok := walColl[id]
+			if !ok {
+				return fmt.Sprintf("collection %s: document %s missing from WAL", name, id), nil
+			}
+			equal, err := mongoexpr.CanonicalEqual(walDoc, physDoc)
+			if err != nil {
+				return "", err
+			}
+			if !equal {
+				return fmt.Sprintf("collection %s: document %s differs", name, id), nil
+			}
+		}
+	}
+	for name, walColl := range walState {
+		if _, ok := physState[name]; !ok && len(walColl) > 0 {
+			return fmt.Sprintf("collection %s exists in WAL but not physically", name), nil
+		}
+	}
+	return "", nil
+}
+
+func fatal(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "compat-verify: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/compat/README.md
+++ b/compat/README.md
@@ -1,0 +1,32 @@
+# Driver-compatibility harness
+
+Real, **unmodified** official drivers run real-world workloads against the
+physical database of a checked-out Argon branch; afterwards `compat-verify`
+requires the WAL materialization to reproduce the physical state exactly,
+document by document.
+
+| Harness | Driver | Exercises |
+|---|---|---|
+| `pymongo/` | PyMongo (pytest) | CRUD, update operators, upserts, mixed `bulk_write`, secondary/compound indexes, sort/skip/limit, aggregation, `distinct`, multi-document transactions, cursor batching |
+| `mongoose/` | Mongoose (Node ODM) | Schema models with validation and defaults, `create`/`insertMany`, `findOneAndUpdate` with operators, lean queries, aggregation, schema indexes, `updateMany`/`deleteMany` |
+
+Run locally (needs a MongoDB replica set on `MONGODB_URI`, Go, Python 3
+with `pymongo`+`pytest`, Node):
+
+```bash
+bash compat/run.sh
+```
+
+## What this proves — and what it doesn't
+
+It proves the drop-in contract Argon actually makes: **applications using
+official drivers work unchanged against a checked-out branch, and every
+write becomes versioned history that reproduces the database state
+exactly.** The query side is real mongod, so query behavior is mongod's
+by construction; the part in question — and verified here — is capture
+fidelity across the whole write surface, including transactions.
+
+It is *not* the MongoDB vendors' internal driver test suites; those test
+driver-server protocol internals against controlled topologies and
+failpoints, which is orthogonal to Argon (drivers talk to an ordinary
+mongod either way).

--- a/compat/mongoose/compat.test.mjs
+++ b/compat/mongoose/compat.test.mjs
@@ -1,0 +1,77 @@
+// Driver-compatibility harness: Mongoose against a checked-out Argon branch.
+//
+// A real-world ODM workload through unmodified Mongoose: schema models,
+// validation, saves, queries, findOneAndUpdate, aggregation, indexes and
+// deletes. The convergence check (compat-verify) afterwards asserts that
+// Argon's WAL reproduces exactly what the ODM did.
+//
+// The branch connection string arrives via ARGON_BRANCH_URI.
+
+import assert from "node:assert/strict";
+import mongoose from "mongoose";
+
+const uri = process.env.ARGON_BRANCH_URI;
+assert.ok(uri, "ARGON_BRANCH_URI must point at a checked-out branch");
+
+await mongoose.connect(uri);
+
+const productSchema = new mongoose.Schema(
+  {
+    _id: String,
+    name: { type: String, required: true },
+    price: { type: Number, min: 0 },
+    stock: { type: Number, default: 0 },
+    tags: [String],
+  },
+  { versionKey: false }
+);
+productSchema.index({ price: -1 });
+const Product = mongoose.model("Product", productSchema, "products");
+
+// Create through the model, including defaults and validation.
+await Product.create({ _id: "laptop", name: "Laptop", price: 1000, stock: 10, tags: ["tech"] });
+await Product.insertMany(
+  Array.from({ length: 30 }, (_, i) => ({
+    _id: `gadget-${i}`,
+    name: `Gadget ${i}`,
+    price: i * 10,
+    stock: i,
+  }))
+);
+
+// Validation actually fires.
+await assert.rejects(Product.create({ _id: "bad", price: 5 }), /name.*required/i);
+
+// findOneAndUpdate with operators, returning the new document.
+const discounted = await Product.findOneAndUpdate(
+  { _id: "laptop" },
+  { $inc: { price: -100 }, $push: { tags: "sale" } },
+  { new: true }
+);
+assert.equal(discounted.price, 900);
+assert.deepEqual(discounted.tags, ["tech", "sale"]);
+
+// Queries with sort/limit/lean.
+const expensive = await Product.find({ price: { $gte: 200 } }).sort({ price: -1 }).limit(3).lean();
+assert.equal(expensive.length, 3);
+assert.equal(expensive[0]._id, "laptop");
+
+// Aggregation through the ODM.
+const stats = await Product.aggregate([
+  { $group: { _id: null, avgPrice: { $avg: "$price" }, count: { $sum: 1 } } },
+]);
+assert.equal(stats[0].count, 31);
+
+// Index creation through the schema.
+await Product.createIndexes();
+const indexes = await Product.collection.indexes();
+assert.ok(indexes.some((ix) => ix.key.price === -1));
+
+// Updates and deletes en masse.
+const restocked = await Product.updateMany({ stock: { $lt: 5 } }, { $set: { stock: 5 } });
+assert.ok(restocked.modifiedCount >= 4);
+const removed = await Product.deleteMany({ price: { $lt: 50 } });
+assert.ok(removed.deletedCount >= 4);
+
+await mongoose.disconnect();
+console.log("mongoose compat workload passed");

--- a/compat/mongoose/package-lock.json
+++ b/compat/mongoose/package-lock.json
@@ -1,0 +1,241 @@
+{
+  "name": "argon-mongoose-compat",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "argon-mongoose-compat",
+      "dependencies": {
+        "mongoose": "^8.0.0"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.12.tgz",
+      "integrity": "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
+    "node_modules/mongodb": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.1.tgz",
+      "integrity": "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.10.4",
+        "kareem": "2.6.3",
+        "mongodb": "~6.20.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/compat/mongoose/package.json
+++ b/compat/mongoose/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "argon-mongoose-compat",
+  "private": true,
+  "type": "module",
+  "scripts": { "test": "node compat.test.mjs" },
+  "dependencies": { "mongoose": "^8.0.0" }
+}

--- a/compat/pymongo/test_compat.py
+++ b/compat/pymongo/test_compat.py
@@ -1,0 +1,120 @@
+"""Driver-compatibility harness: PyMongo against a checked-out Argon branch.
+
+This is not MongoDB's internal driver test suite — it is a real-world
+workload through the unmodified official Python driver, run against the
+physical database of a checked-out branch. It exercises CRUD, update
+operators, bulk writes, indexes, sort/skip/limit, aggregation, distinct
+and multi-document transactions, asserting driver-level results. The
+convergence check (compat-verify) afterwards asserts that Argon's WAL
+reproduces exactly what the driver did.
+
+The branch connection string arrives via ARGON_BRANCH_URI.
+"""
+
+import os
+
+import pytest
+from pymongo import ASCENDING, DESCENDING, MongoClient, UpdateOne, InsertOne, DeleteOne
+
+
+@pytest.fixture(scope="module")
+def db():
+    uri = os.environ.get("ARGON_BRANCH_URI")
+    assert uri, "ARGON_BRANCH_URI must point at a checked-out branch"
+    client = MongoClient(uri)
+    database = client.get_default_database()
+    yield database
+    client.close()
+
+
+def test_crud_roundtrip(db):
+    users = db.users
+    result = users.insert_one({"_id": "alice", "score": 10, "tags": ["a", "b"]})
+    assert result.inserted_id == "alice"
+
+    many = users.insert_many([{"_id": f"user-{i}", "score": i} for i in range(20)])
+    assert len(many.inserted_ids) == 20
+
+    updated = users.update_one({"_id": "alice"}, {"$inc": {"score": 5}, "$push": {"tags": "c"}})
+    assert updated.modified_count == 1
+    doc = users.find_one({"_id": "alice"})
+    assert doc["score"] == 15
+    assert doc["tags"] == ["a", "b", "c"]
+
+    replaced = users.replace_one({"_id": "user-0"}, {"replaced": True})
+    assert replaced.modified_count == 1
+
+    upserted = users.update_one({"_id": "ghost"}, {"$setOnInsert": {"born": True}}, upsert=True)
+    assert upserted.upserted_id == "ghost"
+
+    deleted = users.delete_many({"score": {"$gte": 15}})
+    assert deleted.deleted_count >= 1
+
+
+def test_queries_indexes_and_aggregation(db):
+    orders = db.orders
+    orders.insert_many(
+        [{"_id": f"o{i}", "amount": i * 10, "region": ["east", "west"][i % 2]} for i in range(50)]
+    )
+
+    orders.create_index([("amount", DESCENDING)])
+    orders.create_index([("region", ASCENDING), ("amount", DESCENDING)])
+
+    top = list(orders.find().sort("amount", DESCENDING).skip(2).limit(3))
+    assert [d["_id"] for d in top] == ["o47", "o46", "o45"]
+
+    assert orders.count_documents({"region": "east"}) == 25
+    assert sorted(orders.distinct("region")) == ["east", "west"]
+
+    pipeline = [
+        {"$match": {"amount": {"$gte": 100}}},
+        {"$group": {"_id": "$region", "total": {"$sum": "$amount"}}},
+        {"$sort": {"_id": 1}},
+    ]
+    groups = list(orders.aggregate(pipeline))
+    assert len(groups) == 2
+    assert groups[0]["_id"] == "east"
+
+
+def test_bulk_write_mixed(db):
+    items = db.items
+    result = items.bulk_write(
+        [
+            InsertOne({"_id": "i1", "n": 1}),
+            InsertOne({"_id": "i2", "n": 2}),
+            UpdateOne({"_id": "i1"}, {"$set": {"n": 100}}),
+            DeleteOne({"_id": "i2"}),
+            UpdateOne({"_id": "i3"}, {"$set": {"n": 3}}, upsert=True),
+        ],
+        ordered=True,
+    )
+    assert result.inserted_count == 2
+    assert result.modified_count == 1
+    assert result.deleted_count == 1
+    assert result.upserted_count == 1
+    assert items.find_one({"_id": "i1"})["n"] == 100
+
+
+def test_multi_document_transaction(db):
+    accounts = db.accounts
+    ledger = db.ledger
+    accounts.insert_one({"_id": "a", "balance": 100})
+    accounts.insert_one({"_id": "b", "balance": 0})
+
+    client = db.client
+    with client.start_session() as session:
+        with session.start_transaction():
+            accounts.update_one({"_id": "a"}, {"$inc": {"balance": -40}}, session=session)
+            accounts.update_one({"_id": "b"}, {"$inc": {"balance": 40}}, session=session)
+            ledger.insert_one({"_id": "t1", "amount": 40}, session=session)
+
+    assert accounts.find_one({"_id": "a"})["balance"] == 60
+    assert accounts.find_one({"_id": "b"})["balance"] == 40
+    assert ledger.count_documents({}) == 1
+
+
+def test_cursor_batching(db):
+    big = db.big
+    big.insert_many([{"_id": i, "payload": "x" * 512} for i in range(500)])
+    seen = sum(1 for _ in big.find({}, batch_size=50))
+    assert seen == 500

--- a/compat/run.sh
+++ b/compat/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Driver-compatibility harness: real, unmodified drivers (PyMongo and
+# Mongoose) run workloads against checked-out Argon branches; afterwards
+# compat-verify requires the WAL to reproduce the physical state exactly.
+#
+# Prerequisites: a MongoDB replica set on MONGODB_URI (default
+# mongodb://localhost:27017), Go, Python 3 with pymongo+pytest, Node.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+STAMP=$(date +%s)
+echo "=== building tools ==="
+go build -o /tmp/argonctl ./cli 2>/dev/null || (cd cli && go build -o /tmp/argonctl .)
+go build -o /tmp/compat-verify ./cmd/compat-verify
+
+run_driver() {
+  local name="$1" project="compat-$1-$STAMP"; shift
+  echo "=== $name: project $project ==="
+  /tmp/argonctl projects create "$project" > /dev/null
+  /tmp/argonctl checkout -p "$project" -b main > /dev/null
+  local uri
+  uri=$(/tmp/argonctl connect -p "$project" -b main)
+  echo "    branch uri: $uri"
+
+  /tmp/argonctl watch -p "$project" -b main &
+  local watch_pid=$!
+  trap "kill $watch_pid 2>/dev/null || true" RETURN
+  sleep 2  # let the change stream open
+
+  ARGON_BRANCH_URI="$uri" "$@"
+
+  echo "=== $name: verifying convergence ==="
+  /tmp/compat-verify --project "$project" --branch main --timeout 90s
+  kill "$watch_pid" 2>/dev/null || true
+  wait "$watch_pid" 2>/dev/null || true
+}
+
+run_driver pymongo python3 -m pytest compat/pymongo/test_compat.py -q
+(cd compat/mongoose && npm install --no-audit --no-fund > /dev/null)
+run_driver mongoose node compat/mongoose/compat.test.mjs
+
+echo "=== driver-compat: ALL GREEN ==="

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -45,6 +45,9 @@ type Services struct {
 	Sandbox      *sandbox.Service
 	Monitor      *wal.Monitor
 	MongoURI     string
+	// Client is the deployment connection, exposed for tools that read
+	// physical branch databases (e.g. convergence verification).
+	Client *mongo.Client
 }
 
 // NewServices creates and returns all WAL services
@@ -157,6 +160,7 @@ func NewServices() (*Services, error) {
 		Sandbox:      sandboxService,
 		Monitor:      monitor,
 		MongoURI:     mongoURI,
+		Client:       client,
 	}, nil
 }
 


### PR DESCRIPTION
The gate behind the drop-in claim, made executable and run on every push.

## What it does

`compat/run.sh`: for each driver — create a project, `checkout`, start `watch`, run the workload through the **unmodified official driver** against the branch's connection string, then run `compat-verify` (new `cmd/compat-verify`), which requires the WAL materialization to equal the physical database **document by document** (canonical comparison, retrying while the ingester drains).

- **PyMongo** (pytest): CRUD, update operators, upserts, mixed `bulk_write`, secondary/compound indexes, sort/skip/limit, aggregation, `distinct`, **multi-document transactions**, 500-doc cursor batching.
- **Mongoose** (Node ODM): schema models with validation + defaults, `findOneAndUpdate` with operators, lean queries, aggregation, schema indexes, `updateMany`/`deleteMany`.

Local run: both harnesses green (pymongo converged at 592 entries, mongoose at 44).

## Honesty note (in `compat/README.md`)

This proves the contract Argon actually makes — unmodified drivers work unchanged against a checked-out branch and capture is faithful across the write surface including transactions. It is **not** the vendors' internal driver suites, which test driver↔server protocol internals against controlled topologies/failpoints — orthogonal to Argon, since drivers talk to an ordinary mongod either way. GTM can cite this job by name as the drop-in gate.

## CI

New `Driver Compatibility` job: Go + Python 3.12 + Node 22 + single-node-RS MongoDB, runs `compat/run.sh` on every push/PR.