### PR TITLE
npm package: bin entries must exist inside the published tarball

### DIFF
--- a/npm/bin/argon.js
+++ b/npm/bin/argon.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Thin launcher: the real binary is downloaded by scripts/install.js at
+// install time (per platform). npm requires bin targets to exist inside
+// the published tarball, so the entry point is this wrapper, not the
+// binary itself.
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const binaryName = process.platform === 'win32' ? 'argon-bin.exe' : 'argon-bin';
+const binaryPath = path.join(__dirname, binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error('The Argon binary is missing. Reinstall with: npm install -g argonctl');
+  console.error('(The installer downloads it from https://github.com/argon-lab/argon/releases)');
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), { stdio: 'inherit' });
+process.exit(result.status === null ? 1 : result.status);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,22 +1,30 @@
 {
   "name": "argonctl",
   "version": "2.0.0",
-  "description": "Git-like MongoDB branching with time travel - CLI tool",
-  "keywords": ["mongodb", "database", "branching", "time-travel", "ml", "ai", "cli"],
+  "description": "Git for MongoDB: branch, time-travel, merge and undo - CLI",
+  "keywords": [
+    "mongodb",
+    "database",
+    "branching",
+    "time-travel",
+    "ml",
+    "ai",
+    "cli"
+  ],
   "homepage": "https://github.com/argon-lab/argon",
   "bugs": {
     "url": "https://github.com/argon-lab/argon/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/argon-lab/argon.git"
+    "url": "git+https://github.com/argon-lab/argon.git"
   },
   "license": "MIT",
   "author": "Argon Lab",
   "main": "index.js",
   "bin": {
-    "argon": "./bin/argon",
-    "argonctl": "./bin/argon"
+    "argon": "bin/argon.js",
+    "argonctl": "bin/argon.js"
   },
   "files": [
     "bin/",

--- a/npm/scripts/install.js
+++ b/npm/scripts/install.js
@@ -25,7 +25,8 @@ function getPlatform() {
 }
 
 function getBinaryName() {
-  return process.platform === 'win32' ? 'argon.exe' : 'argon';
+  // The wrapper bin/argon.js execs this; distinct from the wrapper name.
+  return process.platform === 'win32' ? 'argon-bin.exe' : 'argon-bin';
 }
 
 function downloadBinary(url, dest) {


### PR DESCRIPTION
Modern npm validates bin targets at publish time and silently strips
entries pointing at files the tarball doesn't contain - which is
exactly what the old layout did (the binary only appears at install
time), so a publish from npm >= 9 would ship a package with no argon
command at all.

The bin entries now point at a committed JS launcher (bin/argon.js)
that execs the platform binary; the installer downloads it as
argon-bin(.exe) next to the launcher. Verified end to end: npm pack,
global install from the tarball into a fresh prefix, postinstall
download from the v2.0.0 release, argon/argonctl --version both 2.0.0.
Package went from a 5.2 MB tarball (a stray local darwin binary was
being bundled) to 2.3 kB.
