### PR TITLE
Dataset pins: named immutable branch states for reproducible evals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ argon.exe
 *.out
 vendor/
 compat/mongoose/node_modules/
+api/api

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -138,6 +138,76 @@ func TestAPI_ControlPlaneFlow(t *testing.T) {
 	assert.Contains(t, resp["error"], "not found")
 }
 
+func TestAPI_PinFlow(t *testing.T) {
+	dbName := fmt.Sprintf("argon_api_pin_test_%d", time.Now().UnixNano())
+	services, err := walcli.NewServicesAt("mongodb://localhost:27017", dbName)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = services.Client.Database(dbName).Drop(context.Background())
+	})
+
+	router := NewRouter(services)
+	t.Cleanup(router.Shutdown)
+
+	code, _ := do(t, router, "POST", "/api/v1/projects", map[string]string{"name": "pin-api"})
+	require.Equal(t, http.StatusCreated, code)
+
+	// Seed main through the public write surface.
+	writer, err := services.WriterFor("pin-api", "main")
+	require.NoError(t, err)
+	for i := 0; i < 3; i++ {
+		_, err := writer.Put(context.Background(), "docs", bson.M{"_id": fmt.Sprintf("d%d", i)})
+		require.NoError(t, err)
+	}
+
+	// Pin the current head.
+	code, resp := do(t, router, "POST", "/api/v1/projects/pin-api/pins",
+		map[string]interface{}{"name": "dataset-v1", "note": "eval suite"})
+	require.Equal(t, http.StatusCreated, code, "%v", resp)
+	pinnedLSN := resp["lsn"].(float64)
+	require.Positive(t, pinnedLSN)
+
+	// Duplicate names conflict.
+	code, _ = do(t, router, "POST", "/api/v1/projects/pin-api/pins",
+		map[string]interface{}{"name": "dataset-v1"})
+	require.Equal(t, http.StatusConflict, code)
+
+	// The branch moves on; the pin does not.
+	_, err = writer.Put(context.Background(), "docs", bson.M{"_id": "later"})
+	require.NoError(t, err)
+
+	code, resp = do(t, router, "GET", "/api/v1/projects/pin-api/pins", nil)
+	require.Equal(t, http.StatusOK, code)
+	require.Len(t, resp["pins"], 1)
+
+	// A sandbox forked from the pin starts at exactly the pinned state.
+	code, resp = do(t, router, "POST", "/api/v1/projects/pin-api/pins/dataset-v1/sandboxes",
+		map[string]interface{}{"ttl_minutes": 15})
+	require.Equal(t, http.StatusCreated, code, "%v", resp)
+	assert.EqualValues(t, pinnedLSN, resp["fork_lsn"])
+	sandboxName := resp["branch"].(string)
+	connStr := resp["connection_string"].(string)
+	t.Cleanup(func() {
+		branch, err := services.Branches.GetBranch(mustProjectID(t, services, "pin-api"), sandboxName)
+		if err == nil && branch.PhysicalDB != "" {
+			_ = services.Client.Database(branch.PhysicalDB).Drop(context.Background())
+		}
+	})
+
+	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(connStr))
+	require.NoError(t, err)
+	defer func() { _ = client.Disconnect(context.Background()) }()
+	count, err := client.Database(dbFromURI(connStr)).Collection("docs").CountDocuments(context.Background(), bson.M{})
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, count, "the sandbox sees the pinned state, not the later write")
+
+	// A pinned branch refuses deletion until the pin is gone.
+	code, resp = do(t, router, "DELETE", "/api/v1/projects/pin-api/pins/dataset-v1", nil)
+	require.Equal(t, http.StatusOK, code, "%v", resp)
+	code, _ = do(t, router, "DELETE", "/api/v1/projects/pin-api/pins/dataset-v1", nil)
+	require.Equal(t, http.StatusNotFound, code)
+}
+
 func mustProjectID(t *testing.T, services *walcli.Services, name string) string {
 	t.Helper()
 	p, err := services.Projects.GetProjectByName(name)

--- a/api/router.go
+++ b/api/router.go
@@ -8,6 +8,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net/http"
@@ -59,6 +61,12 @@ func NewRouter(services *walcli.Services) *Router {
 		v1.GET("/projects/:project/branches/:branch/diff", r.diffBranch)
 		v1.POST("/projects/:project/branches/:branch/merge-preview", r.mergePreview)
 		v1.POST("/merge-plans/:id/apply", r.mergeApply)
+
+		v1.GET("/projects/:project/pins", r.listPins)
+		v1.POST("/projects/:project/pins", r.createPin)
+		v1.DELETE("/projects/:project/pins/:name", r.deletePin)
+		v1.POST("/projects/:project/pins/:name/branches", r.branchFromPin)
+		v1.POST("/projects/:project/pins/:name/sandboxes", r.sandboxFromPin)
 
 		v1.POST("/projects/:project/branches/:branch/undo", r.undoRange)
 		v1.GET("/projects/:project/branches/:branch/time-travel", r.timeTravelInfo)
@@ -303,6 +311,139 @@ func (r *Router) createSandbox(c *gin.Context) {
 		"expires_at":        info.ExpiresAt,
 		"forked_from":       info.ForkedFrom,
 		"fork_lsn":          info.ForkLSN,
+	})
+}
+
+// --- pins ---
+
+func (r *Router) listPins(c *gin.Context) {
+	projectID, _, ok := r.resolve(c)
+	if !ok {
+		return
+	}
+	pins, err := r.services.Pins.List(projectID)
+	if err != nil {
+		abortErr(c, http.StatusInternalServerError, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"pins": pins})
+}
+
+func (r *Router) createPin(c *gin.Context) {
+	projectID, _, ok := r.resolve(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		Branch string `json:"branch"`
+		Name   string `json:"name" binding:"required"`
+		LSN    int64  `json:"lsn"`
+		Note   string `json:"note"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		abortErr(c, http.StatusBadRequest, err)
+		return
+	}
+	branchName := body.Branch
+	if branchName == "" {
+		branchName = "main"
+	}
+	branch, err := r.services.Branches.GetBranch(projectID, branchName)
+	if err != nil {
+		abortErr(c, http.StatusNotFound, fmt.Errorf("branch %q not found", branchName))
+		return
+	}
+	pin, err := r.services.Pins.Create(projectID, branch.ID, body.Name, body.LSN, body.Note)
+	if err != nil {
+		abortErr(c, http.StatusConflict, err)
+		return
+	}
+	c.JSON(http.StatusCreated, pin)
+}
+
+func (r *Router) deletePin(c *gin.Context) {
+	projectID, _, ok := r.resolve(c)
+	if !ok {
+		return
+	}
+	if err := r.services.Pins.Delete(projectID, c.Param("name")); err != nil {
+		abortErr(c, http.StatusNotFound, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"deleted": true})
+}
+
+func (r *Router) branchFromPin(c *gin.Context) {
+	projectID, _, ok := r.resolve(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		Name string `json:"name" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		abortErr(c, http.StatusBadRequest, err)
+		return
+	}
+	pin, err := r.services.Pins.Get(projectID, c.Param("name"))
+	if err != nil {
+		abortErr(c, http.StatusNotFound, err)
+		return
+	}
+	branch, err := r.services.Restore.CreateBranchFromPin(projectID, pin.BranchID, body.Name, pin.LSN)
+	if err != nil {
+		abortErr(c, http.StatusConflict, err)
+		return
+	}
+	c.JSON(http.StatusCreated, branch)
+}
+
+func (r *Router) sandboxFromPin(c *gin.Context) {
+	projectID, _, ok := r.resolve(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		Name       string  `json:"name"`
+		TTLMinutes float64 `json:"ttl_minutes"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil && err.Error() != "EOF" {
+		abortErr(c, http.StatusBadRequest, err)
+		return
+	}
+	pin, err := r.services.Pins.Get(projectID, c.Param("name"))
+	if err != nil {
+		abortErr(c, http.StatusNotFound, err)
+		return
+	}
+	name := body.Name
+	if name == "" {
+		suffix := make([]byte, 4)
+		if _, err := rand.Read(suffix); err != nil {
+			abortErr(c, http.StatusInternalServerError, err)
+			return
+		}
+		name = pin.Name + "-run-" + hex.EncodeToString(suffix)
+	}
+	branch, err := r.services.Restore.CreateBranchFromPin(projectID, pin.BranchID, name, pin.LSN)
+	if err != nil {
+		abortErr(c, http.StatusConflict, err)
+		return
+	}
+	ttl := time.Duration(body.TTLMinutes) * time.Minute
+	info, err := r.services.Sandbox.Adopt(c.Request.Context(), branch.ID, ttl)
+	if err != nil {
+		abortErr(c, http.StatusInternalServerError, err)
+		return
+	}
+	r.startIngester(info.BranchID)
+	c.JSON(http.StatusCreated, gin.H{
+		"branch":            info.BranchName,
+		"connection_string": r.services.BranchConnectionString(info.PhysicalDB),
+		"expires_at":        info.ExpiresAt,
+		"forked_from":       info.ForkedFrom,
+		"fork_lsn":          info.ForkLSN,
+		"pin":               pin.Name,
 	})
 }
 

--- a/cli/cmd/pin.go
+++ b/cli/cmd/pin.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/argon-lab/argon/pkg/walcli"
+	"github.com/spf13/cobra"
+)
+
+var pinCmd = &cobra.Command{
+	Use:   "pin",
+	Short: "Pin branch states as named, immutable datasets",
+	Long: `A pin is a named, immutable reference to a branch state — Argon's
+tag. Pinned history survives garbage collection and branch resets
+forever, so a pinned eval dataset materializes identically no matter
+what happens to the branch afterwards. Fork branches or TTL sandboxes
+from a pin to run against the pinned state.`,
+}
+
+// resolvePin loads the project and pin named by the shared flags.
+func resolvePin(services *walcli.Services, projectName, pinName string) (projectID string, pinBranchID string, pinLSN int64, err error) {
+	project, err := services.Projects.GetProjectByName(projectName)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("project %q not found: %w", projectName, err)
+	}
+	p, err := services.Pins.Get(project.ID, pinName)
+	if err != nil {
+		return "", "", 0, err
+	}
+	return project.ID, p.BranchID, p.LSN, nil
+}
+
+var pinCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Pin a branch state under a name",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		branchName, _ := cmd.Flags().GetString("branch")
+		name, _ := cmd.Flags().GetString("name")
+		lsn, _ := cmd.Flags().GetInt64("lsn")
+		atTime, _ := cmd.Flags().GetString("time")
+		note, _ := cmd.Flags().GetString("note")
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+		if branchName == "" {
+			branchName = "main"
+		}
+		branch, err := services.Branches.GetBranch(project.ID, branchName)
+		if err != nil {
+			return fmt.Errorf("branch %q not found: %w", branchName, err)
+		}
+
+		if atTime != "" {
+			if lsn != 0 {
+				return fmt.Errorf("--lsn and --time are mutually exclusive")
+			}
+			t, err := time.Parse(time.RFC3339, atTime)
+			if err != nil {
+				return fmt.Errorf("invalid --time (want RFC3339, e.g. 2026-07-07T12:00:00Z): %w", err)
+			}
+			lsn, err = services.TimeTravel.FindLSNAtTime(branch, t)
+			if err != nil {
+				return fmt.Errorf("failed to resolve time to LSN: %w", err)
+			}
+		}
+
+		p, err := services.Pins.Create(project.ID, branch.ID, name, lsn, note)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Pinned %s/%s at LSN %d as %q\n", projectName, branchName, p.LSN, p.Name)
+		fmt.Println("This state now survives GC and resets until the pin is deleted.")
+		return nil
+	},
+}
+
+var pinListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List a project's pins",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+		pins, err := services.Pins.List(project.ID)
+		if err != nil {
+			return err
+		}
+		if len(pins) == 0 {
+			fmt.Println("No pins.")
+			return nil
+		}
+		fmt.Printf("%-24s %-16s %-10s %-24s %s\n", "NAME", "BRANCH", "LSN", "CREATED", "NOTE")
+		for _, p := range pins {
+			fmt.Printf("%-24s %-16s %-10d %-24s %s\n",
+				p.Name, p.BranchName, p.LSN, p.CreatedAt.Format(time.RFC3339), p.Note)
+		}
+		return nil
+	},
+}
+
+var pinDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a pin (its history becomes reclaimable)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		name, _ := cmd.Flags().GetString("name")
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		project, err := services.Projects.GetProjectByName(projectName)
+		if err != nil {
+			return fmt.Errorf("project %q not found: %w", projectName, err)
+		}
+		if err := services.Pins.Delete(project.ID, name); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted pin %q\n", name)
+		return nil
+	},
+}
+
+var pinBranchCmd = &cobra.Command{
+	Use:   "branch",
+	Short: "Create a durable branch from a pin",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		name, _ := cmd.Flags().GetString("name")
+		as, _ := cmd.Flags().GetString("as")
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		projectID, branchID, lsn, err := resolvePin(services, projectName, name)
+		if err != nil {
+			return err
+		}
+		branch, err := services.Restore.CreateBranchFromPin(projectID, branchID, as, lsn)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Created branch %q from pin %q (LSN %d)\n", branch.Name, name, lsn)
+		return nil
+	},
+}
+
+var pinSandboxCmd = &cobra.Command{
+	Use:   "sandbox",
+	Short: "Fork a TTL sandbox from a pin (reproducible eval runs)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectName, _ := cmd.Flags().GetString("project")
+		name, _ := cmd.Flags().GetString("name")
+		as, _ := cmd.Flags().GetString("as")
+		ttl, _ := cmd.Flags().GetDuration("ttl")
+
+		services, err := walcli.NewServices()
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
+		}
+		projectID, branchID, lsn, err := resolvePin(services, projectName, name)
+		if err != nil {
+			return err
+		}
+		if as == "" {
+			suffix := make([]byte, 4)
+			if _, err := rand.Read(suffix); err != nil {
+				return fmt.Errorf("failed to generate sandbox name: %w", err)
+			}
+			as = name + "-run-" + hex.EncodeToString(suffix)
+		}
+		branch, err := services.Restore.CreateBranchFromPin(projectID, branchID, as, lsn)
+		if err != nil {
+			return err
+		}
+		info, err := services.Sandbox.Adopt(context.Background(), branch.ID, ttl)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Sandbox %q forked from pin %q (LSN %d)\n", info.BranchName, name, lsn)
+		fmt.Printf("Connect: %s\n", services.BranchConnectionString(info.PhysicalDB))
+		fmt.Printf("Expires: %s\n", info.ExpiresAt.Format(time.RFC3339))
+		fmt.Printf("Run \"argon watch -p %s -b %s\" to capture writes as history.\n", projectName, info.BranchName)
+		return nil
+	},
+}
+
+func init() {
+	pinCreateCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	pinCreateCmd.Flags().StringP("branch", "b", "main", "Branch to pin")
+	pinCreateCmd.Flags().String("name", "", "Pin name, unique per project (required)")
+	pinCreateCmd.Flags().Int64("lsn", 0, "LSN to pin (default: current head)")
+	pinCreateCmd.Flags().String("time", "", "Pin the state as of this RFC3339 time instead of an LSN")
+	pinCreateCmd.Flags().String("note", "", "Free-form note")
+	_ = pinCreateCmd.MarkFlagRequired("project")
+	_ = pinCreateCmd.MarkFlagRequired("name")
+
+	pinListCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	_ = pinListCmd.MarkFlagRequired("project")
+
+	pinDeleteCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	pinDeleteCmd.Flags().String("name", "", "Pin name (required)")
+	_ = pinDeleteCmd.MarkFlagRequired("project")
+	_ = pinDeleteCmd.MarkFlagRequired("name")
+
+	pinBranchCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	pinBranchCmd.Flags().String("name", "", "Pin name (required)")
+	pinBranchCmd.Flags().String("as", "", "Name for the new branch (required)")
+	_ = pinBranchCmd.MarkFlagRequired("project")
+	_ = pinBranchCmd.MarkFlagRequired("name")
+	_ = pinBranchCmd.MarkFlagRequired("as")
+
+	pinSandboxCmd.Flags().StringP("project", "p", "", "Project name (required)")
+	pinSandboxCmd.Flags().String("name", "", "Pin name (required)")
+	pinSandboxCmd.Flags().String("as", "", "Sandbox branch name (default: <pin>-run-<random>)")
+	pinSandboxCmd.Flags().Duration("ttl", time.Hour, "Sandbox time-to-live")
+	_ = pinSandboxCmd.MarkFlagRequired("project")
+	_ = pinSandboxCmd.MarkFlagRequired("name")
+
+	pinCmd.AddCommand(pinCreateCmd, pinListCmd, pinDeleteCmd, pinBranchCmd, pinSandboxCmd)
+	rootCmd.AddCommand(pinCmd)
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -183,6 +183,23 @@ hands out, so agent writes become versioned history without anyone
 running `argon watch` by hand. Register with an MCP client, e.g.
 `claude mcp add argon -- argon mcp`.
 
+### Dataset pins (reproducible evals)
+
+A pin is a named, immutable reference to a branch state — Argon's tag,
+with one addition Git doesn't need: pinned history survives garbage
+collection and resets forever. `argon pin create -p proj --name eval-v1`
+pins the current head (or `--lsn` / `--time`); `argon pin sandbox` forks
+a TTL sandbox that starts at exactly the pinned state; `argon pin branch`
+makes a durable branch instead. Pin an eval dataset once, fork a fresh
+sandbox from the pin for every run, and the input state is identical no
+matter what happened to the branch since — resets included, because
+discarded ranges only apply to readers whose bound lies beyond them, the
+same rule that keeps pre-reset backup branches intact. Deleting a branch
+with pins is refused (like deleting a branch with live children); deleting
+the pin releases its history to the next GC run. The MCP server exposes
+`argon_pin_create` / `argon_pin_list` / `argon_pin_sandbox`, the REST API
+`/projects/:p/pins`.
+
 ## Garbage collection (retention window)
 
 `argon gc` (and `Services.RunGC`) deletes WAL entries that no reader can
@@ -197,7 +214,10 @@ where `S` is the newest snapshot valid for every possible future reader
 the retention window (default 7 days), and `S_i` is the newest snapshot at
 or below each live child's fork point — children and all their descendants
 read the parent's segment with an upper bound pinned to the fork, so they
-can only be served by snapshots at or below it. Entries at or below the
+can only be served by snapshots at or below it. Dataset pins enter the
+same minimum as permanent readers at their LSN: a pin at `P` clamps the
+cutoff to the newest snapshot usable at bound `P`, and to zero — nothing
+reclaimed — while no such snapshot exists. Entries at or below the
 cutoff are deleted; control entries stay.
 
 Two consequences worth stating plainly: history without snapshot coverage
@@ -307,8 +327,8 @@ ingester, plus WAL-convergence verification), and the LangGraph
 checkpointer / Mem0 factory ship as the `argon-agents` Python package on
 top of the REST API.
 
-Planned next: eval dataset pinning; GCS chunk-store backend; synchronous
-capture in the wire proxy.
+Planned next: GCS chunk-store backend; synchronous capture in the wire
+proxy.
 
 ## Storage collections
 
@@ -319,6 +339,7 @@ capture in the wire proxy.
 | `wal_projects` | Project metadata |
 | `wal_counters` | Per-project LSN counters |
 | `wal_snapshots` | Snapshot manifests |
+| `wal_pins` | Dataset pins (named immutable branch states) |
 | `wal_snapshot_chunks` | Content-addressed snapshot data |
 
 Indexes on `wal_log`: unique `(project_id, lsn)`;

--- a/internal/branch/wal/service.go
+++ b/internal/branch/wal/service.go
@@ -24,6 +24,16 @@ type BranchService struct {
 	// may still anchor descendants' history). Used to reclaim snapshots
 	// without this package depending on the snapshot package.
 	onDelete func(branchID string)
+
+	// deleteGuard runs before DeleteBranch commits; a non-nil error
+	// refuses the deletion. Used to keep pinned branches alive without
+	// this package depending on the pin package.
+	deleteGuard func(branchID string) error
+}
+
+// SetDeleteGuard registers a check that can refuse DeleteBranch.
+func (s *BranchService) SetDeleteGuard(guard func(branchID string) error) {
+	s.deleteGuard = guard
 }
 
 // SetDeleteHook registers a callback invoked after a successful
@@ -297,6 +307,12 @@ func (s *BranchService) DeleteBranch(projectID, name string) error {
 	}
 	if childCount > 0 {
 		return errors.New("cannot delete branch with active children")
+	}
+
+	if s.deleteGuard != nil {
+		if err := s.deleteGuard(branch.ID); err != nil {
+			return fmt.Errorf("cannot delete branch: %w", err)
+		}
 	}
 
 	// Create WAL entry for deletion

--- a/internal/gc/service.go
+++ b/internal/gc/service.go
@@ -61,6 +61,18 @@ type Service struct {
 	wal       *wal.Service
 	branches  *branchwal.BranchService
 	snapshots *snapshot.Service
+
+	// pinLSNs returns the pinned LSNs on a branch. Wired by the caller so
+	// this package does not depend on the pin package. A pin at LSN P is a
+	// permanent reader at bound P: it clamps the cutoff exactly like a
+	// live child's fork point does.
+	pinLSNs func(branchID string) ([]int64, error)
+}
+
+// SetPinLookup registers the pinned-LSN lookup used to protect pinned
+// history from reclamation.
+func (s *Service) SetPinLookup(lookup func(branchID string) ([]int64, error)) {
+	s.pinLSNs = lookup
 }
 
 // NewService creates a GC service.
@@ -142,6 +154,14 @@ func (s *Service) gcBranch(ctx context.Context, branch *wal.Branch, liveChildren
 		return nil, fmt.Errorf("failed to list collections: %w", err)
 	}
 
+	var pinnedLSNs []int64
+	if s.pinLSNs != nil {
+		pinnedLSNs, err = s.pinLSNs(branch.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up pins: %w", err)
+		}
+	}
+
 	for _, collection := range collections {
 		// S: coverage for the branch's own (and post-fork) readers — must
 		// be valid for every possible future read bound.
@@ -163,6 +183,17 @@ func (s *Service) gcBranch(ctx context.Context, branch *wal.Branch, liveChildren
 				return nil, err
 			}
 			cutoff = min64(cutoff, childCoverage)
+		}
+
+		// Pins are permanent readers at their LSN: same rule as fork
+		// points. No usable snapshot at or below the pin means nothing
+		// here may be reclaimed at all.
+		for _, pinLSN := range pinnedLSNs {
+			pinCoverage, err := s.snapshots.NewestUsableLSN(branch, collection, pinLSN, pinLSN)
+			if err != nil {
+				return nil, err
+			}
+			cutoff = min64(cutoff, pinCoverage)
 		}
 
 		if cutoff <= 0 {

--- a/internal/pin/service.go
+++ b/internal/pin/service.go
@@ -1,0 +1,194 @@
+// Package pin implements dataset pins: named, immutable references to a
+// branch state (branch, LSN) that stay materializable forever.
+//
+// A pin is to Argon what a tag is to Git — with one addition Git doesn't
+// need: garbage collection reclaims WAL entries once snapshots cover them
+// and the retention window has passed, and a pin punches a permanent hole
+// in that policy. For a pin at LSN P, the branch's reclaim cutoff is
+// clamped to the newest snapshot usable at read bound P — and to zero
+// (nothing reclaimed) while no such snapshot exists. Deleting a branch
+// with pins is refused, the same way deleting a branch with live children
+// is.
+//
+// Pins are also stable across resets: a reset records a discarded range,
+// and discarded ranges only apply to readers whose bound lies beyond the
+// range — a pinned read at P keeps seeing the state that was pinned, the
+// same rule that keeps pre-reset backup branches intact.
+//
+// The intended use is reproducible agent evaluation: pin the dataset
+// branch when an eval suite is authored, then fork branches or TTL
+// sandboxes from the pin for every run and get identical input state,
+// regardless of what happened to the branch since.
+package pin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	branchwal "github.com/argon-lab/argon/internal/branch/wal"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Pin is a named, immutable reference to a branch state.
+type Pin struct {
+	ID         string    `bson:"_id" json:"id"`
+	ProjectID  string    `bson:"project_id" json:"project_id"`
+	BranchID   string    `bson:"branch_id" json:"branch_id"`
+	BranchName string    `bson:"branch_name" json:"branch_name"`
+	Name       string    `bson:"name" json:"name"`
+	LSN        int64     `bson:"lsn" json:"lsn"`
+	Note       string    `bson:"note,omitempty" json:"note,omitempty"`
+	CreatedAt  time.Time `bson:"created_at" json:"created_at"`
+}
+
+// Service manages pins.
+type Service struct {
+	collection *mongo.Collection
+	branches   *branchwal.BranchService
+}
+
+// NewService creates the pin service and its indexes.
+func NewService(db *mongo.Database, branches *branchwal.BranchService) (*Service, error) {
+	s := &Service{
+		collection: db.Collection("wal_pins"),
+		branches:   branches,
+	}
+	_, err := s.collection.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "project_id", Value: 1}, {Key: "name", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys: bson.D{{Key: "branch_id", Value: 1}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pin indexes: %w", err)
+	}
+	return s, nil
+}
+
+// Create pins a branch at the given LSN under a project-unique name. An
+// LSN of 0 pins the branch's current head. The LSN must lie on the
+// branch's own segment (base to head) — the same bounds as branching from
+// history.
+func (s *Service) Create(projectID, branchID, name string, lsn int64, note string) (*Pin, error) {
+	if name == "" {
+		return nil, errors.New("pin name must not be empty")
+	}
+	branch, err := s.branches.GetBranchByID(branchID)
+	if err != nil {
+		return nil, fmt.Errorf("branch not found: %w", err)
+	}
+	if branch.ProjectID != projectID {
+		return nil, fmt.Errorf("branch %s does not belong to project %s", branchID, projectID)
+	}
+	if lsn == 0 {
+		lsn = branch.HeadLSN
+	}
+	if lsn < branch.BaseLSN || lsn > branch.HeadLSN {
+		return nil, fmt.Errorf("pin LSN %d is outside branch range [%d, %d]",
+			lsn, branch.BaseLSN, branch.HeadLSN)
+	}
+
+	pin := &Pin{
+		ID:         primitive.NewObjectID().Hex(),
+		ProjectID:  projectID,
+		BranchID:   branch.ID,
+		BranchName: branch.Name,
+		Name:       name,
+		LSN:        lsn,
+		Note:       note,
+		CreatedAt:  time.Now(),
+	}
+	if _, err := s.collection.InsertOne(context.Background(), pin); err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return nil, fmt.Errorf("pin %q already exists in this project", name)
+		}
+		return nil, fmt.Errorf("failed to create pin: %w", err)
+	}
+	return pin, nil
+}
+
+// Get returns a pin by project and name.
+func (s *Service) Get(projectID, name string) (*Pin, error) {
+	var pin Pin
+	err := s.collection.FindOne(context.Background(),
+		bson.M{"project_id": projectID, "name": name}).Decode(&pin)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, fmt.Errorf("pin %q not found", name)
+		}
+		return nil, err
+	}
+	return &pin, nil
+}
+
+// List returns a project's pins, oldest first.
+func (s *Service) List(projectID string) ([]*Pin, error) {
+	ctx := context.Background()
+	cursor, err := s.collection.Find(ctx, bson.M{"project_id": projectID},
+		options.Find().SetSort(bson.D{{Key: "created_at", Value: 1}}))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	pins := make([]*Pin, 0)
+	if err := cursor.All(ctx, &pins); err != nil {
+		return nil, err
+	}
+	return pins, nil
+}
+
+// Delete removes a pin. The history it protected becomes reclaimable on
+// the next GC run.
+func (s *Service) Delete(projectID, name string) error {
+	res, err := s.collection.DeleteOne(context.Background(),
+		bson.M{"project_id": projectID, "name": name})
+	if err != nil {
+		return err
+	}
+	if res.DeletedCount == 0 {
+		return fmt.Errorf("pin %q not found", name)
+	}
+	return nil
+}
+
+// LSNsForBranch returns the pinned LSNs on a branch — the GC service's
+// pin-lookup hook.
+func (s *Service) LSNsForBranch(branchID string) ([]int64, error) {
+	ctx := context.Background()
+	cursor, err := s.collection.Find(ctx, bson.M{"branch_id": branchID})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	var pins []Pin
+	if err := cursor.All(ctx, &pins); err != nil {
+		return nil, err
+	}
+	lsns := make([]int64, len(pins))
+	for i, p := range pins {
+		lsns[i] = p.LSN
+	}
+	return lsns, nil
+}
+
+// RequireNoPins is the branch service's delete guard: deleting a branch
+// that pins reference would orphan them.
+func (s *Service) RequireNoPins(branchID string) error {
+	count, err := s.collection.CountDocuments(context.Background(),
+		bson.M{"branch_id": branchID})
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf("branch has %d pin(s); delete them first (argon pin delete)", count)
+	}
+	return nil
+}

--- a/internal/restore/service.go
+++ b/internal/restore/service.go
@@ -134,6 +134,39 @@ func (s *Service) CreateBranchAtLSN(projectID, sourceBranchID, newBranchName str
 	return newBranch, nil
 }
 
+// CreateBranchFromPin forks a branch at a pinned LSN. Unlike
+// CreateBranchAtLSN it does not bound the target by the source's current
+// head: a pin stays valid across resets — its reads fall inside the
+// discarded range, where the pre-reset rule preserves them — so a pinned
+// LSN may legitimately lie above a reset head.
+func (s *Service) CreateBranchFromPin(projectID, sourceBranchID, newBranchName string, pinnedLSN int64) (*wal.Branch, error) {
+	if newBranchName == "" {
+		return nil, fmt.Errorf("branch name must not be empty")
+	}
+	sourceBranch, err := s.branches.GetBranchByID(sourceBranchID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get source branch: %w", err)
+	}
+	if pinnedLSN < sourceBranch.BaseLSN {
+		return nil, fmt.Errorf("pinned LSN %d is below the source branch's base %d",
+			pinnedLSN, sourceBranch.BaseLSN)
+	}
+
+	newBranch := &wal.Branch{
+		ID:        primitive.NewObjectID().Hex(),
+		ProjectID: projectID,
+		Name:      newBranchName,
+		ParentID:  sourceBranch.ID,
+		BaseLSN:   pinnedLSN,
+		HeadLSN:   pinnedLSN,
+		CreatedAt: time.Now(),
+	}
+	if err := s.branches.CreateBranchWithData(newBranch); err != nil {
+		return nil, fmt.Errorf("failed to create branch: %w", err)
+	}
+	return newBranch, nil
+}
+
 // CreateBranchAtTime creates a new branch from a specific timestamp
 func (s *Service) CreateBranchAtTime(projectID, sourceBranchID, newBranchName string, timestamp time.Time) (*wal.Branch, error) {
 	// Get the source branch

--- a/internal/sandbox/service.go
+++ b/internal/sandbox/service.go
@@ -85,6 +85,43 @@ func (s *Service) Create(ctx context.Context, projectID, parentBranchID, name st
 	}, nil
 }
 
+// Adopt turns an existing, not-yet-live branch into a sandbox: stamps the
+// TTL and checks it out. This is how sandboxes are created from a
+// historical point (a pin) — the branch is forked at the pinned LSN by the
+// restore service first, then adopted here.
+func (s *Service) Adopt(ctx context.Context, branchID string, ttl time.Duration) (*Info, error) {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	branch, err := s.branches.GetBranchByID(branchID)
+	if err != nil {
+		return nil, fmt.Errorf("branch not found: %w", err)
+	}
+	forkedFrom := ""
+	if branch.ParentID != "" {
+		if parent, err := s.branches.GetBranchByID(branch.ParentID); err == nil {
+			forkedFrom = parent.Name
+		}
+	}
+
+	expires := time.Now().Add(ttl)
+	if err := s.branches.SetExpiry(branch.ID, &expires); err != nil {
+		return nil, fmt.Errorf("failed to stamp sandbox TTL: %w", err)
+	}
+	info, err := s.checkout.Checkout(ctx, branch.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check the sandbox out: %w", err)
+	}
+	return &Info{
+		BranchID:   branch.ID,
+		BranchName: branch.Name,
+		PhysicalDB: info.PhysicalDB,
+		ExpiresAt:  expires,
+		ForkedFrom: forkedFrom,
+		ForkLSN:    branch.BaseLSN,
+	}, nil
+}
+
 // Extend pushes a sandbox's expiry further out from now.
 func (s *Service) Extend(ctx context.Context, branchID string, ttl time.Duration) (time.Time, error) {
 	branch, err := s.branches.GetBranchByID(branchID)

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -23,6 +23,9 @@ var toolHandlers = map[string]toolHandler{
 	"argon_merge_apply":     toolMergeApply,
 	"argon_undo":            toolUndo,
 	"argon_snapshot_create": toolSnapshotCreate,
+	"argon_pin_create":      toolPinCreate,
+	"argon_pin_list":        toolPinList,
+	"argon_pin_sandbox":     toolPinSandbox,
 }
 
 // schema builds the JSON schema for a tool's arguments.
@@ -131,6 +134,37 @@ func toolDescriptors() []map[string]interface{} {
 				"to_lsn":   num("End of the range (default: branch head)"),
 				"actor":    str("Only revert writes by this actor"),
 				"dry_run":  boolean("Preview without applying"),
+			}),
+		},
+		{
+			"name": "argon_pin_create",
+			"description": "Pin a branch state under a name: a named, immutable dataset reference that " +
+				"survives garbage collection and resets forever. Pin an eval dataset once, then fork " +
+				"sandboxes from the pin for every run and get identical input state.",
+			"inputSchema": schema([]string{"project", "name"}, map[string]interface{}{
+				"project": str("Project name"),
+				"branch":  str("Branch to pin (default: main)"),
+				"name":    str("Pin name, unique per project"),
+				"lsn":     num("LSN to pin (default: current head)"),
+				"note":    str("Free-form note"),
+			}),
+		},
+		{
+			"name":        "argon_pin_list",
+			"description": "List a project's pins (name, branch, LSN, note).",
+			"inputSchema": schema([]string{"project"}, map[string]interface{}{
+				"project": str("Project name"),
+			}),
+		},
+		{
+			"name": "argon_pin_sandbox",
+			"description": "Fork a TTL sandbox from a pin and get a connection string. The sandbox starts " +
+				"at exactly the pinned state — the reproducible-eval workflow.",
+			"inputSchema": schema([]string{"project", "pin"}, map[string]interface{}{
+				"project":     str("Project name"),
+				"pin":         str("Pin name"),
+				"name":        str("Sandbox name (default: <pin>-run-<random>)"),
+				"ttl_minutes": num("Sandbox TTL in minutes (default: 60)"),
 			}),
 		},
 		{
@@ -388,4 +422,84 @@ func toolSnapshotCreate(ctx context.Context, s *Server, args map[string]interfac
 		return "", err
 	}
 	return fmt.Sprintf("Snapshotted %d collection(s) at LSN %d.", len(snaps), branch.HeadLSN), nil
+}
+
+func toolPinCreate(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	projectID, branchID, err := s.resolveBranchID(argString(args, "project"), argString(args, "branch"))
+	if err != nil {
+		return "", err
+	}
+	var lsn int64
+	if v, ok := argNumber(args, "lsn"); ok {
+		lsn = int64(v)
+	}
+	pin, err := s.services.Pins.Create(projectID, branchID, argString(args, "name"), lsn, argString(args, "note"))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(
+		"Pinned branch %q at LSN %d as %q. This state survives GC and resets until the pin is deleted; "+
+			"fork reproducible sandboxes from it with argon_pin_sandbox.",
+		pin.BranchName, pin.LSN, pin.Name), nil
+}
+
+func toolPinList(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	project, err := s.services.Projects.GetProjectByName(argString(args, "project"))
+	if err != nil {
+		return "", fmt.Errorf("project %q not found", argString(args, "project"))
+	}
+	pins, err := s.services.Pins.List(project.ID)
+	if err != nil {
+		return "", err
+	}
+	if len(pins) == 0 {
+		return "No pins.", nil
+	}
+	var sb strings.Builder
+	for _, p := range pins {
+		fmt.Fprintf(&sb, "%s: branch %s at LSN %d (created %s)", p.Name, p.BranchName, p.LSN,
+			p.CreatedAt.Format(time.RFC3339))
+		if p.Note != "" {
+			fmt.Fprintf(&sb, " — %s", p.Note)
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String(), nil
+}
+
+func toolPinSandbox(ctx context.Context, s *Server, args map[string]interface{}) (string, error) {
+	project, err := s.services.Projects.GetProjectByName(argString(args, "project"))
+	if err != nil {
+		return "", fmt.Errorf("project %q not found", argString(args, "project"))
+	}
+	pin, err := s.services.Pins.Get(project.ID, argString(args, "pin"))
+	if err != nil {
+		return "", err
+	}
+	name := argString(args, "name")
+	if name == "" {
+		name = fmt.Sprintf("%s-run-%s", pin.Name, primitive.NewObjectID().Hex()[18:])
+	}
+	branch, err := s.services.Restore.CreateBranchFromPin(project.ID, pin.BranchID, name, pin.LSN)
+	if err != nil {
+		return "", err
+	}
+	ttl := time.Hour
+	if minutes, ok := argNumber(args, "ttl_minutes"); ok && minutes > 0 {
+		ttl = time.Duration(minutes) * time.Minute
+	}
+	info, err := s.services.Sandbox.Adopt(ctx, branch.ID, ttl)
+	if err != nil {
+		return "", err
+	}
+	s.startIngester(info.BranchID)
+	return fmt.Sprintf(
+		"Sandbox %q forked from pin %q (LSN %d).\n"+
+			"Connection string: %s\n"+
+			"Expires: %s\n"+
+			"The sandbox starts at exactly the pinned state; writes are captured as versioned history.",
+		info.BranchName, pin.Name, pin.LSN,
+		s.services.BranchConnectionString(info.PhysicalDB),
+		info.ExpiresAt.Format(time.RFC3339),
+	), nil
 }

--- a/pkg/walcli/services.go
+++ b/pkg/walcli/services.go
@@ -14,6 +14,7 @@ import (
 	"github.com/argon-lab/argon/internal/materializer"
 	"github.com/argon-lab/argon/internal/merge"
 	"github.com/argon-lab/argon/internal/migrate"
+	"github.com/argon-lab/argon/internal/pin"
 	projectwal "github.com/argon-lab/argon/internal/project/wal"
 	"github.com/argon-lab/argon/internal/restore"
 	"github.com/argon-lab/argon/internal/sandbox"
@@ -44,6 +45,7 @@ type Services struct {
 	Undo         *undo.Service
 	Merge        *merge.Service
 	Sandbox      *sandbox.Service
+	Pins         *pin.Service
 	Monitor      *wal.Monitor
 	MongoURI     string
 	// Client is the deployment connection, exposed for tools that read
@@ -118,6 +120,14 @@ func NewServicesAt(mongoURI, dbName string) (*Services, error) {
 	undoService := undo.NewService(walService, branchService, client)
 	mergeService := merge.NewService(db, walService, branchService, materializerService, client)
 	sandboxService := sandbox.NewService(branchService, checkoutService)
+	pinService, err := pin.NewService(db, branchService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pin service: %w", err)
+	}
+	// Pinned history must survive GC, and pinned branches must survive
+	// deletion.
+	gcService.SetPinLookup(pinService.LSNsForBranch)
+	branchService.SetDeleteGuard(pinService.RequireNoPins)
 	// Snapshot immediately after imports: an imported history is otherwise
 	// pure linear replay until something trips the auto-snapshot threshold.
 	importerService.SetImportedHook(func(branch *wal.Branch) {
@@ -165,6 +175,7 @@ func NewServicesAt(mongoURI, dbName string) (*Services, error) {
 		Undo:         undoService,
 		Merge:        mergeService,
 		Sandbox:      sandboxService,
+		Pins:         pinService,
 		Monitor:      monitor,
 		MongoURI:     mongoURI,
 		Client:       client,

--- a/tests/wal/pin_test.go
+++ b/tests/wal/pin_test.go
@@ -1,0 +1,268 @@
+package wal_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/argon-lab/argon/internal/gc"
+	"github.com/argon-lab/argon/internal/pin"
+	"github.com/argon-lab/argon/internal/sandbox"
+	"github.com/argon-lab/argon/internal/walwriter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestPin_CRUDAndValidation(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	pins, err := pin.NewService(db, f.branches)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("pin-crud", "main", "")
+	require.NoError(t, err)
+	writer := walwriter.New(f.wal, f.branches, f.mat, main)
+	for i := 0; i < 5; i++ {
+		_, err := writer.Put(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%d", i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+
+	// LSN 0 pins the current head.
+	head, err := pins.Create("pin-crud", main.ID, "at-head", 0, "eval suite v1")
+	require.NoError(t, err)
+	assert.Equal(t, main.HeadLSN, head.LSN)
+	assert.Equal(t, "main", head.BranchName)
+
+	// Names are unique per project.
+	_, err = pins.Create("pin-crud", main.ID, "at-head", 0, "")
+	require.ErrorContains(t, err, "already exists")
+
+	// Bounds: beyond the head is refused.
+	_, err = pins.Create("pin-crud", main.ID, "future", main.HeadLSN+100, "")
+	require.ErrorContains(t, err, "outside branch range")
+
+	// Wrong project is refused.
+	_, err = pins.Create("other-project", main.ID, "cross", 0, "")
+	require.ErrorContains(t, err, "does not belong")
+
+	mid, err := pins.Create("pin-crud", main.ID, "mid", main.HeadLSN-2, "")
+	require.NoError(t, err)
+
+	list, err := pins.List("pin-crud")
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	got, err := pins.Get("pin-crud", "mid")
+	require.NoError(t, err)
+	assert.Equal(t, mid.LSN, got.LSN)
+
+	require.NoError(t, pins.Delete("pin-crud", "mid"))
+	_, err = pins.Get("pin-crud", "mid")
+	require.ErrorContains(t, err, "not found")
+	require.ErrorContains(t, pins.Delete("pin-crud", "mid"), "not found")
+}
+
+func TestPin_BranchFromPinMaterializesPinnedState(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	pins, err := pin.NewService(db, f.branches)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("pin-branch", "main", "")
+	require.NoError(t, err)
+	writer := walwriter.New(f.wal, f.branches, f.mat, main)
+	for i := 0; i < 4; i++ {
+		_, err := writer.Put(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%d", i), "v": int32(1)})
+		require.NoError(t, err)
+	}
+	p, err := pins.Create("pin-branch", main.ID, "dataset-v1", 0, "")
+	require.NoError(t, err)
+
+	// The branch moves on: overwrites and new documents.
+	_, err = writer.Put(ctx, "docs", bson.M{"_id": "d0", "v": int32(2)})
+	require.NoError(t, err)
+	_, err = writer.Put(ctx, "docs", bson.M{"_id": "d9", "v": int32(1)})
+	require.NoError(t, err)
+
+	run, err := f.restore.CreateBranchFromPin("pin-branch", p.BranchID, "eval-run-1", p.LSN)
+	require.NoError(t, err)
+	state, err := f.mat.MaterializeCollection(run, "docs")
+	require.NoError(t, err)
+	assert.Len(t, state, 4, "pinned state has the original four documents")
+	assert.EqualValues(t, 1, state["d0"]["v"], "pinned state predates the overwrite")
+	assert.NotContains(t, state, "d9")
+}
+
+func TestPin_SurvivesReset(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	pins, err := pin.NewService(db, f.branches)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("pin-reset", "main", "")
+	require.NoError(t, err)
+	writer := walwriter.New(f.wal, f.branches, f.mat, main)
+	for i := 0; i < 3; i++ {
+		_, err := writer.Put(ctx, "docs", bson.M{"_id": fmt.Sprintf("keep%d", i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+	resetTarget := main.HeadLSN
+
+	for i := 0; i < 3; i++ {
+		_, err := writer.Put(ctx, "docs", bson.M{"_id": fmt.Sprintf("extra%d", i)})
+		require.NoError(t, err)
+	}
+	p, err := pins.Create("pin-reset", main.ID, "with-extras", 0, "")
+	require.NoError(t, err)
+
+	// Reset the branch to before the extras: a discarded range now covers
+	// the pinned entries — but only for readers beyond the pin.
+	_, err = f.restore.ResetBranchToLSN(main.ID, resetTarget)
+	require.NoError(t, err)
+
+	run, err := f.restore.CreateBranchFromPin("pin-reset", p.BranchID, "pinned-run", p.LSN)
+	require.NoError(t, err)
+	state, err := f.mat.MaterializeCollection(run, "docs")
+	require.NoError(t, err)
+	assert.Len(t, state, 6, "the pin still sees the pre-reset state")
+	assert.Contains(t, state, "extra0")
+
+	// The branch itself reads post-reset state.
+	main, _ = f.branches.GetBranchByID(main.ID)
+	mainState, err := f.mat.MaterializeCollection(main, "docs")
+	require.NoError(t, err)
+	assert.Len(t, mainState, 3)
+}
+
+func TestPin_GCKeepsPinnedHistory(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	pins, err := pin.NewService(db, f.branches)
+	require.NoError(t, err)
+	gcService := gc.NewService(f.wal, f.branches, f.snapshots)
+	gcService.SetPinLookup(pins.LSNsForBranch)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("pin-gc", "main", "")
+	require.NoError(t, err)
+	writer := walwriter.New(f.wal, f.branches, f.mat, main)
+	for i := 0; i < 5; i++ {
+		_, err := writer.Put(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%d", i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+	pinLSN := main.HeadLSN
+	p, err := pins.Create("pin-gc", main.ID, "dataset", pinLSN, "")
+	require.NoError(t, err)
+
+	for i := 5; i < 10; i++ {
+		_, err := writer.Put(ctx, "docs", bson.M{"_id": fmt.Sprintf("d%d", i)})
+		require.NoError(t, err)
+	}
+	main, _ = f.branches.GetBranchByID(main.ID)
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, main.HeadLSN)
+	require.NoError(t, err)
+
+	// The head snapshot covers everything for ordinary readers — but the
+	// pin reads at its own LSN and no snapshot at or below it exists, so
+	// nothing may be reclaimed.
+	report, err := gcService.RunProject(ctx, "pin-gc", zeroRetention)
+	require.NoError(t, err)
+	assert.Zero(t, report.EntriesRemoved, "pinned history without pin-usable coverage survives")
+
+	// A snapshot at the pin gives the pin its own floor: entries at or
+	// below it are covered for every reader, the rest stay for the pin.
+	_, err = f.snapshots.CreateSnapshot(ctx, main.ID, pinLSN)
+	require.NoError(t, err)
+	report, err = gcService.RunProject(ctx, "pin-gc", zeroRetention)
+	require.NoError(t, err)
+	assert.EqualValues(t, 5, report.EntriesRemoved, "entries at or below the pin's snapshot reclaimed")
+
+	// The pinned state still materializes exactly after GC.
+	run, err := f.restore.CreateBranchFromPin("pin-gc", p.BranchID, "post-gc-run", p.LSN)
+	require.NoError(t, err)
+	state, err := f.mat.MaterializeCollection(run, "docs")
+	require.NoError(t, err)
+	assert.Len(t, state, 5)
+
+	// Deleting the pin releases the hold: the head snapshot now covers all.
+	require.NoError(t, f.branches.DeleteBranch("pin-gc", "post-gc-run"))
+	require.NoError(t, pins.Delete("pin-gc", "dataset"))
+	report, err = gcService.RunProject(ctx, "pin-gc", zeroRetention)
+	require.NoError(t, err)
+	assert.EqualValues(t, 5, report.EntriesRemoved, "unpinned history reclaimed up to the head snapshot")
+}
+
+func TestPin_DeleteGuardProtectsPinnedBranches(t *testing.T) {
+	db := setupTestDB(t)
+	f := newSnapshotFixture(t, db)
+	pins, err := pin.NewService(db, f.branches)
+	require.NoError(t, err)
+	f.branches.SetDeleteGuard(pins.RequireNoPins)
+	ctx := context.Background()
+
+	main, err := f.branches.CreateBranch("pin-guard", "main", "")
+	require.NoError(t, err)
+	other, err := f.branches.CreateBranch("pin-guard", "datasets", main.ID)
+	require.NoError(t, err)
+	writer := walwriter.New(f.wal, f.branches, f.mat, other)
+	_, err = writer.Put(ctx, "docs", bson.M{"_id": "d"})
+	require.NoError(t, err)
+
+	_, err = pins.Create("pin-guard", other.ID, "hold", 0, "")
+	require.NoError(t, err)
+
+	err = f.branches.DeleteBranch("pin-guard", "datasets")
+	require.ErrorContains(t, err, "pin")
+
+	require.NoError(t, pins.Delete("pin-guard", "hold"))
+	require.NoError(t, f.branches.DeleteBranch("pin-guard", "datasets"))
+}
+
+func TestPin_SandboxFromPin(t *testing.T) {
+	f := newIngestFixture(t, "pin-sandbox")
+	pins, err := pin.NewService(f.metaDB, f.branches)
+	require.NoError(t, err)
+	sandboxes := sandbox.NewService(f.branches, f.checkout)
+	ctx := context.Background()
+
+	// The fixture seeded one document; pin that state, then move on.
+	main, err := f.branches.GetBranchByID(f.branchID)
+	require.NoError(t, err)
+	p, err := pins.Create("pin-sandbox", main.ID, "seed-state", 0, "")
+	require.NoError(t, err)
+
+	stop := f.startIngester(t)
+	_, err = f.physical.Collection("users").InsertOne(ctx, bson.M{"_id": "later", "n": int32(1)})
+	require.NoError(t, err)
+	f.waitForEntries(t, "users", 2)
+	stop()
+
+	// Fork a sandbox from the pin: it materializes exactly the pinned state.
+	_, err = f.restore.CreateBranchFromPin("pin-sandbox", p.BranchID, "", p.LSN)
+	require.Error(t, err, "empty branch names are refused")
+	branch, err := f.restore.CreateBranchFromPin("pin-sandbox", p.BranchID, "eval-1", p.LSN)
+	require.NoError(t, err)
+	info, err := sandboxes.Adopt(ctx, branch.ID, time.Hour)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = f.client.Database(info.PhysicalDB).Drop(context.Background())
+	})
+	assert.Equal(t, "main", info.ForkedFrom)
+	assert.Equal(t, p.LSN, info.ForkLSN)
+
+	docs := f.client.Database(info.PhysicalDB).Collection("users")
+	count, err := docs.CountDocuments(ctx, bson.M{})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, count, "sandbox has the pinned seed state only")
+
+	var seed bson.M
+	require.NoError(t, docs.FindOne(ctx, bson.M{"_id": "seed"}).Decode(&seed))
+}


### PR DESCRIPTION
## What

A pin is Argon's tag — `argon pin create -p proj --name eval-v1` names the current branch state (or `--lsn` / `--time`) — with one addition Git doesn't need: **pinned history survives garbage collection and resets forever**. This closes the last open roadmap item (M5: eval dataset pinning).

The eval workflow: pin a dataset branch once; fork a fresh sandbox from the pin for every run (`argon pin sandbox`, REST `POST /projects/:p/pins/:name/sandboxes`, MCP `argon_pin_sandbox`); every run starts from identical input state no matter what happened to the branch since.

## How it holds

- **GC**: each pin enters the reclaim-cutoff minimum as a permanent reader at its LSN — the cutoff clamps to the newest snapshot usable at that bound, and to zero (nothing reclaimed) while none exists. Same shape as the live-child fork-point rule.
- **Resets**: discarded ranges only apply to readers whose bound lies beyond them (the rule that keeps pre-reset backup branches intact), so a pinned read keeps seeing the pinned state after the branch is reset below it.
- **Deletion**: a new delete guard on the branch service refuses deleting branches with pins, like branches with live children. Expired-sandbox sweeps skip pinned sandboxes loudly.
- `CreateBranchFromPin` forks at the pinned LSN without bounding by the source's current head (legitimately above a reset head); it also refuses empty branch names.
- `sandbox.Adopt` turns a pre-created branch into a TTL sandbox so sandboxes can start from a historical point.

## Surfaces

CLI `argon pin create/list/delete/branch/sandbox` · REST `/projects/:p/pins` (list/create/delete, branch-from-pin, sandbox-from-pin with supervised ingester) · MCP `argon_pin_create` / `argon_pin_list` / `argon_pin_sandbox` (13 tools now).

## Testing

- Unit/integration: pin CRUD and bounds, pinned-state materialization, **reset survival**, **GC protection and release** (no pin-usable snapshot → nothing reclaimed; snapshot at pin → reclaim below, keep above; delete pin → full reclaim), delete guard, sandbox-from-pin against a checked-out branch with real driver reads.
- REST: pin flow end-to-end including a pymongo read of a pinned sandbox seeing exactly the pinned state.
- Full suite green locally with the S3 chunk-store gate; lint clean across all three modules.

Also removes a stray 21 MB `api/api` build binary that slipped into #27 and gitignores it.