### PR TITLE
npm installer: Windows release assets carry an .exe suffix

### DIFF
--- a/npm/scripts/install.js
+++ b/npm/scripts/install.js
@@ -56,7 +56,8 @@ async function install() {
   try {
     const platform = getPlatform();
     const binaryName = getBinaryName();
-    const downloadUrl = `https://github.com/argon-lab/argon/releases/download/v${version}/argon-${platform}`;
+    const assetName = process.platform === 'win32' ? `argon-${platform}.exe` : `argon-${platform}`;
+    const downloadUrl = `https://github.com/argon-lab/argon/releases/download/v${version}/${assetName}`;
     
     const binDir = path.join(__dirname, '..', 'bin');
     const binaryPath = path.join(binDir, binaryName);


### PR DESCRIPTION
The download URL omitted it, so every Windows npm install has 404ed
against the release assets since 1.0.
