### PR TITLE
ci: enable npm auto-publish + fix MCP Registry description length

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,21 +71,23 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # publish-npm:
-  #   name: Publish to npm
-  #   needs: release
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #
-  #   - name: Setup Node.js
-  #     uses: actions/setup-node@v3
-  #     with:
-  #       node-version: '18'
-  #       registry-url: 'https://registry.npmjs.org'
-  #
-  #   - name: Publish to npm
-  #     working-directory: ./npm
-  #     run: npm publish --access public
-  #     env:
-  #       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  publish-npm:
+    name: Publish to npm
+    needs: release
+    runs-on: ubuntu-latest
+    # Requires an NPM_TOKEN repo secret — an npm "Automation" (or granular,
+    # 2FA-bypass) token that owns argonctl, so CI can publish without an OTP.
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Publish to npm
+      working-directory: ./npm
+      run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.argon-lab/argon",
-  "description": "Versioned MongoDB sandboxes for AI agents — branch, time-travel, diff/merge, and undo a MongoDB database over MCP.",
+  "description": "Versioned MongoDB sandboxes for AI agents: branch, time-travel, merge, and undo over MCP.",
   "repository": {
     "url": "https://github.com/argon-lab/argon",
     "source": "github"


### PR DESCRIPTION
Two release-automation fixes:

1. **`server.json`** — shorten `description` to ≤100 chars (the MCP Registry rejects longer). The registry entry `io.github.argon-lab/argon` is already live at v2.0.1; this syncs master so future release-triggered publishes don't fail validation.
2. **`release.yml`** — enable the `publish-npm` job so a tag push auto-publishes `argonctl` to npm.

**Action required to activate #2:** add an `NPM_TOKEN` repo secret — an npm **Automation** token (or granular with 2FA bypass) that owns `argonctl`, so CI publishes without an OTP:
```
gh secret set NPM_TOKEN --repo argon-lab/argon   # paste the token (hidden)
```
After that, cutting a release ( bump version → tag `vX.Y.Z`) auto-builds binaries **and** publishes npm; then run the `publish-mcp` workflow (or dispatch it) to register the new version.