### PR TITLE
Roadmap: reframe proxy 'synchronous capture' as a read-your-writes barrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Planned: GCS chunk-store backend; synchronous capture in the wire proxy.
+Planned: GCS chunk-store backend; an opt-in read-your-writes barrier in
+the wire proxy (hold a write's ack until the ingester confirms the WAL
+entry — a synchronization barrier, not in-proxy capture).
 
 ## [2.0.0] - 2026-07-07
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -275,8 +275,12 @@ explicit because the URI database is the alias. Aliases that don't resolve
 (unknown project/branch, or a branch that isn't checked out) get a
 synthesized `{ok: 0}` command error naming the proxy, not a dropped
 connection. Capture stays asynchronous through the change-stream ingester
-— the proxy is deliberately only the routing layer, though it is the
-natural place synchronous capture would live one day.
+— the proxy is deliberately only the routing layer. It is the natural
+place to one day close the ingest-lag window (see the roadmap), but not
+by parsing writes: the change stream already hands the ingester
+before/after images, transaction resolution and mongod's commit order for
+free, and re-deriving those in the proxy would mean reimplementing
+MongoDB write semantics — the one thing this design refuses to do.
 
 ## Migration from schema v1
 
@@ -327,8 +331,21 @@ ingester, plus WAL-convergence verification), and the LangGraph
 checkpointer / Mem0 factory ship as the `argon-agents` Python package on
 top of the REST API.
 
-Planned next: GCS chunk-store backend; synchronous capture in the wire
-proxy.
+Planned next:
+
+- **GCS chunk-store backend** — a third cloud object store alongside
+  S3-compatible and filesystem.
+- **A read-your-writes barrier in the wire proxy** — an opt-in mode where
+  the proxy holds a write's acknowledgement until the change-stream
+  ingester confirms the entry has landed in the WAL, giving callers zero
+  effective ingest lag (immediate `diff`/materialize after a write) and
+  strict "no write exists that isn't logged" semantics. This is
+  deliberately a *synchronization barrier*, not synchronous capture: the
+  proxy still never parses writes or owns images — the ingester remains
+  the single capture path — so it stays cheap and keeps mongod as the only
+  query engine. It does not remove the replica-set requirement (change
+  streams still do the capturing); dropping that would require true
+  in-proxy capture, which we are not planning.
 
 ## Storage collections
 

--- a/internal/wireproxy/proxy.go
+++ b/internal/wireproxy/proxy.go
@@ -22,8 +22,12 @@
 //     is the URI database, which is the alias, and SCRAM must run against
 //     a real database.
 //   - Capture stays asynchronous (the change-stream ingester); the proxy
-//     does not intercept writes. Synchronous capture would live here one
-//     day — this is deliberately only the routing layer.
+//     does not intercept writes and never will — the change stream hands
+//     the ingester before/after images and mongod's commit order for free,
+//     and re-deriving those here would mean reimplementing MongoDB write
+//     semantics. A planned opt-in mode would hold a write's ack until the
+//     ingester confirms the WAL entry (a synchronization barrier for
+//     read-your-writes), which needs none of that parsing.
 package wireproxy
 
 import (


### PR DESCRIPTION
Follow-up to a design question: the roadmap's "synchronous capture in the wire proxy" over-promised and mis-described what we'd actually build.

**Why the old framing was wrong.** Synchronous capture implies the proxy parses write commands and owns before/after document images. But the change-stream ingester already gets those images, transaction resolution, and mongod's authoritative commit order **for free** from the change stream. Re-deriving them in the proxy means reimplementing MongoDB write semantics (update operators, multi/upsert, findAndModify, bulkWrite, txn commit/abort, concurrent LSN ordering) — the one thing the whole design refuses to do.

**What's actually planned.** A *synchronization barrier*: an opt-in mode where the proxy holds a write's ack until the ingester confirms the WAL entry landed. That delivers the real value people would want — zero effective ingest lag (immediate diff/materialize after a write), strict "no write exists that isn't logged" — while the ingester stays the single capture path and mongod stays the only query engine. Roughly 10% of the work for 80% of the value, and it doesn't fight the core principle.

**Honest bound kept explicit:** it does **not** remove the replica-set requirement (change streams still do the capturing); dropping that would need true in-proxy capture, which we are not planning.

Updated in three places for one voice:  (proxy section + roadmap),  [Unreleased], and the  package doc. Docs-and-comments only; no behavior change.