### PR TITLE
Docs: restructure for skimmability — the flow is the skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,123 +7,121 @@
 [![npm](https://img.shields.io/npm/v/argonctl?logo=npm&label=npm)](https://www.npmjs.com/package/argonctl)
 [![PyPI](https://img.shields.io/pypi/v/argon-agents?logo=pypi&label=argon--agents)](https://pypi.org/project/argon-agents/)
 
-**Branch, time-travel, merge and undo your MongoDB — with real drivers, real
-mongod, and versioned history underneath. Built for the age of AI agents.**
+**Branch, time-travel, merge and undo your MongoDB. Any driver, real mongod,
+versioned history underneath. Built for AI agents.**
 
-## What is Argon?
+Three ideas, thirty seconds:
 
-Argon is a version-control engine for MongoDB. Every write becomes an entry
-in a deterministic write-ahead log; branches are metadata pointers into that
-log. On top of that one idea:
+1. **A branch is a pointer, not a copy** — created in milliseconds at any
+   data size.
+2. **`checkout` turns a branch into a real MongoDB database** — pymongo,
+   mongoose, mongosh, indexes, aggregation, transactions: all real, and
+   every write becomes versioned history.
+3. **Nothing is ever lost** — diff it, merge it, undo it, rewind it, or pin
+   it forever.
 
-- **Branch in milliseconds** — creating a branch writes a pointer, not a
-  copy, regardless of data size
-- **Work with any MongoDB driver** — `argon checkout` materializes a branch
-  into a real MongoDB database; pymongo, mongoose, the Go driver, indexes,
-  aggregation and transactions all run on mongod itself, and every write is
-  captured back into versioned history
-- **Time-travel and undo** — materialize any historical state by LSN or
-  timestamp; revert ranges of history (even one agent's writes) with
-  append-only compensations
-- **Merge with review** — three-way merges as persisted, reviewable plans:
-  a data pull request; conflicts are never resolved silently
-- **Agent-native** — TTL sandboxes, dataset pins for reproducible evals, an
-  MCP server, a REST control plane, and LangGraph/Mem0 adapters
-  ([argon-agents](https://github.com/argon-lab/argon-agents))
-
-Performance numbers live in one place: the
-[public benchmark suite](https://github.com/argon-lab/benchmarks), pinned
-engine refs, reproducible with `docker compose up`. This README quotes none,
-by policy.
-
-## Sixty seconds
+## Install
 
 ```bash
-brew install argon-lab/tap/argonctl        # or: npm install -g argonctl
-# MongoDB must run as a replica set (change streams) — see docs/OPERATIONS.md
+brew install argon-lab/tap/argonctl      # macOS
+npm install -g argonctl                  # cross-platform
 
-# Bring an existing database in ("git clone")
+# MongoDB must run as a replica set (one-node is fine):
+docker run -d --name argon-mongo -p 27017:27017 mongo:7 --replSet rs0
+docker exec argon-mongo mongosh --quiet --eval 'rs.initiate()'
+```
+
+## The flow
+
+```
+main ──branch──▶ experiment ──checkout──▶ mongodb://…  ← any driver
+                                              │
+                     ┌── argon diff ──────────┤  every write captured
+                     ▼                        ▼
+        merge (a data PR)          or   undo / discard / rewind
+```
+
+```bash
+# 0 · Bring your data in ("git clone") — or: argon projects create myapp
 argon import database --uri mongodb://localhost:27017 --database myapp --project myapp
 
-# Branch ("git checkout -b") — a metadata write, instant at any size
+# 1 · Branch — instant, no copy
 argon branches create experiment -p myapp
 
-# Materialize the branch into a real MongoDB database and get a URI
-argon checkout -p myapp -b experiment
-argon watch -p myapp -b experiment        # capture writes as history
+# 2 · Get a real database for it, capture writes
+argon checkout -p myapp -b experiment      # prints a connection string
+argon watch    -p myapp -b experiment      # keep running while you write
 
-# ... point any driver at the URI, write freely ...
-
-# Review and merge the work back — a data pull request
-argon diff -p myapp -b experiment
+# 3 · Review and merge back — a data pull request
+argon diff          -p myapp -b experiment
 argon merge preview -p myapp -b experiment
 argon merge apply <plan-id>
 
-# Disaster recovery: preview, then rewind
-argon restore preview -p myapp -b main --time 2026-07-07T09:00:00Z
-argon restore reset   -p myapp -b main --time 2026-07-07T09:00:00Z --backup pre-incident
+# …or rewind instead of merging
+argon restore reset -p myapp -b main --time 2026-07-07T09:00:00Z --backup pre-incident
 ```
 
-For agents, the same engine over MCP: `claude mcp add argon -- argon mcp`
-hands your agent sandboxes, diffs, merges, undo and pins as tools.
+Prefer clicking? `argon console` serves a local web console (UI + REST API)
+and opens your browser.
 
-## Status
+## What you get
 
-The v2 engine is complete: every milestone of the
-[rebuild plan](docs/ARCHITECTURE.md) has shipped, each merged only with CI
-green.
-
-| Milestone | Scope | Status |
+| | Command | In one line |
 |---|---|---|
-| **M1 · Correctness** | Deterministic replay (property-tested), distributed LSN sequencer, branch ancestry isolation, truthful write results, WAL v2 migration | ✅ |
-| **M2 · Bounded time travel** | Content-addressed snapshots bound replay depth · retention-window GC + full branch reclamation · MongoDB/S3/filesystem chunk stores · [public benchmarks](https://github.com/argon-lab/benchmarks) | ✅ |
-| **M3 · True drop-in** | Physical MongoDB database per branch (`argon checkout` → URI) · change-stream capture with transaction grouping (`argon watch`) · `argon undo` with per-actor conflict detection · real-driver workloads (pymongo, mongoose) verified against WAL convergence in CI on every push | ✅ |
-| **M4 · Merge & diff** | `argon diff` · three-way merges as persisted, reviewable plans (`argon merge preview/apply`) · conflicts never silent · merges undoable like any range | ✅ |
-| **M5 · Agent ecosystem** | MCP server (13 tools, supervised ingesters) · TTL sandboxes · dataset pins for reproducible evals (`argon pin`) · REST control plane · LangGraph checkpointer + Mem0 factory ([argon-agents](https://github.com/argon-lab/argon-agents)) | ✅ |
-| **Beyond** | Wire-protocol proxy: stable `mongodb://proxy/<project>~<branch>` connection strings (`argon proxy`) | ✅ |
+| **Branching** | `argon branches create` | a metadata write — instant, zero copy |
+| **Real databases** | `argon checkout` / `argon proxy` | any driver, real mongod; proxy serves stable `mongodb://host/<project>~<branch>` URIs |
+| **Write capture** | `argon watch` | change-stream → versioned history, per-actor attribution |
+| **Time travel** | `argon time-travel query` | any historical state, by LSN or timestamp |
+| **Undo** | `argon undo --actor <a>` | revert a range or one writer's changes; append-only, conflict-aware |
+| **Restore** | `argon restore preview/reset/branch` | rewind a branch or fork history; recorded, never destructive |
+| **Data PRs** | `argon merge preview/apply` | three-way merges as reviewable plans; conflicts never silent |
+| **Sandboxes** | `argon sandbox create --ttl 1h` | fork + checkout + TTL in one step — disposable agent workspaces |
+| **Dataset pins** | `argon pin create` / `pin sandbox` | immutable named states that survive GC and resets — reproducible evals |
+| **Web console** | `argon console` | local UI + REST API in one command |
 
-Planned next: GCS chunk-store backend; synchronous capture in the wire
-proxy. Honest limitations are listed in
-[ARCHITECTURE.md](docs/ARCHITECTURE.md#known-limitations-and-roadmap).
+Storage stays bounded: snapshots + retention-window GC keep state plus a
+window of history, not every write forever. Details and the consistency
+model, stated honestly: [ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
-## How it works
+## For AI agents
 
-One deterministic, physical write-ahead log per project. Entries carry full
-document images (zstd-compressed), so replay is a pure fold — the same
-prefix always materializes the same state, byte for byte, property-tested in
-CI. Branches are `(parent, fork LSN, head LSN)` pointers; snapshots are
-content-addressed chunks that bound replay depth (and deduplicate across
-branches); GC reclaims what snapshots cover and retention allows, and never
-touches history that a live branch, a pin, or an uncovered read still
-needs.
+```bash
+claude mcp add argon -- argon mcp        # 13 tools: sandbox, diff, merge, undo, pins
+pip install argon-agents                 # LangGraph checkpointer + Mem0, over REST
+```
 
-The full design — including the consistency model, stated honestly — is in
-[ARCHITECTURE.md](docs/ARCHITECTURE.md).
+```python
+saver = ArgonCheckpointSaver.from_sandbox(argon, "myapp")   # checkpoint on a disposable branch
+saver.merge()                                               # adopt the run — or .discard()
+
+argon.create_pin("myapp", "eval-v1")                        # pin the dataset once
+run = argon.sandbox_from_pin("myapp", "eval-v1")            # identical state, every eval run
+```
+
+The full agent workflow: [docs/AGENTS.md](docs/AGENTS.md).
 
 ## Documentation
 
 | | |
 |---|---|
-| [Quick start](docs/QUICK_START.md) | Install to first merge in ten minutes |
-| [CLI reference](docs/CLI.md) | Every command, honestly described |
-| [Architecture](docs/ARCHITECTURE.md) | How the engine works and what it guarantees |
-| [Agents](docs/AGENTS.md) | Sandboxes, pins, MCP server, REST API, argon-agents |
-| [Operations](docs/OPERATIONS.md) | Deployment, chunk stores, GC, v1→v2 migration |
-| [Performance](docs/PERFORMANCE.md) | Where the numbers live and how to reproduce them |
+| [Quick start](docs/QUICK_START.md) | install → first merge, step by step |
+| [CLI reference](docs/CLI.md) | every command |
+| [Agents](docs/AGENTS.md) | sandboxes, pins, MCP, REST API, argon-agents, proxy |
+| [Architecture](docs/ARCHITECTURE.md) | how it works and what it guarantees |
+| [Operations](docs/OPERATIONS.md) | deployment, chunk stores (S3/FS), GC, v1→v2 migration |
+| [Performance](docs/PERFORMANCE.md) | every number lives in the [reproducible benchmarks](https://github.com/argon-lab/benchmarks) — none here, by policy |
 
 ## Community
 
-- 🐛 [Issues](https://github.com/argon-lab/argon/issues)
-- 💬 [Discussions](https://github.com/argon-lab/argon/discussions)
-- 🏗️ [Contributing](CONTRIBUTING.md)
-- 📧 [argonlabs.tech](https://www.argonlabs.tech)
+[Issues](https://github.com/argon-lab/argon/issues) ·
+[Discussions](https://github.com/argon-lab/argon/discussions) ·
+[Contributing](CONTRIBUTING.md) ·
+[argonlabs.tech](https://www.argonlabs.tech)
 
 ---
 
 <div align="center">
 
-**Give your MongoDB a time machine. Branch without fear.**
-
-⭐ **Star us** if Argon saves your day!
+**Give your MongoDB a time machine. Branch without fear.** ⭐
 
 </div>

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,73 +1,73 @@
 # Argon for AI agents
 
-Agents write to databases with confidence and no memory of consequences.
-Argon's answer is to make every agent write *versioned*: give the agent a
-real MongoDB database that is actually a disposable branch, review what it
-did as a diff, merge what's good, undo what isn't, and reproduce any run
-from a pinned dataset.
+Give the agent a real MongoDB database that is secretly a disposable
+branch. Review what it did as a diff. Merge the good, undo the bad,
+reproduce any run from a pinned dataset.
 
-Four surfaces expose the same engine — pick by integration point:
+```
+pin ──▶ sandbox (TTL) ──▶ agent writes via any driver ──▶ diff
+                                                           │
+                              merge (data PR) ◀────────────┴──▶ undo / discard
+```
+
+Four surfaces, one engine — pick by integration point:
 
 | Surface | Start it | For |
 |---|---|---|
 | CLI | `argon sandbox`, `argon pin`, … | humans, scripts, CI |
-| MCP server | `argon mcp` (stdio) | Claude/Cursor/any MCP client |
-| REST API | `go run ./api` (port 8080) | language SDKs, services |
+| MCP server | `argon mcp` (stdio) | Claude / Cursor / any MCP client |
+| REST API + console | `argon console` (or `go run ./api`) | language SDKs, browsers |
 | Wire proxy | `argon proxy` | stable per-branch connection strings |
 
 ## Sandboxes
 
-A sandbox is a branch forked from a parent, checked out into its own
-physical MongoDB database, and stamped with a TTL:
+Fork + checkout + TTL, one step:
 
 ```bash
 argon sandbox create -p myapp --ttl 1h
 # → connection string; hand it to the agent, any driver works
 ```
 
-Every write the agent makes is captured as versioned history (the MCP and
-REST servers run the capture ingester for you; with the bare CLI, run
-`argon watch`). Then:
+MCP and REST sandboxes capture writes automatically (supervised
+ingesters); with the bare CLI, run `argon watch`. Then:
 
-- `argon diff` — see exactly what the agent changed
-- `argon merge preview/apply` — adopt it, as a reviewable data PR
-- `argon undo --actor <agent>` — revert one writer's changes, refusing
-  documents someone else touched since
-- `argon sandbox discard` / TTL expiry — throw it away; storage reclaimed
+```bash
+argon diff -p myapp -b <sandbox>              # exactly what the agent changed
+argon merge preview/apply …                   # adopt it — a reviewable data PR
+argon undo … --actor <agent>                  # revert one writer, conflict-aware
+argon sandbox discard …                       # or let the TTL reclaim it
+```
 
-## Pins: reproducible eval datasets
+## Pins — reproducible evals
 
-A pin is a named, immutable reference to a branch state that survives
-garbage collection and resets forever:
+A pin is a named, immutable branch state that survives GC and resets
+forever:
 
 ```bash
 argon pin create  -p myapp --name eval-v1 --note "golden dataset"
-argon pin sandbox -p myapp --name eval-v1     # fresh sandbox per eval run
+argon pin sandbox -p myapp --name eval-v1     # fresh sandbox per run
 ```
 
-Pin the dataset once, fork a sandbox from the pin for every run: identical
-input state on every run, no matter what happened to the branch since —
-including resets. Delete the pin to release its history to GC.
+Pin once, fork per run: identical input state every time, no matter what
+happened to the branch since. Delete the pin to release its history.
 
-## The MCP server
+## MCP server
 
 ```bash
 claude mcp add argon -- argon mcp
 ```
 
-Thirteen tools over stdio: `argon_sandbox_create` / `argon_sandbox_discard`
-/ `argon_sandbox_keep`, `argon_branch_list`, `argon_connect`, `argon_diff`,
-`argon_merge_preview` / `argon_merge_apply`, `argon_undo`,
-`argon_snapshot_create`, `argon_pin_create` / `argon_pin_list` /
-`argon_pin_sandbox`. The server supervises a change-stream ingester for
-every sandbox it hands out, so agent writes become history without any
-extra process.
+Thirteen tools: sandbox create/discard/keep · branch list · connect ·
+diff · merge preview/apply · undo · snapshot create · pin create/list/
+sandbox. The server runs a capture ingester for every sandbox it hands
+out — no extra process.
 
-## The REST control plane
+## REST control plane
 
-`api/` serves the same workflow over HTTP for language SDKs (default
-`:8080`, `PORT` to change). Control plane only — data flows through the
-MongoDB connection strings it returns.
+`argon console` serves the REST API plus a web UI locally (binds
+127.0.0.1, opens your browser); `go run ./api` serves the API alone
+(default `:8080`, `PORT` to change). Control plane only — data flows
+through the MongoDB connection strings it returns.
 
 ```
 POST   /api/v1/projects                                {name}
@@ -103,20 +103,13 @@ GET    /api/v1/status/ingesters
 ```
 
 Sandbox-creating endpoints start a supervised ingester; errors return
-`{"error": "..."}` with a meaningful status.
+`{"error": "..."}` with a meaningful status. Optional switches, all off
+by default: `ARGON_API_TOKEN` (Bearer auth on every `/api` endpoint
+except `/meta`), `ARGON_READ_ONLY=1`, `ARGON_CORS_ORIGINS`.
 
-Cross-cutting switches, all off by default: `ARGON_API_TOKEN` requires
-`Authorization: Bearer <token>` on every `/api` endpoint except `/meta`;
-`ARGON_READ_ONLY=1` rejects writes; `ARGON_CORS_ORIGINS` narrows browser
-origins (default: any). The server also serves the web console UI at `/`
-when one is bundled (`scripts/sync-ui.sh`) — `argon console` is the
-one-command local wrapper: it binds to localhost and opens the browser.
+## Python — argon-agents
 
-## Python: argon-agents
-
-[argon-lab/argon-agents](https://github.com/argon-lab/argon-agents) wraps
-the REST API for agent frameworks
-(`pip install argon-agents` — add `[langgraph]` for the checkpointer):
+`pip install argon-agents` (add `[langgraph]` for the checkpointer):
 
 ```python
 from argon_agents import ArgonClient, ArgonCheckpointSaver
@@ -126,9 +119,8 @@ argon = ArgonClient("http://localhost:8080")
 # LangGraph: the official MongoDB checkpointer on a sandboxed branch
 saver = ArgonCheckpointSaver.from_sandbox(argon, "myapp", ttl_minutes=60)
 graph = builder.compile(checkpointer=saver)
-...
-saver.fork(argon)        # branch the whole checkpoint history
-saver.merge()            # adopt the run   — or saver.discard()
+saver.fork(argon)     # branch the whole checkpoint history
+saver.merge()         # adopt the run — or saver.discard()
 
 # Mem0: sandboxed agent memory
 from argon_agents import sandboxed_mem0_config
@@ -139,23 +131,20 @@ argon.create_pin("myapp", "eval-v1")
 run = argon.sandbox_from_pin("myapp", "eval-v1")
 ```
 
-LangGraph's checkpoint ids give step-level rewind *within* a thread;
-Argon adds branch-level fork/merge/undo/audit *across* the whole store.
+LangGraph's checkpoint ids rewind steps *within* a thread; Argon adds
+fork/merge/undo/audit *across* the whole store.
 
-## The wire proxy
+## Wire proxy
 
-Checked-out branches get machine-named physical databases
-(`argon_br_<id>`). `argon proxy` gives them stable, human-readable
-connection strings instead:
+Checked-out branches get machine-named physical databases. `argon proxy`
+serves stable, human-readable URIs instead:
 
 ```
 mongodb://proxy-host:27018/<project>~<branch>?directConnection=true
 ```
 
-The proxy rewrites each command's `$db` to the branch's physical database
-and forwards everything else byte-for-byte; mongod still evaluates every
-query. Constraints, honestly: `directConnection=true` is required,
-compression is negotiated away, use `authSource=admin` with auth, and
-unresolvable aliases return a clean command error naming the proxy.
-Capture stays asynchronous — run `argon watch` (or use API/MCP sandboxes)
-for the branch behind the alias.
+The proxy rewrites each command's `$db` to the branch's physical database;
+mongod still evaluates every query. Constraints: `directConnection=true`
+required, compression negotiated away, `authSource=admin` with auth,
+unresolvable aliases return a clean command error. Capture stays
+asynchronous — run `argon watch` (or use API/MCP sandboxes) behind it.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,41 +1,35 @@
 # CLI reference
 
-Every command talks to the MongoDB deployment named by `MONGODB_URI`
-(default `mongodb://localhost:27017`); Argon's metadata lives in the
-`argon_wal` database there. Shared flags: `-p/--project`, `-b/--branch`
-(default `main`), `-o/--output table|json|yaml`.
+Every command talks to `MONGODB_URI` (default `mongodb://localhost:27017`);
+metadata lives in the `argon_wal` database. Shared flags: `-p/--project`,
+`-b/--branch` (default `main`), `-o/--output table|json|yaml`.
 
-## Projects and branches
+## Projects & branches
 
 ```
-argon projects create <name>          Create a project (with a main branch)
+argon projects create <name>                   project + main branch
 argon projects list
-argon branches create <name> -p P [--from B]   A metadata write, no data copy
-argon branches list -p P
-argon branches delete <name> -p P     Refused for main, for branches with
-                                      live children, and for pinned branches
+argon branches create <name> -p P [--from B]   instant — a pointer, no copy
+argon branches list   -p P
+argon branches delete <name> -p P              refused for main, branches with
+                                               live children, pinned branches
 ```
 
-## Working with real MongoDB databases
+## Work with real databases
 
 ```
-argon checkout -p P -b B    Materialize the branch into a physical MongoDB
-                            database and print its connection string.
-                            Re-running refreshes to the branch's WAL state.
-argon connect  -p P -b B    Print the connection string of a checked-out branch
-argon watch    -p P -b B    Capture the branch's direct writes into the WAL
-                            (change stream; keep it running while you write)
-argon release  -p P -b B    Drop the physical database; the WAL keeps history
-argon proxy [--listen :27018]
-                            Wire-protocol proxy: clients connect to
-                            mongodb://host:27018/<project>~<branch>
-                            (directConnection=true) and are routed to the
-                            branch's physical database
+argon checkout -p P -b B      materialize into a physical MongoDB database,
+                              print its URI (re-run to refresh)
+argon connect  -p P -b B      print a checked-out branch's URI
+argon watch    -p P -b B      capture direct writes into history (keep running)
+argon release  -p P -b B      drop the physical db; history stays
+argon proxy [--listen :27018] stable URIs: mongodb://host/<project>~<branch>
+argon console [--port 1818]   local web console (REST API + UI), opens browser
 ```
 
-While a branch is checked out, its WAL is fed by `watch` (or the API/MCP
-server's supervised ingesters); programmatic SDK writes to it are refused
-to keep one source of truth.
+While a branch is checked out, its history is fed by `watch` (or the
+API/MCP servers' ingesters); SDK writes to it are refused — one source of
+truth.
 
 ## Import ("git clone")
 
@@ -45,8 +39,7 @@ argon import database --uri U --database D --project P [--dry-run] [--yes]
 argon import status
 ```
 
-Import writes every document as versioned history and snapshots the result
-automatically, so subsequent reads don't replay the whole import.
+Imports auto-snapshot, so reads never replay the whole import.
 
 ## History: time travel, undo, restore
 
@@ -55,78 +48,63 @@ argon time-travel info  -p P -b B
 argon time-travel query -p P -b B --lsn N [-c collection]
 
 argon undo -p P -b B --from-lsn N [--to-lsn M] [--actor A] [--dry-run]
-        Revert a range by restoring pre-images — append-only compensations,
-        never rewritten history. With --actor, reverts one writer's changes
-        and refuses documents that someone else touched since.
+    Revert a range by restoring pre-images — append-only, never rewrites
+    history. --actor reverts one writer and refuses documents someone
+    else touched since.
 
 argon restore preview -p P -b B (--lsn N | --time RFC3339)
 argon restore reset   -p P -b B (--lsn N | --time RFC3339) [--backup NAME]
-        Rewind the branch head. Recorded, not destructive: discarded
-        entries stay for audit; --backup forks the pre-reset head first.
+    Rewind the head. Recorded, not destructive: discarded entries stay
+    for audit; --backup forks the pre-reset head first.
 argon restore branch  -p P -b B (--lsn N | --time RFC3339) --as NAME
-        Fork the historical state into a new branch instead.
+    Fork the historical state into a new branch instead.
 ```
 
 ## Merge — data pull requests
 
 ```
-argon diff          -p P -b B      What merging B into its parent would change
-argon merge preview -p P -b B      Compute and persist a reviewable plan
+argon diff          -p P -b B                  what merging B would change
+argon merge preview -p P -b B                  persist a reviewable plan
 argon merge apply <plan-id> [--strategy theirs|ours]
 argon merge list    -p P
 ```
 
-Plans apply exactly once and refuse stale parent heads. Conflicts (both
-sides changed the same document since the fork) fail loudly unless a
-strategy resolves them; every merge is one WAL entry range, undoable like
-any other.
+Plans apply exactly once and refuse stale parent heads; conflicts fail
+loudly unless a strategy resolves them. Merges are undoable like any range.
 
 ## Pins — immutable datasets
 
 ```
-argon pin create  -p P [-b B] --name N [--lsn L | --time T] [--note ...]
+argon pin create  -p P [-b B] --name N [--lsn L | --time T] [--note …]
 argon pin list    -p P
 argon pin delete  -p P --name N
-argon pin branch  -p P --name N --as NEW       Durable branch from the pin
+argon pin branch  -p P --name N --as NEW       durable branch from the pin
 argon pin sandbox -p P --name N [--ttl 1h]     TTL sandbox from the pin
 ```
 
-A pin names a branch state and keeps it materializable forever: GC never
-reclaims what a pinned read needs, and resets can't disturb it. Pin an
-eval dataset once; fork a sandbox per run; every run starts identical.
+Pinned states survive GC and resets forever — pin an eval dataset once,
+fork a sandbox per run, get identical input every time.
 
 ## Sandboxes — disposable agent branches
 
 ```
-argon sandbox create -p P [--from B] [--name N] [--ttl 1h]
+argon sandbox create -p P [--from B] [--name N] [--ttl 1h]   fork+checkout+TTL
 argon sandbox list / discard / keep / sweep
 ```
 
-`create` forks, checks out and TTL-stamps in one step and prints the
-connection string. `sweep` reaps expired sandboxes (pinned ones are
-skipped loudly); `keep` removes the TTL.
+`sweep` reaps expired sandboxes (pinned ones skipped loudly); `keep`
+removes the TTL.
 
-## Snapshots and GC
+## Snapshots, GC, agents, migration
 
 ```
-argon snapshot create -p P -b B      Manual snapshot (they're also automatic)
+argon snapshot create -p P -b B     manual (they're also automatic)
 argon snapshot list   -p P -b B
 argon gc -p P [--retention 168h] [--dry-run]
-```
+    Reclaim entries covered by snapshots, outside retention, and needed
+    by no live child or pin. No snapshot → nothing is ever deleted.
 
-Snapshots bound replay depth; GC deletes WAL entries that are covered by
-snapshots, outside the retention window, and needed by no live child or
-pin. No snapshot → nothing is ever deleted.
-
-## Agents and migration
-
-```
-argon mcp                 Serve the sandbox/merge/undo/pin workflow over the
-                          Model Context Protocol (stdio); supervises an
-                          ingester for every sandbox it hands out
-argon console [--port 1818] [--host 127.0.0.1] [--no-browser]
-                          Serve the web console (REST API + UI) against your
-                          local engine and open it in a browser
-argon migrate-wal --project P [--dry-run]    v1 → v2 WAL schema migration
-argon status / metrics    Health and performance counters
+argon mcp                           MCP server over stdio (13 tools)
+argon migrate-wal --project P [--dry-run]      v1 → v2 schema migration
+argon status / metrics              health and performance counters
 ```

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,105 +1,85 @@
 # Quick start
 
-From install to your first merged branch in about ten minutes.
+Install → first merged branch, step by step.
 
-## 1. Install
-
-```bash
-brew install argon-lab/tap/argonctl     # macOS
-npm install -g argonctl                  # cross-platform
-
-# or from source
-git clone https://github.com/argon-lab/argon
-cd argon/cli && go build -o argon .
-```
-
-## 2. MongoDB (replica set required)
-
-Argon captures writes through change streams, which MongoDB only serves on
-replica sets. A single-node replica set is fine for development:
+## 1 · Install + MongoDB
 
 ```bash
+brew install argon-lab/tap/argonctl      # or: npm install -g argonctl
+
+# MongoDB must be a replica set (change streams); one node is fine:
 docker run -d --name argon-mongo -p 27017:27017 mongo:7 --replSet rs0
-docker exec argon-mongo mongosh --quiet --eval \
-  'rs.initiate({_id:"rs0", members:[{_id:0, host:"localhost:27017"}]})'
+docker exec argon-mongo mongosh --quiet --eval 'rs.initiate()'
 ```
 
 Argon connects to `MONGODB_URI` (default `mongodb://localhost:27017`) and
 keeps its metadata in the `argon_wal` database.
 
-## 3. Import an existing database ("git clone")
+## 2 · Bring your data in
 
 ```bash
-argon import preview  --uri mongodb://localhost:27017 --database myapp
 argon import database --uri mongodb://localhost:27017 --database myapp --project myapp
+# starting fresh instead: argon projects create myapp
 ```
 
-Every document becomes versioned history on the project's `main` branch,
-and a snapshot is taken automatically so reads never replay the whole
-import. (Starting fresh instead: `argon projects create myapp`.)
+Every document becomes versioned history on `main`; a snapshot is taken
+automatically so reads never replay the whole import.
 
-## 4. Branch and work with any driver
+## 3 · Branch and work with any driver
 
 ```bash
-argon branches create experiment -p myapp     # a metadata write — instant
-argon checkout -p myapp -b experiment         # materialize into a real MongoDB db
-argon watch    -p myapp -b experiment         # capture writes as history (keep running)
+argon branches create experiment -p myapp   # instant — a pointer, no copy
+argon checkout -p myapp -b experiment       # → prints a MongoDB URI
+argon watch    -p myapp -b experiment       # captures writes (keep running)
 ```
 
-`checkout` prints a connection string. Point pymongo, mongoose, mongosh —
-anything — at it and work normally: real indexes, aggregation,
-transactions, all evaluated by mongod itself. While `watch` runs, every
-write becomes a WAL entry attributed to its actor.
+Point pymongo, mongoose, mongosh — anything — at the URI and work
+normally: real indexes, aggregation, transactions. Every write becomes
+history, attributed to its actor.
 
-Prefer stable connection strings? `argon proxy` serves
-`mongodb://<host>:27018/<project>~<branch>?directConnection=true` and
-routes to the branch's physical database (see
-[AGENTS.md](AGENTS.md#the-wire-proxy)).
+Want stable URIs instead of per-checkout ones? `argon proxy` serves
+`mongodb://host:27018/<project>~<branch>?directConnection=true`.
+Prefer a UI? `argon console` opens a local web console.
 
-## 5. Review and merge — a data pull request
+## 4 · Review and merge — a data pull request
 
 ```bash
-argon diff          -p myapp -b experiment    # what would change
-argon merge preview -p myapp -b experiment    # persist a reviewable plan
-argon merge apply <plan-id>                   # exactly-once, refuses stale heads
+argon diff          -p myapp -b experiment   # what would change
+argon merge preview -p myapp -b experiment   # persist a reviewable plan
+argon merge apply <plan-id>                  # exactly-once; stale heads refused
 ```
 
-Conflicts are never resolved silently: `apply` fails and names them;
-resolve with `--strategy theirs|ours` or fix the data and re-preview.
+Conflicts fail loudly; resolve with `--strategy theirs|ours` or fix the
+data and re-preview.
 
-## 6. Time travel, undo, restore
+## 5 · Time travel, undo, rewind
 
 ```bash
-argon time-travel info  -p myapp -b main
 argon time-travel query -p myapp -b main --lsn 1000
 
-# Revert a range (or one actor's writes) with append-only compensations
-argon undo -p myapp -b main --from-lsn 990 --to-lsn 1000 --dry-run
+argon undo -p myapp -b main --from-lsn 990 --dry-run          # revert a range
+argon undo -p myapp -b main --from-lsn 990 --actor agent-7    # …or one writer
 
-# Rewind the whole branch — preview first, keep a backup fork
 argon restore preview -p myapp -b main --time 2026-07-07T09:00:00Z
 argon restore reset   -p myapp -b main --time 2026-07-07T09:00:00Z --backup pre-incident
 ```
 
-Resets are recorded, not destructive: discarded entries stay in the WAL
-for audit, and the backup branch (or any pin) keeps the old state
-readable.
+Resets are recorded, not destructive: discarded entries stay for audit,
+and the backup branch (or any pin) keeps the old state readable.
 
-## 7. For agents
+## 6 · For agents
 
 ```bash
-claude mcp add argon -- argon mcp        # sandboxes, diff/merge, undo, pins as MCP tools
-argon sandbox create -p myapp --ttl 1h   # disposable branch + connection string
-argon pin create -p myapp --name eval-v1 # immutable dataset for reproducible evals
-argon pin sandbox -p myapp --name eval-v1
+claude mcp add argon -- argon mcp           # sandboxes/diff/merge/undo/pins as MCP tools
+argon sandbox create -p myapp --ttl 1h      # disposable branch + URI, one step
+argon pin create  -p myapp --name eval-v1   # immutable dataset state
+argon pin sandbox -p myapp --name eval-v1   # identical input, every eval run
 ```
 
-The full agent workflow — sandboxes, pins, the REST control plane and the
-Python adapters — is in [AGENTS.md](AGENTS.md).
+Full agent workflow (MCP, REST, Python): [AGENTS.md](AGENTS.md).
 
 ## Where next
 
-- [CLI.md](CLI.md) — every command
-- [ARCHITECTURE.md](ARCHITECTURE.md) — what the engine guarantees, honestly
-- [OPERATIONS.md](OPERATIONS.md) — snapshot stores (S3/filesystem), GC and
-  retention, v1→v2 migration
+[CLI.md](CLI.md) — every command ·
+[ARCHITECTURE.md](ARCHITECTURE.md) — guarantees, honestly ·
+[OPERATIONS.md](OPERATIONS.md) — S3 snapshots, GC, migration

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,26 @@
 # Argon documentation
 
-Argon is a version-control engine for MongoDB: branches, time travel,
-merges and undo over a deterministic write-ahead log, with real MongoDB
-databases as the working surface.
+Argon versions MongoDB the way Git versions code: branch → work with any
+driver → diff → merge or undo, with real MongoDB databases as the working
+surface and versioned history underneath.
 
 Reading order:
 
-1. **[QUICK_START.md](QUICK_START.md)** — install to first merge in ten
-   minutes: import, branch, checkout, capture, merge, rewind.
-2. **[CLI.md](CLI.md)** — the command reference.
-3. **[AGENTS.md](AGENTS.md)** — the agent workflow: TTL sandboxes, dataset
-   pins for reproducible evals, the MCP server, the REST control plane,
-   the wire proxy, and the
-   [argon-agents](https://github.com/argon-lab/argon-agents) Python
-   package (LangGraph, Mem0).
-4. **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the engine works: the WAL,
-   branches and ancestry, snapshots, GC, merge, the consistency model
-   stated honestly, and known limitations.
+1. **[QUICK_START.md](QUICK_START.md)** — install → first merge, step by
+   step.
+2. **[CLI.md](CLI.md)** — every command.
+3. **[AGENTS.md](AGENTS.md)** — the agent flow: TTL sandboxes, dataset
+   pins for reproducible evals, MCP server, REST API + web console,
+   [argon-agents](https://github.com/argon-lab/argon-agents) (LangGraph,
+   Mem0), wire proxy.
+4. **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the engine works: the
+   WAL, branches, snapshots, GC, merge, the consistency model stated
+   honestly, known limitations.
 5. **[OPERATIONS.md](OPERATIONS.md)** — running it: replica-set
-   requirement, snapshot chunk-store backends (MongoDB/S3/filesystem),
-   retention and GC, migrating v1 data.
+   requirement, snapshot chunk stores (MongoDB/S3/filesystem), retention
+   and GC, migrating v1 data.
 6. **[PERFORMANCE.md](PERFORMANCE.md)** — a pointer, deliberately: every
-   performance number lives in the reproducible
+   number lives in the reproducible
    [benchmark suite](https://github.com/argon-lab/benchmarks), nowhere
    else.
 


### PR DESCRIPTION
Second documentation pass, orthogonal to #32: that one made the docs *true*, this one makes them *fast to follow*.

The bar: a reader grasps Argon in thirty seconds and is running commands within one screen.

- **README** — three-idea opener (branch = pointer / checkout = real MongoDB / nothing lost), install with the replica-set one-liner inline, an ASCII flow diagram, the four-step happy path, and a what-you-get table where every row is *feature + command*. The M1–M5 milestone table is gone: it narrated our rebuild history, not the product; CHANGELOG holds that story.
- **QUICK_START** — six numbered steps, commands first, one sentence each.
- **CLI** — prose tightened; `argon console` added.
- **AGENTS** — opens with the pin → sandbox → diff → merge/undo flow; prose halved; the full REST endpoint table, console/auth switches, and proxy constraints from #38 all kept intact.

No facts added or removed; link check clean; performance numbers still live only in the benchmarks repo.