### PR TITLE
Add MCP Registry publishing (server.json + argonctl mcpName)

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "argonctl",
   "version": "2.0.0",
+  "mcpName": "io.github.argon-lab/argon",
   "description": "Git for MongoDB: branch, time-travel, merge and undo - CLI",
   "keywords": [
     "mongodb",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.argon-lab/argon",
+  "description": "Versioned MongoDB sandboxes for AI agents — branch, time-travel, diff/merge, and undo a MongoDB database over MCP.",
+  "repository": {
+    "url": "https://github.com/argon-lab/argon",
+    "source": "github"
+  },
+  "version": "2.0.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "argonctl",
+      "version": "2.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Add MCP Registry publishing

Registers Argon's MCP server (`argon mcp`) in the official [MCP Registry](https://registry.modelcontextprotocol.io) under `io.github.argon-lab/argon`, so agent clients (Claude, Cursor, …) can discover it. This replaces a PR to `modelcontextprotocol/servers`, which no longer accepts community servers and now redirects everyone to the registry.

### What's in this PR
- **`server.json`** (repo root) — the registry manifest: npm package `argonctl`, stdio transport, `mcp` positional arg (so clients run `npx argonctl mcp`). Schema `2025-12-11`.
- **`npm/package.json`** — adds `"mcpName": "io.github.argon-lab/argon"`. The registry verifies the published npm package carries this field before it will register the server.

### Not in this PR (needs `workflow` scope / your creds)
A CI workflow to publish on release, and one manual npm publish. Details below.

<details>
<summary><b>1. Add <code>.github/workflows/publish-mcp.yml</code></b> (couldn't push it — my token lacks <code>workflow</code> scope)</summary>

```yaml
name: Publish to MCP Registry

on:
  release:
    types: [published]
  workflow_dispatch:
    inputs:
      version:
        description: "Version to publish, e.g. 2.0.1 (defaults to the release tag)"
        required: false

permissions:
  contents: read
  id-token: write # required for github-oidc login to the registry

jobs:
  publish:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Resolve version
        id: ver
        run: |
          v="${{ github.event.inputs.version }}"
          [ -z "$v" ] && v="${GITHUB_REF_NAME#v}"
          echo "version=$v" >> "$GITHUB_OUTPUT"
      - name: Stamp version into server.json
        run: |
          v="${{ steps.ver.outputs.version }}"
          tmp=$(mktemp)
          jq --arg v "$v" '.version=$v | .packages[0].version=$v' server.json > "$tmp" && mv "$tmp" server.json
          cat server.json
      - name: Install mcp-publisher
        run: |
          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
          sudo mv mcp-publisher /usr/local/bin/
      - name: Authenticate (GitHub OIDC)
        run: mcp-publisher login github-oidc
      - name: Publish
        run: mcp-publisher publish
```
</details>

### First-time registration runbook
`install.js` downloads the CLI binary from `releases/download/v${version}/…`, so the npm version must have a matching GitHub release. The registry also needs the npm package (at the referenced version) to carry `mcpName`. So the first publish is coupled to a release:

1. Merge this PR.
2. Cut the next release (e.g. tag `v2.0.1`) so `release.yml` builds the binaries + creates the GitHub release.
3. `npm publish` `argonctl@2.0.1` from `npm/` (npm publish is commented out in `release.yml`, so it's manual — same as today). This ships the `mcpName` field to npm.
4. The `publish-mcp` workflow runs on the release (or trigger it via **workflow_dispatch** with the version) — it stamps the version into `server.json` and publishes to the registry via OIDC.

After that, every release auto-registers the new version. Verify at `https://registry.modelcontextprotocol.io/v0/servers?search=argon`.
