### PR TITLE
ingest: survive control-plane restarts without losing capture

### DIFF
--- a/api/server/api_test.go
+++ b/api/server/api_test.go
@@ -418,6 +418,71 @@ func TestAPI_TokenReadOnlyAndCORS(t *testing.T) {
 	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
 }
 
+func TestAPI_RestartReattachesIngesters(t *testing.T) {
+	dbName := fmt.Sprintf("argon_api_restart_test_%d", time.Now().UnixNano())
+	services, err := walcli.NewServicesAt("mongodb://localhost:27017", dbName)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = services.Client.Database(dbName).Drop(context.Background())
+	})
+
+	router := NewRouter(services)
+	code, _ := do(t, router, "POST", "/api/v1/projects", map[string]string{"name": "restart-test"})
+	require.Equal(t, http.StatusCreated, code)
+	code, resp := do(t, router, "POST", "/api/v1/projects/restart-test/branches/main/checkout", nil)
+	require.Equal(t, http.StatusOK, code, "%v", resp)
+	connStr := resp["connection_string"].(string)
+	t.Cleanup(func() {
+		branch, err := services.Branches.GetBranch(mustProjectID(t, services, "restart-test"), "main")
+		if err == nil && branch.PhysicalDB != "" {
+			_ = services.Client.Database(branch.PhysicalDB).Drop(context.Background())
+		}
+	})
+
+	// Wait for the ingester to checkpoint its stream position, then the
+	// process "dies": supervision is gone, the branch stays live.
+	state := services.Client.Database(dbName).Collection("wal_ingest_state")
+	deadlineToken := time.Now().Add(10 * time.Second)
+	for {
+		n, err := state.CountDocuments(context.Background(), bson.M{})
+		require.NoError(t, err)
+		if n > 0 {
+			break
+		}
+		require.True(t, time.Now().Before(deadlineToken), "ingester never checkpointed")
+		time.Sleep(100 * time.Millisecond)
+	}
+	router.Shutdown()
+
+	// A write lands while nobody is watching.
+	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(connStr))
+	require.NoError(t, err)
+	defer func() { _ = client.Disconnect(context.Background()) }()
+	_, err = client.Database(dbFromURI(connStr)).Collection("notes").
+		InsertOne(context.Background(), bson.M{"_id": "orphan", "text": "written while down"})
+	require.NoError(t, err)
+
+	// A new router re-attaches and catches up from the resume token.
+	router2 := NewRouter(services)
+	t.Cleanup(router2.Shutdown)
+	projectID := mustProjectID(t, services, "restart-test")
+	branch, err := services.Branches.GetBranch(projectID, "main")
+	require.NoError(t, err)
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		b, err := services.Branches.GetBranchByID(branch.ID)
+		require.NoError(t, err)
+		entries, err := services.WAL.GetBranchEntries(branch.ID, "notes", 0, b.HeadLSN)
+		require.NoError(t, err)
+		if len(entries) >= 1 {
+			break
+		}
+		require.True(t, time.Now().Before(deadline),
+			"restarted router never caught up on the unsupervised write")
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 func mustProjectID(t *testing.T, services *walcli.Services, name string) string {
 	t.Helper()
 	p, err := services.Projects.GetProjectByName(name)

--- a/api/server/router.go
+++ b/api/server/router.go
@@ -107,7 +107,33 @@ func NewRouterWith(services *walcli.Services, opts Options) *Router {
 		v1.POST("/projects/:project/branches/:branch/snapshots", r.createSnapshot)
 	}
 	r.mountUI()
+	r.superviseLiveBranches()
 	return r
+}
+
+// superviseLiveBranches re-attaches an ingester to every branch that was
+// checked out when a previous process exited — supervision is in-memory,
+// so a restart would otherwise leave live branches capturing nothing.
+// Ingestion resumes from the persisted resume token, so writes made while
+// unsupervised are caught up (at-least-once), not lost.
+func (r *Router) superviseLiveBranches() {
+	projects, err := r.services.Projects.ListProjects()
+	if err != nil {
+		log.Printf("api: cannot list projects to re-attach ingesters: %v", err)
+		return
+	}
+	for _, p := range projects {
+		branches, err := r.services.Branches.ListBranches(p.ID)
+		if err != nil {
+			log.Printf("api: cannot list branches for project %s: %v", p.Name, err)
+			continue
+		}
+		for _, b := range branches {
+			if b.IsLive() {
+				r.startIngester(b.ID)
+			}
+		}
+	}
 }
 
 // Shutdown stops every supervised ingester.

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -110,6 +110,14 @@ func (s *Service) Run(ctx context.Context, branchID string, opts ...RunOption) e
 		close(cfg.ready)
 	}
 
+	// Checkpoint the stream position immediately. Without a persisted
+	// token a later restart would open the stream at "now" and silently
+	// skip whatever landed while unsupervised; with this checkpoint the
+	// capture gap closes at stream open instead of at the first event.
+	if err := s.flush(branch, nil, stream.ResumeToken()); err != nil {
+		return err
+	}
+
 	batch := make([]*wal.Entry, 0, maxBatch)
 	for {
 		if ctx.Err() != nil {


### PR DESCRIPTION
Found driving the web console (C2) end to end: I applied a merge plan into a live `main` right after restarting the server — the physical database updated, but the WAL never heard about it. Supervision of ingesters is in-memory, so a restart leaves every live branch capturing nothing.

Two halves, both small:

1. **Re-attach at startup** (`api/server`): the router lists live branches and starts an ingester for each, resuming from the persisted resume token — writes made while unsupervised are caught up, at-least-once.
2. **Checkpoint at stream open** (`internal/ingest`): a branch with no captured writes yet had no persisted token, so a restarted stream opened at "now" and silently skipped the unsupervised window. `Run` now persists the initial resume token as soon as the stream opens (`flush` with an empty batch), closing the gap at stream open instead of at the first event.

New test: checkout → wait for checkpoint → shut the router down → write through the driver while nobody watches → new router catches the orphan write. Full `tests/wal` and `api/server` suites green against a local replica set.