### PR TITLE
Bump CLI and npm package versions to 2.0.0

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -32,7 +32,7 @@ Examples:
   argon metrics                           # Detailed performance metrics
 
 The first MongoDB database with Git-like time travel.`,
-	Version: "1.0.0",
+	Version: "2.0.0",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argonctl",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Git-like MongoDB branching with time travel - CLI tool",
   "keywords": ["mongodb", "database", "branching", "time-travel", "ml", "ai", "cli"],
   "homepage": "https://github.com/argon-lab/argon",


### PR DESCRIPTION
The engine, docs and CHANGELOG are already at 2.0.0; the CLI --version
string and the npm wrapper (which downloads release binaries keyed by
its own version) were still on 1.0.x.
