### PR TITLE
Wire-protocol proxy: branch-aliased MongoDB connection strings

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -21,7 +21,7 @@ import (
 // do drives one JSON request through the router.
 func do(t *testing.T, router http.Handler, method, path string, body interface{}) (int, map[string]interface{}) {
 	t.Helper()
-	var payload *bytes.Buffer = bytes.NewBuffer(nil)
+	payload := bytes.NewBuffer(nil)
 	if body != nil {
 		raw, err := json.Marshal(body)
 		require.NoError(t, err)
@@ -76,9 +76,7 @@ func TestAPI_ControlPlaneFlow(t *testing.T) {
 	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(connStr))
 	require.NoError(t, err)
 	defer func() { _ = client.Disconnect(context.Background()) }()
-	agentDB := client.Database(connStr[len(connStr)-len("argon_br_")-24:]) // fallback parse below
-	// Robust: use the default database from the URI.
-	agentDB = client.Database(dbFromURI(connStr))
+	agentDB := client.Database(dbFromURI(connStr))
 	_, err = agentDB.Collection("notes").InsertOne(context.Background(), bson.M{"_id": "n1", "text": "from-agent"})
 	require.NoError(t, err)
 

--- a/cli/cmd/branches.go
+++ b/cli/cmd/branches.go
@@ -132,13 +132,13 @@ func init() {
 	// Add flags
 	branchesCreateCmd.Flags().StringP("project", "p", "", "Project name (required)")
 	branchesCreateCmd.Flags().String("from", "main", "Source branch to branch from")
-	branchesCreateCmd.MarkFlagRequired("project")
+	_ = branchesCreateCmd.MarkFlagRequired("project")
 
 	branchesListCmd.Flags().StringP("project", "p", "", "Project name (required)")
-	branchesListCmd.MarkFlagRequired("project")
+	_ = branchesListCmd.MarkFlagRequired("project")
 
 	branchesDeleteCmd.Flags().StringP("project", "p", "", "Project name (required)")
-	branchesDeleteCmd.MarkFlagRequired("project")
+	_ = branchesDeleteCmd.MarkFlagRequired("project")
 
 	// Add subcommands
 	branchesCmd.AddCommand(branchesCreateCmd)

--- a/cli/cmd/proxy.go
+++ b/cli/cmd/proxy.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+var proxyCmd = &cobra.Command{
+	Use:   "proxy",
+	Short: "Serve branch-aliased MongoDB connection strings",
+	Long: `A MongoDB wire-protocol proxy that resolves branch aliases: clients
+connect to
+
+  mongodb://<proxy-host>:<port>/<project>~<branch>?directConnection=true
+
+and the proxy rewrites commands to the branch's physical database.
+Traffic to non-alias databases passes through untouched. Run "argon
+watch" (or the API/MCP server) for the branch so writes become
+versioned history.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		listen, _ := cmd.Flags().GetString("listen")
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+
+		upstream := upstreamAddr(services.MongoURI)
+		proxy := services.NewWireProxy(upstream)
+
+		listener, err := net.Listen("tcp", listen)
+		if err != nil {
+			return fmt.Errorf("failed to listen on %s: %w", listen, err)
+		}
+
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
+		hint := listen
+		if strings.HasPrefix(hint, ":") {
+			hint = "<host>" + hint
+		}
+		fmt.Printf("Argon proxy listening on %s (upstream %s)\n", listen, upstream)
+		fmt.Printf("Connect with: mongodb://%s/<project>~<branch>?directConnection=true\n", hint)
+		return proxy.Serve(ctx, listener)
+	},
+}
+
+// upstreamAddr extracts host:port from a mongodb URI.
+func upstreamAddr(uri string) string {
+	rest := uri
+	if i := strings.Index(rest, "://"); i >= 0 {
+		rest = rest[i+3:]
+	}
+	if i := strings.IndexAny(rest, "/?"); i >= 0 {
+		rest = rest[:i]
+	}
+	if i := strings.LastIndex(rest, "@"); i >= 0 {
+		rest = rest[i+1:]
+	}
+	if rest == "" {
+		return "localhost:27017"
+	}
+	if !strings.Contains(rest, ":") {
+		rest += ":27017"
+	}
+	return rest
+}
+
+func init() {
+	proxyCmd.Flags().String("listen", ":27018", "Address to listen on")
+	rootCmd.AddCommand(proxyCmd)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -50,9 +50,9 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", "table", "Output format (json|yaml|table)")
 
 	// Bind flags to viper
-	viper.BindPFlag("api-key", rootCmd.PersistentFlags().Lookup("api-key"))
-	viper.BindPFlag("project-id", rootCmd.PersistentFlags().Lookup("project-id"))
-	viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
+	_ = viper.BindPFlag("api-key", rootCmd.PersistentFlags().Lookup("api-key"))
+	_ = viper.BindPFlag("project-id", rootCmd.PersistentFlags().Lookup("project-id"))
+	_ = viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
 }
 
 // initConfig reads in config file and ENV variables.

--- a/cli/cmd/timetravel.go
+++ b/cli/cmd/timetravel.go
@@ -121,16 +121,16 @@ func init() {
 	// Add flags
 	timeTravelInfoCmd.Flags().StringP("project", "p", "", "Project name (required)")
 	timeTravelInfoCmd.Flags().StringP("branch", "b", "", "Branch name (required)")
-	timeTravelInfoCmd.MarkFlagRequired("project")
-	timeTravelInfoCmd.MarkFlagRequired("branch")
+	_ = timeTravelInfoCmd.MarkFlagRequired("project")
+	_ = timeTravelInfoCmd.MarkFlagRequired("branch")
 
 	timeTravelQueryCmd.Flags().StringP("project", "p", "", "Project name (required)")
 	timeTravelQueryCmd.Flags().StringP("branch", "b", "", "Branch name (required)")
 	timeTravelQueryCmd.Flags().String("lsn", "", "LSN to query (required)")
 	timeTravelQueryCmd.Flags().StringP("collection", "c", "", "Collection name")
-	timeTravelQueryCmd.MarkFlagRequired("project")
-	timeTravelQueryCmd.MarkFlagRequired("branch")
-	timeTravelQueryCmd.MarkFlagRequired("lsn")
+	_ = timeTravelQueryCmd.MarkFlagRequired("project")
+	_ = timeTravelQueryCmd.MarkFlagRequired("branch")
+	_ = timeTravelQueryCmd.MarkFlagRequired("lsn")
 
 	// Add subcommands
 	timeTravelCmd.AddCommand(timeTravelInfoCmd)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -231,6 +231,33 @@ is gone. Expression evaluation survives only as a migration artifact
 expression entries one final time, and canonical BSON
 comparison/serialization lives there for snapshots and diffs.
 
+### The wire-protocol proxy (`argon proxy`)
+
+Checked-out branches have machine-generated physical database names
+(`argon_br_<id>`). The proxy (`internal/wireproxy`) gives them stable,
+human-readable connection strings instead:
+
+```
+mongodb://proxy-host:27018/<project>~<branch>?directConnection=true
+```
+
+It is a TCP proxy that parses OP_MSG frames from the client, rewrites the
+`$db` field of commands addressed to a branch alias (`project~branch`) to
+the branch's physical database, and forwards everything else byte-for-byte
+— responses are a raw copy in the other direction. mongod still evaluates
+every query; the proxy only routes.
+
+Honest constraints: compression is negotiated away (the proxy blanks the
+handshake's `compression` field so OP_COMPRESSED never appears);
+`directConnection=true` is required (topology discovery would hand clients
+the upstream's own address); with auth, `authSource=admin` must be
+explicit because the URI database is the alias. Aliases that don't resolve
+(unknown project/branch, or a branch that isn't checked out) get a
+synthesized `{ok: 0}` command error naming the proxy, not a dropped
+connection. Capture stays asynchronous through the change-stream ingester
+— the proxy is deliberately only the routing layer, though it is the
+natural place synchronous capture would live one day.
+
 ## Migration from schema v1
 
 v1 logged updates/deletes as expressions and re-executed them on replay —
@@ -249,8 +276,12 @@ entries removed). Migration is idempotent.
 - **Resolve-then-append is not atomic** — concurrent writers to the same
   branch are last-writer-wins at document level. The WAL itself stays
   consistent because every entry is self-contained.
-- **Capture is driver-level** — only writes through the Argon SDK/driver are
-  logged today. Writes made directly to MongoDB bypass the WAL.
+- **Capture is asynchronous** — for checked-out branches, any driver's
+  writes to the physical database become history via the change-stream
+  ingester (`argon watch`, the API server, or the MCP server must be
+  running); the WAL trails the primary by the ingest lag. Writes made
+  while no ingester runs are recovered on resume (resume tokens), but
+  writes to non-Argon databases are never captured.
 
 ## Known limitations and roadmap
 
@@ -270,15 +301,14 @@ Performance characteristics are measured by the public benchmark suite at
 https://github.com/argon-lab/benchmarks — reproducible with
 `docker compose up`, results recorded with pinned engine refs.
 
-Planned next (in order):
+Recently closed from this list: driver compatibility is now exercised in
+CI on every push (pymongo and mongoose harnesses writing through a live
+ingester, plus WAL-convergence verification), and the LangGraph
+checkpointer / Mem0 factory ship as the `argon-agents` Python package on
+top of the REST API.
 
-1. **M3 (last box) — driver-suite validation**: running the official
-   pymongo/mongoose test suites against branch databases in CI — until
-   then, "any driver connects" is stated as an architectural fact, not an
-   unqualified drop-in claim.
-2. **M5 (remaining) — integrations**: LangGraph checkpointer with fork and
-   rewind; eval dataset pinning. The MCP server and TTL sandboxes shipped
-   in #23.
+Planned next: eval dataset pinning; GCS chunk-store backend; synchronous
+capture in the wire proxy.
 
 ## Storage collections
 

--- a/internal/project/wal/service.go
+++ b/internal/project/wal/service.go
@@ -130,6 +130,16 @@ func (s *ProjectService) GetProjectByName(name string) (*wal.Project, error) {
 	return &project, nil
 }
 
+// GetProjectIDByName resolves a project name to its ID (the wire proxy's
+// alias lookup interface).
+func (s *ProjectService) GetProjectIDByName(name string) (string, error) {
+	project, err := s.GetProjectByName(name)
+	if err != nil {
+		return "", err
+	}
+	return project.ID, nil
+}
+
 // ListProjects lists all WAL-enabled projects
 func (s *ProjectService) ListProjects() ([]*wal.Project, error) {
 	ctx := context.Background()

--- a/internal/wireproxy/proxy.go
+++ b/internal/wireproxy/proxy.go
@@ -1,0 +1,309 @@
+// Package wireproxy is a MongoDB wire-protocol proxy that gives branches
+// stable, human-readable connection strings:
+//
+//	mongodb://proxy-host:27018/<project>~<branch>?directConnection=true
+//
+// Clients speak ordinary MongoDB through it. The proxy rewrites the $db
+// field of OP_MSG commands whose database is a branch alias
+// ("project~branch") to the branch's physical database and forwards
+// everything else untouched — responses stream back as a raw byte copy.
+// Traffic to non-alias databases passes through completely unmodified, so
+// the proxy is transparent for everything that isn't Argon's.
+//
+// Design constraints, stated honestly:
+//
+//   - Compression is negotiated away: the proxy strips the "compression"
+//     field from handshake commands so the server never agrees to
+//     OP_COMPRESSED (whose payloads we could not rewrite cheaply).
+//   - Clients should use directConnection=true; topology discovery would
+//     otherwise hand them the upstream's own address and they would
+//     bypass the proxy.
+//   - With authentication, use authSource=admin: the default authSource
+//     is the URI database, which is the alias, and SCRAM must run against
+//     a real database.
+//   - Capture stays asynchronous (the change-stream ingester); the proxy
+//     does not intercept writes. Synchronous capture would live here one
+//     day — this is deliberately only the routing layer.
+package wireproxy
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const (
+	opMsg        = 2013
+	opCompressed = 2012
+
+	flagChecksumPresent = 1 << 0
+
+	maxMessageSize = 48 * 1024 * 1024
+	aliasSeparator = "~"
+	resolveTTL     = 5 * time.Second
+)
+
+// ProjectLookup resolves project names to IDs.
+type ProjectLookup interface {
+	GetProjectIDByName(name string) (string, error)
+}
+
+// Proxy accepts client connections and forwards them to the upstream
+// deployment with alias rewriting.
+type Proxy struct {
+	upstreamAddr string
+	projects     ProjectLookup
+	branches     *branchwal.BranchService
+
+	cacheMu sync.Mutex
+	cache   map[string]cachedTarget
+}
+
+type cachedTarget struct {
+	physicalDB string
+	err        error
+	expires    time.Time
+}
+
+// New creates a proxy that dials upstreamAddr (host:port) for every client.
+func New(upstreamAddr string, projects ProjectLookup, branches *branchwal.BranchService) *Proxy {
+	return &Proxy{
+		upstreamAddr: upstreamAddr,
+		projects:     projects,
+		branches:     branches,
+		cache:        make(map[string]cachedTarget),
+	}
+}
+
+// Serve accepts connections on the listener until the context is canceled.
+func (p *Proxy) Serve(ctx context.Context, listener net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		_ = listener.Close()
+	}()
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		go p.handle(ctx, conn)
+	}
+}
+
+func (p *Proxy) handle(ctx context.Context, client net.Conn) {
+	defer func() { _ = client.Close() }()
+
+	upstream, err := net.Dial("tcp", p.upstreamAddr)
+	if err != nil {
+		log.Printf("wireproxy: upstream dial failed: %v", err)
+		return
+	}
+	defer func() { _ = upstream.Close() }()
+
+	done := make(chan struct{}, 2)
+
+	// Server → client: responses are never modified.
+	go func() {
+		_, _ = io.Copy(client, upstream)
+		done <- struct{}{}
+	}()
+
+	// Client → server: frame messages and rewrite as needed.
+	go func() {
+		p.pump(client, upstream)
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+	}
+}
+
+// pump reads framed messages from the client, rewrites them, and writes
+// them upstream. Synthesized error replies go straight back to the client.
+func (p *Proxy) pump(client net.Conn, upstream net.Conn) {
+	header := make([]byte, 4)
+	for {
+		if _, err := io.ReadFull(client, header); err != nil {
+			return
+		}
+		length := int(binary.LittleEndian.Uint32(header))
+		if length < 16 || length > maxMessageSize {
+			log.Printf("wireproxy: dropping connection with invalid message length %d", length)
+			return
+		}
+		message := make([]byte, length)
+		copy(message, header)
+		if _, err := io.ReadFull(client, message[4:]); err != nil {
+			return
+		}
+
+		rewritten, errReply := p.rewrite(message)
+		if errReply != nil {
+			if _, err := client.Write(errReply); err != nil {
+				return
+			}
+			continue
+		}
+		if _, err := upstream.Write(rewritten); err != nil {
+			return
+		}
+	}
+}
+
+// rewrite returns the (possibly modified) message to forward, or a
+// synthesized error reply to send back to the client instead.
+func (p *Proxy) rewrite(message []byte) (forward []byte, errReply []byte) {
+	opCode := int32(binary.LittleEndian.Uint32(message[12:16]))
+	if opCode == opCompressed {
+		// Should not happen — we strip compression from handshakes — but a
+		// compressed alias command would slip through unrewritten, so pass
+		// it along and let the server reject the unknown database loudly.
+		log.Printf("wireproxy: unexpected OP_COMPRESSED message; compression negotiation slipped through")
+		return message, nil
+	}
+	if opCode != opMsg {
+		// OP_QUERY handshakes and other legacy ops pass through: their
+		// database is admin/$cmd, never an alias.
+		return message, nil
+	}
+
+	flagBits := binary.LittleEndian.Uint32(message[16:20])
+	body := message[20:]
+	if flagBits&flagChecksumPresent != 0 {
+		body = body[:len(body)-4] // strip; recomputed on rewrite
+	}
+
+	// Section kind 0 (the command document) is first in practice; kind 1
+	// document sequences follow it.
+	if len(body) < 5 || body[0] != 0 {
+		return message, nil
+	}
+	docLen := int(binary.LittleEndian.Uint32(body[1:5]))
+	if docLen < 5 || 1+docLen > len(body) {
+		return message, nil
+	}
+	rawDoc := bson.Raw(body[1 : 1+docLen])
+	rest := body[1+docLen:]
+
+	var doc bson.D
+	if err := bson.Unmarshal(rawDoc, &doc); err != nil {
+		return message, nil
+	}
+
+	changed := false
+	requestID := binary.LittleEndian.Uint32(message[4:8])
+
+	for i, elem := range doc {
+		switch elem.Key {
+		case "$db":
+			alias, ok := elem.Value.(string)
+			if !ok || !strings.Contains(alias, aliasSeparator) {
+				continue
+			}
+			physical, err := p.resolve(alias)
+			if err != nil {
+				return nil, buildErrorReply(requestID, err.Error())
+			}
+			doc[i].Value = physical
+			changed = true
+		case "compression":
+			// Never let the server agree to OP_COMPRESSED.
+			doc[i].Value = bson.A{}
+			changed = true
+		}
+	}
+	if !changed {
+		return message, nil
+	}
+
+	newDoc, err := bson.Marshal(doc)
+	if err != nil {
+		return message, nil
+	}
+
+	// Reassemble: header + flags (checksum bit cleared) + section 0 + rest.
+	out := make([]byte, 0, 20+1+len(newDoc)+len(rest))
+	out = append(out, message[:16]...)
+	var flags [4]byte
+	binary.LittleEndian.PutUint32(flags[:], flagBits&^flagChecksumPresent)
+	out = append(out, flags[:]...)
+	out = append(out, 0)
+	out = append(out, newDoc...)
+	out = append(out, rest...)
+	binary.LittleEndian.PutUint32(out[0:4], uint32(len(out)))
+	return out, nil
+}
+
+// resolve maps "project~branch" to the physical database, with a short
+// cache so hot paths don't hit metadata every command.
+func (p *Proxy) resolve(alias string) (string, error) {
+	p.cacheMu.Lock()
+	if hit, ok := p.cache[alias]; ok && time.Now().Before(hit.expires) {
+		p.cacheMu.Unlock()
+		return hit.physicalDB, hit.err
+	}
+	p.cacheMu.Unlock()
+
+	physical, err := p.lookup(alias)
+	p.cacheMu.Lock()
+	p.cache[alias] = cachedTarget{physicalDB: physical, err: err, expires: time.Now().Add(resolveTTL)}
+	p.cacheMu.Unlock()
+	return physical, err
+}
+
+func (p *Proxy) lookup(alias string) (string, error) {
+	parts := strings.SplitN(alias, aliasSeparator, 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("invalid branch alias %q (want project%sbranch)", alias, aliasSeparator)
+	}
+	projectID, err := p.projects.GetProjectIDByName(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("project %q not found", parts[0])
+	}
+	branch, err := p.branches.GetBranch(projectID, parts[1])
+	if err != nil {
+		return "", fmt.Errorf("branch %q not found in project %q", parts[1], parts[0])
+	}
+	if !branch.IsLive() {
+		return "", fmt.Errorf("branch %q is not checked out; run argon checkout first", parts[1])
+	}
+	return branch.PhysicalDB, nil
+}
+
+// buildErrorReply synthesizes an OP_MSG {ok: 0} response so drivers get a
+// clean command error instead of a dropped connection.
+func buildErrorReply(requestID uint32, message string) []byte {
+	doc, err := bson.Marshal(bson.D{
+		{Key: "ok", Value: 0},
+		{Key: "errmsg", Value: "argon proxy: " + message},
+		{Key: "code", Value: 26}, // NamespaceNotFound
+		{Key: "codeName", Value: "NamespaceNotFound"},
+	})
+	if err != nil {
+		return nil
+	}
+	out := make([]byte, 16, 16+4+1+len(doc))
+	binary.LittleEndian.PutUint32(out[4:8], 0)          // requestID (server-side)
+	binary.LittleEndian.PutUint32(out[8:12], requestID) // responseTo
+	binary.LittleEndian.PutUint32(out[12:16], opMsg)
+	var flags [4]byte
+	out = append(out, flags[:]...)
+	out = append(out, 0)
+	out = append(out, doc...)
+	binary.LittleEndian.PutUint32(out[0:4], uint32(len(out)))
+	return out
+}

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -21,6 +21,7 @@ import (
 	"github.com/argon-lab/argon/internal/timetravel"
 	"github.com/argon-lab/argon/internal/undo"
 	"github.com/argon-lab/argon/internal/walwriter"
+	"github.com/argon-lab/argon/internal/wireproxy"
 	"github.com/argon-lab/argon/internal/wal"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -208,6 +209,12 @@ func (s *Services) ApplyUndoPlan(ctx context.Context, branchID string, plan *und
 		return 0, 0, err
 	}
 	return s.Undo.Apply(ctx, branch, plan)
+}
+
+// NewWireProxy builds the wire-protocol proxy over these services (the
+// cli module cannot import internal packages).
+func (s *Services) NewWireProxy(upstreamAddr string) *wireproxy.Proxy {
+	return wireproxy.New(upstreamAddr, s.Projects, s.Branches)
 }
 
 // BranchConnectionString renders the URI applications use to reach a

--- a/tests/wal/wireproxy_test.go
+++ b/tests/wal/wireproxy_test.go
@@ -1,0 +1,127 @@
+package wal_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	projectwal "github.com/argon-lab/argon/internal/project/wal"
+	"github.com/argon-lab/argon/internal/wireproxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// startProxy runs a wire proxy on an ephemeral port over the fixture's
+// services and returns its address.
+func startProxy(t *testing.T, f *ingestFixture) string {
+	t.Helper()
+	projectService, err := projectwal.NewProjectService(f.metaDB, f.wal, f.branches)
+	require.NoError(t, err)
+
+	proxy := wireproxy.New("localhost:27017", projectService, f.branches)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = proxy.Serve(ctx, listener) }()
+	t.Cleanup(cancel)
+	return listener.Addr().String()
+}
+
+func TestWireProxy_AliasRouting(t *testing.T) {
+	f := newIngestFixture(t, "proxy-e2e")
+	ctx := context.Background()
+	stop := f.startIngester(t)
+	defer stop()
+
+	addr := startProxy(t, f)
+
+	// The fixture creates branches directly under the project ID
+	// "proxy-e2e" with no project document; alias resolution looks projects
+	// up by name, so register the mapping.
+	_, err := f.metaDB.Collection("wal_projects").InsertOne(ctx, bson.M{
+		"_id": "proxy-e2e", "name": "proxy-e2e", "use_wal": true,
+	})
+	require.NoError(t, err)
+
+	uri := fmt.Sprintf("mongodb://%s/proxy-e2e~main?directConnection=true", addr)
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	require.NoError(t, err)
+	defer func() { _ = client.Disconnect(context.Background()) }()
+
+	db := client.Database("proxy-e2e~main")
+
+	t.Run("CRUD through the alias", func(t *testing.T) {
+		_, err := db.Collection("docs").InsertOne(ctx, bson.M{"_id": "via-proxy", "v": int32(1)})
+		require.NoError(t, err)
+
+		var doc bson.M
+		require.NoError(t, db.Collection("docs").FindOne(ctx, bson.M{"_id": "via-proxy"}).Decode(&doc))
+		assert.EqualValues(t, 1, doc["v"])
+
+		// The write landed in the branch's physical database.
+		var physDoc bson.M
+		require.NoError(t, f.physical.Collection("docs").FindOne(ctx, bson.M{"_id": "via-proxy"}).Decode(&physDoc))
+		assert.EqualValues(t, 1, physDoc["v"])
+	})
+
+	t.Run("Cursor batching and aggregation through the alias", func(t *testing.T) {
+		docs := make([]interface{}, 300)
+		for i := range docs {
+			docs[i] = bson.M{"_id": fmt.Sprintf("batch-%03d", i), "n": int32(i), "group": i % 3}
+		}
+		_, err := db.Collection("bulk").InsertMany(ctx, docs)
+		require.NoError(t, err)
+
+		// Small batch size forces getMore round-trips through the proxy.
+		cursor, err := db.Collection("bulk").Find(ctx, bson.M{}, options.Find().SetBatchSize(20))
+		require.NoError(t, err)
+		count := 0
+		for cursor.Next(ctx) {
+			count++
+		}
+		require.NoError(t, cursor.Err())
+		assert.Equal(t, 300, count)
+
+		_, err = db.Collection("bulk").Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{Key: "n", Value: -1}}})
+		require.NoError(t, err)
+
+		agg, err := db.Collection("bulk").Aggregate(ctx, mongo.Pipeline{
+			{{Key: "$group", Value: bson.M{"_id": "$group", "total": bson.M{"$sum": "$n"}}}},
+		})
+		require.NoError(t, err)
+		var groups []bson.M
+		require.NoError(t, agg.All(ctx, &groups))
+		assert.Len(t, groups, 3)
+	})
+
+	t.Run("Writes through the proxy become versioned history", func(t *testing.T) {
+		f.waitForEntries(t, "docs", 1)
+		branch, err := f.branches.GetBranchByID(f.branchID)
+		require.NoError(t, err)
+		walState, err := f.matFull.MaterializeCollection(branch, "docs")
+		require.NoError(t, err)
+		assert.Contains(t, walState, "via-proxy")
+	})
+
+	t.Run("Non-alias traffic passes through untouched", func(t *testing.T) {
+		other := client.Database("proxy_plain_db")
+		t.Cleanup(func() { _ = other.Drop(context.Background()) })
+		_, err := other.Collection("x").InsertOne(ctx, bson.M{"_id": 1})
+		require.NoError(t, err)
+		count, err := other.Collection("x").CountDocuments(ctx, bson.M{})
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, count)
+	})
+
+	t.Run("Unknown aliases fail with a clean command error", func(t *testing.T) {
+		bad := client.Database("proxy-e2e~no-such-branch")
+		_, err := bad.Collection("x").InsertOne(ctx, bson.M{"_id": 1})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "argon proxy")
+	})
+}


### PR DESCRIPTION
## What

`argon proxy` gives checked-out branches stable, human-readable connection strings:

```
mongodb://proxy-host:27018/<project>~<branch>?directConnection=true
```

A TCP proxy (`internal/wireproxy`) parses OP_MSG frames from the client, rewrites the `$db` field of commands addressed to a branch alias (`project~branch`) to the branch's physical database, and forwards everything else byte-for-byte. Responses stream back as a raw copy — mongod still evaluates every filter, pipeline and index; the proxy only routes.

## Design constraints (stated honestly)

- **Compression negotiated away**: the handshake's `compression` field is blanked so the server never agrees to OP_COMPRESSED (whose payloads we could not rewrite cheaply). Message checksums are stripped when a frame is rewritten.
- **`directConnection=true` required**: topology discovery would hand clients the upstream's own address and bypass the proxy.
- **Auth**: use `authSource=admin` — the default authSource is the URI database, which is the alias.
- **Unresolvable aliases** (unknown project/branch, branch not checked out) get a synthesized `{ok: 0}` command error naming the proxy, not a dropped connection. Resolutions cache for 5s.
- **Capture stays asynchronous** via the change-stream ingester; the proxy is deliberately only the routing layer.

## Testing

End-to-end test drives the official Go driver through a live proxy: CRUD, a 300-document cursor with batchSize 20 (getMore round-trips through the rewriter), aggregation, index build, ingester convergence of proxied writes into the WAL, untouched passthrough for non-alias databases, and the synthesized error surfacing as a clean driver command error.

Also: CLI smoke test (passthrough ping + roundtrip via pymongo), full suite green locally with the S3 chunk-store gate enabled, and `golangci-lint` clean across all three modules (this PR also fixes latent errcheck/staticcheck findings in `cli/` and `api/`, which the CI lint job doesn't cover).

## Docs

ARCHITECTURE.md gains a proxy section; the stale "capture is driver-level" consistency bullet is corrected (post-M3 capture is the change-stream ingester) and the roadmap reflects driver-suite CI and argon-agents shipping.